### PR TITLE
DATAJDBC-95 - Saving and loading a trivial entity.

### DIFF
--- a/src/main/java/org/springframework/data/jdbc/repository/EntityRowMapper.java
+++ b/src/main/java/org/springframework/data/jdbc/repository/EntityRowMapper.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jdbc.repository;
+
+import java.lang.reflect.InvocationTargetException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.springframework.data.mapping.PersistentEntity;
+import org.springframework.data.mapping.PersistentProperty;
+import org.springframework.data.mapping.PropertyHandler;
+
+/**
+ * @author Jens Schauder
+ */
+class EntityRowMapper<T> implements org.springframework.jdbc.core.RowMapper<T> {
+
+	private final PersistentEntity<T, ?> entity;
+
+	EntityRowMapper(PersistentEntity<T, ?> entity) {
+		this.entity = entity;
+	}
+
+	@Override
+	public T mapRow(ResultSet rs, int rowNum) throws SQLException {
+
+		try {
+
+			T t = createInstance();
+
+			entity.doWithProperties((PropertyHandler) property -> {
+				setProperty(rs, t, property);
+			});
+
+			return t;
+		} catch (Exception e) {
+			throw new RuntimeException(String.format("Could not instantiate %s", entity.getType()));
+		}
+	}
+
+	private T createInstance() throws InstantiationException, IllegalAccessException, InvocationTargetException {
+		return (T) entity.getPersistenceConstructor().getConstructor().newInstance();
+	}
+
+	private void setProperty(ResultSet rs, T t, PersistentProperty property) {
+
+		try {
+			property.getSetter().invoke(t, rs.getObject(property.getName()));
+		} catch (Exception e) {
+			throw new RuntimeException(String.format("Couldn't set property %s.", property.getName()), e);
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/jdbc/repository/support/JdbcRepositoryFactory.java
+++ b/src/main/java/org/springframework/data/jdbc/repository/support/JdbcRepositoryFactory.java
@@ -39,13 +39,12 @@ public class JdbcRepositoryFactory extends RepositoryFactorySupport {
 
 	@Override
 	public <T, ID extends Serializable> EntityInformation<T, ID> getEntityInformation(Class<T> aClass) {
-		JdbcPersistentEntity<T> persistentEntity = (JdbcPersistentEntity<T>) context.getPersistentEntity(aClass);
-		return new JdbcPersistentEntityInformation<T, ID>(persistentEntity);
+		return new JdbcPersistentEntityInformation<T, ID>((JdbcPersistentEntity<T>) context.getPersistentEntity(aClass));
 	}
 
 	@Override
 	protected Object getTargetRepository(RepositoryInformation repositoryInformation) {
-		return new SimpleJdbcRepository(getEntityInformation(repositoryInformation.getDomainType()), dataSource);
+		return new SimpleJdbcRepository(context.getPersistentEntity(repositoryInformation.getDomainType()), dataSource);
 	}
 
 	@Override

--- a/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryIntegrationTests.java
@@ -48,19 +48,18 @@ public class JdbcRepositoryIntegrationTests {
 
 	private final NamedParameterJdbcTemplate template = new NamedParameterJdbcTemplate(db);
 
+	private final DummyEntityRepository repository = createRepository(db);
+
+	private DummyEntity entity = createDummyEntity();
+
 	@After
-	public void afeter() {
+	public void after() {
 		db.shutdown();
 	}
 
 
 	@Test
 	public void canSaveAnEntity() throws SQLException {
-		DummyEntityRepository repository = createRepository();
-
-		DummyEntity entity = new DummyEntity();
-		entity.setId(23L);
-		entity.setName("Entity Name");
 
 		entity = repository.save(entity);
 
@@ -74,9 +73,31 @@ public class JdbcRepositoryIntegrationTests {
 				count);
 	}
 
-	private DummyEntityRepository createRepository() throws SQLException {
-		JdbcRepositoryFactory jdbcRepositoryFactory = new JdbcRepositoryFactory(db);
-		return jdbcRepositoryFactory.getRepository(DummyEntityRepository.class);
+	@Test
+	public void canSaveAndLoadAnEntity() throws SQLException {
+
+		entity = repository.save(entity);
+
+		DummyEntity reloadedEntity = repository.findOne(entity.getId());
+
+		assertEquals(
+				entity.getId(),
+				reloadedEntity.getId());
+		assertEquals(
+				entity.getName(),
+				reloadedEntity.getName());
+	}
+
+	private static DummyEntityRepository createRepository(EmbeddedDatabase db) {
+		return new JdbcRepositoryFactory(db).getRepository(DummyEntityRepository.class);
+	}
+
+
+	private static DummyEntity createDummyEntity() {
+		DummyEntity entity = new DummyEntity();
+		entity.setId(23L);
+		entity.setName("Entity Name");
+		return entity;
 	}
 
 	private interface DummyEntityRepository extends CrudRepository<DummyEntity, Long> {


### PR DESCRIPTION
Creation of the necessary sql statements is now dynamic and driven in a
trivial way by the entity.

Known issues with the solution that need to get fixed later:

Sql generating code is in the repository and should go somewhere else.

Mapping logic is very trivial and should go in a separate place.