### PR TITLE
Associate value with `isTrue`/`isFalse` criteria operators

### DIFF
--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/QueryMapper.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/QueryMapper.java
@@ -494,13 +494,15 @@ class QueryMapper {
 
 		if (comparator == Comparator.IS_TRUE) {
 
-			Expression bind = bindBoolean(column, parameterSource, true);
+			Expression bind = bindBoolean(column, parameterSource,
+					mappedValue instanceof Boolean ? (Boolean) mappedValue : true);
 			return column.isEqualTo(bind);
 		}
 
 		if (comparator == Comparator.IS_FALSE) {
 
-			Expression bind = bindBoolean(column, parameterSource, false);
+			Expression bind = bindBoolean(column, parameterSource,
+					mappedValue instanceof Boolean ? (Boolean) mappedValue : false);
 			return column.isEqualTo(bind);
 		}
 

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/query/Criteria.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/query/Criteria.java
@@ -781,12 +781,12 @@ public class Criteria implements CriteriaDefinition {
 
 		@Override
 		public Criteria isTrue() {
-			return createCriteria(Comparator.IS_TRUE, null);
+			return createCriteria(Comparator.IS_TRUE, true);
 		}
 
 		@Override
 		public Criteria isFalse() {
-			return createCriteria(Comparator.IS_FALSE, null);
+			return createCriteria(Comparator.IS_FALSE, false);
 		}
 
 		protected Criteria createCriteria(Comparator comparator, @Nullable Object value) {

--- a/spring-data-relational/src/test/java/org/springframework/data/relational/core/query/CriteriaUnitTests.java
+++ b/spring-data-relational/src/test/java/org/springframework/data/relational/core/query/CriteriaUnitTests.java
@@ -32,10 +32,10 @@ import org.springframework.data.relational.core.sql.SqlIdentifier;
  * @author Jens Schauder
  * @author Roman Chigvintsev
  */
-public class CriteriaUnitTests {
+class CriteriaUnitTests {
 
 	@Test // DATAJDBC-513
-	public void fromCriteria() {
+	void fromCriteria() {
 
 		Criteria nested1 = where("foo").isNotNull();
 		Criteria nested2 = where("foo").isNull();
@@ -48,7 +48,7 @@ public class CriteriaUnitTests {
 	}
 
 	@Test // DATAJDBC-513
-	public void fromCriteriaOptimized() {
+	void fromCriteriaOptimized() {
 
 		Criteria nested = where("foo").is("bar").and("baz").isNotNull();
 		CriteriaDefinition criteria = Criteria.from(nested);
@@ -57,7 +57,7 @@ public class CriteriaUnitTests {
 	}
 
 	@Test // DATAJDBC-513
-	public void isEmpty() {
+	void isEmpty() {
 
 		assertSoftly(softly -> {
 
@@ -79,7 +79,7 @@ public class CriteriaUnitTests {
 	}
 
 	@Test // DATAJDBC-513
-	public void andChainedCriteria() {
+	void andChainedCriteria() {
 
 		Criteria criteria = where("foo").is("bar").and("baz").isNotNull();
 
@@ -97,7 +97,7 @@ public class CriteriaUnitTests {
 	}
 
 	@Test // DATAJDBC-513
-	public void andGroupedCriteria() {
+	void andGroupedCriteria() {
 
 		Criteria grouped = where("foo").is("bar").and(where("foo").is("baz").or("bar").isNotNull());
 		Criteria criteria = grouped;
@@ -118,7 +118,7 @@ public class CriteriaUnitTests {
 	}
 
 	@Test // DATAJDBC-513
-	public void orChainedCriteria() {
+	void orChainedCriteria() {
 
 		Criteria criteria = where("foo").is("bar").or("baz").isNotNull();
 
@@ -133,7 +133,7 @@ public class CriteriaUnitTests {
 	}
 
 	@Test // DATAJDBC-513
-	public void orGroupedCriteria() {
+	void orGroupedCriteria() {
 
 		Criteria criteria = where("foo").is("bar").or(where("foo").is("baz"));
 
@@ -151,7 +151,7 @@ public class CriteriaUnitTests {
 	}
 
 	@Test // DATAJDBC-513
-	public void shouldBuildEqualsCriteria() {
+	void shouldBuildEqualsCriteria() {
 
 		Criteria criteria = where("foo").is("bar");
 
@@ -161,7 +161,7 @@ public class CriteriaUnitTests {
 	}
 
 	@Test
-	public void shouldBuildEqualsIgnoreCaseCriteria() {
+	void shouldBuildEqualsIgnoreCaseCriteria() {
 		Criteria criteria = where("foo").is("bar").ignoreCase(true);
 
 		assertThat(criteria.getColumn()).isEqualTo(SqlIdentifier.unquoted("foo"));
@@ -171,7 +171,7 @@ public class CriteriaUnitTests {
 	}
 
 	@Test // DATAJDBC-513
-	public void shouldBuildNotEqualsCriteria() {
+	void shouldBuildNotEqualsCriteria() {
 
 		Criteria criteria = where("foo").not("bar");
 
@@ -181,7 +181,7 @@ public class CriteriaUnitTests {
 	}
 
 	@Test // DATAJDBC-513
-	public void shouldBuildInCriteria() {
+	void shouldBuildInCriteria() {
 
 		Criteria criteria = where("foo").in("bar", "baz");
 
@@ -192,7 +192,7 @@ public class CriteriaUnitTests {
 	}
 
 	@Test // DATAJDBC-513
-	public void shouldBuildNotInCriteria() {
+	void shouldBuildNotInCriteria() {
 
 		Criteria criteria = where("foo").notIn("bar", "baz");
 
@@ -202,7 +202,7 @@ public class CriteriaUnitTests {
 	}
 
 	@Test // DATAJDBC-513
-	public void shouldBuildGtCriteria() {
+	void shouldBuildGtCriteria() {
 
 		Criteria criteria = where("foo").greaterThan(1);
 
@@ -212,7 +212,7 @@ public class CriteriaUnitTests {
 	}
 
 	@Test // DATAJDBC-513
-	public void shouldBuildGteCriteria() {
+	void shouldBuildGteCriteria() {
 
 		Criteria criteria = where("foo").greaterThanOrEquals(1);
 
@@ -222,7 +222,7 @@ public class CriteriaUnitTests {
 	}
 
 	@Test // DATAJDBC-513
-	public void shouldBuildLtCriteria() {
+	void shouldBuildLtCriteria() {
 
 		Criteria criteria = where("foo").lessThan(1);
 
@@ -232,7 +232,7 @@ public class CriteriaUnitTests {
 	}
 
 	@Test // DATAJDBC-513
-	public void shouldBuildLteCriteria() {
+	void shouldBuildLteCriteria() {
 
 		Criteria criteria = where("foo").lessThanOrEquals(1);
 
@@ -242,7 +242,7 @@ public class CriteriaUnitTests {
 	}
 
 	@Test // DATAJDBC-513
-	public void shouldBuildLikeCriteria() {
+	void shouldBuildLikeCriteria() {
 
 		Criteria criteria = where("foo").like("hello%");
 
@@ -252,7 +252,7 @@ public class CriteriaUnitTests {
 	}
 
 	@Test
-	public void shouldBuildNotLikeCriteria() {
+	void shouldBuildNotLikeCriteria() {
 		Criteria criteria = where("foo").notLike("hello%");
 
 		assertThat(criteria.getColumn()).isEqualTo(SqlIdentifier.unquoted("foo"));
@@ -261,7 +261,7 @@ public class CriteriaUnitTests {
 	}
 
 	@Test // DATAJDBC-513
-	public void shouldBuildIsNullCriteria() {
+	void shouldBuildIsNullCriteria() {
 
 		Criteria criteria = where("foo").isNull();
 
@@ -270,7 +270,7 @@ public class CriteriaUnitTests {
 	}
 
 	@Test // DATAJDBC-513
-	public void shouldBuildIsNotNullCriteria() {
+	void shouldBuildIsNotNullCriteria() {
 
 		Criteria criteria = where("foo").isNotNull();
 
@@ -279,7 +279,7 @@ public class CriteriaUnitTests {
 	}
 
 	@Test // DATAJDBC-513
-	public void shouldBuildIsTrueCriteria() {
+	void shouldBuildIsTrueCriteria() {
 
 		Criteria criteria = where("foo").isTrue();
 
@@ -289,7 +289,7 @@ public class CriteriaUnitTests {
 	}
 
 	@Test // DATAJDBC-513
-	public void shouldBuildIsFalseCriteria() {
+	void shouldBuildIsFalseCriteria() {
 
 		Criteria criteria = where("foo").isFalse();
 

--- a/spring-data-relational/src/test/java/org/springframework/data/relational/core/query/CriteriaUnitTests.java
+++ b/spring-data-relational/src/test/java/org/springframework/data/relational/core/query/CriteriaUnitTests.java
@@ -285,6 +285,7 @@ public class CriteriaUnitTests {
 
 		assertThat(criteria.getColumn()).isEqualTo(SqlIdentifier.unquoted("foo"));
 		assertThat(criteria.getComparator()).isEqualTo(CriteriaDefinition.Comparator.IS_TRUE);
+		assertThat(criteria.getValue()).isEqualTo(true);
 	}
 
 	@Test // DATAJDBC-513
@@ -294,5 +295,6 @@ public class CriteriaUnitTests {
 
 		assertThat(criteria.getColumn()).isEqualTo(SqlIdentifier.unquoted("foo"));
 		assertThat(criteria.getComparator()).isEqualTo(CriteriaDefinition.Comparator.IS_FALSE);
+		assertThat(criteria.getValue()).isEqualTo(false);
 	}
 }


### PR DESCRIPTION
We now associate a boolean value with both operators as those operators are rendered using equals comparison in the actual SQL text.

Should be also backported to `main`.

Related issue: https://github.com/spring-projects/spring-data-r2dbc/issues/733