### PR TITLE
Avoid duplicate selection of columns.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-relational-parent</artifactId>
-	<version>2.3.0-SNAPSHOT</version>
+	<version>2.3.0-1073-duplicate-select-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Relational Parent</name>

--- a/spring-data-jdbc-distribution/pom.xml
+++ b/spring-data-jdbc-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.3.0-SNAPSHOT</version>
+		<version>2.3.0-1073-duplicate-select-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-jdbc</artifactId>
-	<version>2.3.0-SNAPSHOT</version>
+	<version>2.3.0-1073-duplicate-select-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.3.0-SNAPSHOT</version>
+		<version>2.3.0-1073-duplicate-select-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlGenerator.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlGenerator.java
@@ -381,11 +381,11 @@ class SqlGenerator {
 		Table table = this.getTable();
 
 		Select select = StatementBuilder //
-			.select(getIdColumn()) //
-			.from(table) //
-			.where(getIdColumn().isEqualTo(getBindMarker(ID_SQL_PARAMETER))) //
-			.lock(lockMode) //
-			.build();
+				.select(getIdColumn()) //
+				.from(table) //
+				.where(getIdColumn().isEqualTo(getBindMarker(ID_SQL_PARAMETER))) //
+				.lock(lockMode) //
+				.build();
 
 		return render(select);
 	}
@@ -395,10 +395,10 @@ class SqlGenerator {
 		Table table = this.getTable();
 
 		Select select = StatementBuilder //
-			.select(getIdColumn()) //
-			.from(table) //
-			.lock(lockMode) //
-			.build();
+				.select(getIdColumn()) //
+				.from(table) //
+				.lock(lockMode) //
+				.build();
 
 		return render(select);
 	}
@@ -727,9 +727,9 @@ class SqlGenerator {
 
 		Join(Table joinTable, Column joinColumn, Column parentId) {
 
-			Assert.notNull( joinTable,"JoinTable must not be null.");
-			Assert.notNull( joinColumn,"JoinColumn must not be null.");
-			Assert.notNull( parentId,"ParentId must not be null.");
+			Assert.notNull(joinTable, "JoinTable must not be null.");
+			Assert.notNull(joinColumn, "JoinColumn must not be null.");
+			Assert.notNull(parentId, "ParentId must not be null.");
 
 			this.joinTable = joinTable;
 			this.joinColumn = joinColumn;

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlGenerator.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlGenerator.java
@@ -15,6 +15,11 @@
  */
 package org.springframework.data.jdbc.core.convert;
 
+import java.util.*;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jdbc.repository.support.SimpleJdbcRepository;
@@ -32,11 +37,6 @@ import org.springframework.data.relational.core.sql.render.SqlRenderer;
 import org.springframework.data.util.Lazy;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
-
-import java.util.*;
-import java.util.function.Function;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 /**
  * Generates SQL statements to be used by {@link SimpleJdbcRepository}
@@ -751,12 +751,14 @@ class SqlGenerator {
 		@Override
 		public boolean equals(Object o) {
 
-			if (this == o) return true;
-			if (o == null || getClass() != o.getClass()) return false;
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
 			Join join = (Join) o;
-			return joinTable.equals(join.joinTable) &&
-					joinColumn.equals(join.joinColumn) &&
-					parentId.equals(join.parentId);
+			return joinTable.equals(join.joinTable) && joinColumn.equals(join.joinColumn) && parentId.equals(join.parentId);
 		}
 
 		@Override
@@ -767,10 +769,10 @@ class SqlGenerator {
 		@Override
 		public String toString() {
 
-			return "Join{" +
-					"joinTable=" + joinTable +
-					", joinColumn=" + joinColumn +
-					", parentId=" + parentId +
+			return "Join{" + //
+					"joinTable=" + joinTable + //
+					", joinColumn=" + joinColumn + //
+					", parentId=" + parentId + //
 					'}';
 		}
 	}

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlGeneratorUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlGeneratorUnitTests.java
@@ -23,7 +23,6 @@ import static org.springframework.data.relational.core.sql.SqlIdentifier.*;
 import java.util.Map;
 import java.util.Set;
 
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.annotation.Id;
@@ -374,6 +373,23 @@ public class SqlGeneratorUnitTests {
 				+ "WHERE dummy_entity.backref = :backref " + "ORDER BY key-column");
 	}
 
+	@Test // GH-1073
+	public void findAllByPropertyAvoidsDuplicateColumns() {
+
+		final SqlGenerator sqlGenerator = createSqlGenerator(ReferencedEntity.class);
+		final String sql = sqlGenerator.getFindAllByProperty(
+				Identifier.of(quoted("id"), "parent-id-value", DummyEntity.class), //
+				quoted("X_L1ID"), // this key column collides with the name derived by the naming strategy for the id of
+													// ReferencedEntity.
+				false);
+
+		final String id = "referenced_entity.x_l1id AS x_l1id";
+		assertThat(sql.indexOf(id)) //
+				.describedAs(sql) //
+				.isEqualTo(sql.lastIndexOf(id));
+
+	}
+
 	@Test // DATAJDBC-219
 	public void updateWithVersion() {
 
@@ -709,6 +725,7 @@ public class SqlGeneratorUnitTests {
 		Set<Element> elements;
 		Map<Integer, Element> mappedElements;
 		AggregateReference<OtherAggregate, Long> other;
+		Map<Long, ReferencedEntity> mappedReference;
 	}
 
 	static class VersionedEntity extends DummyEntity {

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-relational</artifactId>
-	<version>2.3.0-SNAPSHOT</version>
+	<version>2.3.0-1073-duplicate-select-SNAPSHOT</version>
 
 	<name>Spring Data Relational</name>
 	<description>Spring Data Relational support</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.3.0-SNAPSHOT</version>
+		<version>2.3.0-1073-duplicate-select-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/AbstractSegment.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/AbstractSegment.java
@@ -15,12 +15,15 @@
  */
 package org.springframework.data.relational.core.sql;
 
+import java.util.Arrays;
+
 import org.springframework.util.Assert;
 
 /**
  * Abstract implementation to support {@link Segment} implementations.
  *
  * @author Mark Paluch
+ * @author Jens Schauder
  * @since 1.1
  */
 abstract class AbstractSegment implements Segment {
@@ -47,21 +50,21 @@ abstract class AbstractSegment implements Segment {
 		visitor.leave(this);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * @see java.lang.Object#hashCode()
-	 */
 	@Override
-	public int hashCode() {
-		return toString().hashCode();
+	public boolean equals(Object o) {
+
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		AbstractSegment that = (AbstractSegment) o;
+		return Arrays.equals(children, that.children);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * @see java.lang.Object#equals(java.lang.Object)
-	 */
 	@Override
-	public boolean equals(Object obj) {
-		return obj instanceof Segment && toString().equals(obj.toString());
+	public int hashCode() {
+		return Arrays.hashCode(children);
 	}
 }

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/Column.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/Column.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.data.relational.core.sql;
 
+import java.util.Objects;
+
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
@@ -364,6 +366,27 @@ public class Column extends AbstractSegment implements Expression, Named {
 		return prefix;
 	}
 
+	@Override
+	public boolean equals(Object o) {
+
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		Column column = (Column) o;
+		return name.equals(column.name) && table.equals(column.table);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), name, table);
+	}
+
 	/**
 	 * {@link Aliased} {@link Column} implementation.
 	 */
@@ -418,6 +441,27 @@ public class Column extends AbstractSegment implements Expression, Named {
 		@Override
 		public String toString() {
 			return getPrefix() + getName() + " AS " + getAlias();
+		}
+
+		@Override
+		public boolean equals(Object o) {
+
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			if (!super.equals(o)) {
+				return false;
+			}
+			AliasedColumn that = (AliasedColumn) o;
+			return alias.equals(that.alias);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(super.hashCode(), alias);
 		}
 	}
 }

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/Table.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/Table.java
@@ -15,15 +15,18 @@
  */
 package org.springframework.data.relational.core.sql;
 
+import java.util.Objects;
+
 import org.springframework.util.Assert;
 
 /**
- * Represents a table reference within a SQL statement. Typically used to denote {@code FROM} or {@code JOIN} or to
+ * Represents a table reference within a SQL statement. Typically, used to denote {@code FROM} or {@code JOIN} or to
  * prefix a {@link Column}.
  * <p/>
  * Renders to: {@code <name>} or {@code <name> AS <name>}.
  *
  * @author Mark Paluch
+ * @author Jens Schauder
  * @since 1.1
  */
 public class Table extends AbstractSegment implements TableLike {
@@ -107,7 +110,6 @@ public class Table extends AbstractSegment implements TableLike {
 		return new AliasedTable(name, alias);
 	}
 
-
 	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.relational.core.sql.Named#getName()
@@ -133,6 +135,26 @@ public class Table extends AbstractSegment implements TableLike {
 	@Override
 	public String toString() {
 		return name.toString();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		Table table = (Table) o;
+		return name.equals(table.name);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), name);
 	}
 
 	/**
@@ -183,6 +205,27 @@ public class Table extends AbstractSegment implements TableLike {
 		@Override
 		public String toString() {
 			return getName() + " AS " + getAlias();
+		}
+
+		@Override
+		public boolean equals(Object o) {
+
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			if (!super.equals(o)) {
+				return false;
+			}
+			AliasedTable that = (AliasedTable) o;
+			return alias.equals(that.alias);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(super.hashCode(), alias);
 		}
 	}
 }


### PR DESCRIPTION
When the key column of a MappedCollection is also present in the contained entity that column got select twice.
We now check if the column already gets selected before adding it to the selection.

This only works properly if the column names derived for the entity property and the key column match exactly, which might require use of a `@Column` annotation depending on the used NamingStrategy.

Closes #1073