### PR TITLE
Issue/1137 duplicate constructor calls for setting version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-relational-parent</artifactId>
-	<version>2.4.0-SNAPSHOT</version>
+	<version>2.4.0-1137-dup-constructor-calls-for-version-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Relational Parent</name>

--- a/spring-data-jdbc-distribution/pom.xml
+++ b/spring-data-jdbc-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.4.0-SNAPSHOT</version>
+		<version>2.4.0-1137-dup-constructor-calls-for-version-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-jdbc</artifactId>
-	<version>2.4.0-SNAPSHOT</version>
+	<version>2.4.0-1137-dup-constructor-calls-for-version-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.4.0-SNAPSHOT</version>
+		<version>2.4.0-1137-dup-constructor-calls-for-version-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/AggregateChangeExecutor.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/AggregateChangeExecutor.java
@@ -55,10 +55,6 @@ class AggregateChangeExecutor {
 			root = aggregateChange.getEntity();
 		}
 
-		if (root != null) {
-			root = executionContext.populateRootVersionIfNecessary(root);
-		}
-
 		return root;
 	}
 

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/AggregateChangeExecutor.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/AggregateChangeExecutor.java
@@ -51,7 +51,9 @@ class AggregateChangeExecutor {
 		aggregateChange.forEachAction(action -> execute(action, executionContext));
 
 		T root = executionContext.populateIdsIfNecessary();
-		root = root == null ? aggregateChange.getEntity() : root;
+		if (root == null) {
+			root = aggregateChange.getEntity();
+		}
 
 		if (root != null) {
 			root = executionContext.populateRootVersionIfNecessary(root);

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/JdbcAggregateChangeExecutionContext.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/JdbcAggregateChangeExecutionContext.java
@@ -147,16 +147,10 @@ class JdbcAggregateChangeExecutionContext {
 	<T> void executeDeleteRoot(DbAction.DeleteRoot<T> delete) {
 
 		if (delete.getPreviousVersion() != null) {
-
-			RelationalPersistentEntity<T> persistentEntity = getRequiredPersistentEntity(delete.getEntityType());
-			if (persistentEntity.hasVersionProperty()) {
-
-				accessStrategy.deleteWithVersion(delete.getId(), delete.getEntityType(), delete.getPreviousVersion());
-				return;
-			}
+			accessStrategy.deleteWithVersion(delete.getId(), delete.getEntityType(), delete.getPreviousVersion());
+		} else {
+			accessStrategy.delete(delete.getId(), delete.getEntityType());
 		}
-
-		accessStrategy.delete(delete.getId(), delete.getEntityType());
 	}
 
 	<T> void executeDelete(DbAction.Delete<T> delete) {

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/JdbcAggregateTemplate.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/JdbcAggregateTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +53,7 @@ import org.springframework.util.Assert;
  * @author Christoph Strobl
  * @author Milan Milanov
  * @author Myeonghyeon Lee
+ * @author Chirag Tailor
  */
 public class JdbcAggregateTemplate implements JdbcAggregateOperations {
 

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/JdbcAggregateTemplate.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/JdbcAggregateTemplate.java
@@ -35,8 +35,10 @@ import org.springframework.data.relational.core.conversion.MutableAggregateChang
 import org.springframework.data.relational.core.conversion.RelationalEntityDeleteWriter;
 import org.springframework.data.relational.core.conversion.RelationalEntityInsertWriter;
 import org.springframework.data.relational.core.conversion.RelationalEntityUpdateWriter;
+import org.springframework.data.relational.core.conversion.RelationalEntityVersionUtils;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
+import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
 import org.springframework.data.relational.core.mapping.event.*;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.lang.Nullable;
@@ -63,6 +65,7 @@ public class JdbcAggregateTemplate implements JdbcAggregateOperations {
 
 	private final DataAccessStrategy accessStrategy;
 	private final AggregateChangeExecutor executor;
+	private final JdbcConverter converter;
 
 	private EntityCallbacks entityCallbacks = EntityCallbacks.create();
 
@@ -86,6 +89,7 @@ public class JdbcAggregateTemplate implements JdbcAggregateOperations {
 		this.publisher = publisher;
 		this.context = context;
 		this.accessStrategy = dataAccessStrategy;
+		this.converter = converter;
 
 		this.jdbcEntityInsertWriter = new RelationalEntityInsertWriter(context);
 		this.jdbcEntityUpdateWriter = new RelationalEntityUpdateWriter(context);
@@ -115,6 +119,7 @@ public class JdbcAggregateTemplate implements JdbcAggregateOperations {
 		this.publisher = publisher;
 		this.context = context;
 		this.accessStrategy = dataAccessStrategy;
+		this.converter = converter;
 
 		this.jdbcEntityInsertWriter = new RelationalEntityInsertWriter(context);
 		this.jdbcEntityUpdateWriter = new RelationalEntityUpdateWriter(context);
@@ -332,7 +337,7 @@ public class JdbcAggregateTemplate implements JdbcAggregateOperations {
 
 		MutableAggregateChange<T> change = changeCreator.apply(aggregateRoot);
 
-		aggregateRoot = triggerBeforeSave(aggregateRoot, change);
+		aggregateRoot = triggerBeforeSave(change.getEntity(), change);
 
 		change.setEntity(aggregateRoot);
 
@@ -359,21 +364,58 @@ public class JdbcAggregateTemplate implements JdbcAggregateOperations {
 
 	private <T> MutableAggregateChange<T> createInsertChange(T instance) {
 
-		MutableAggregateChange<T> aggregateChange = MutableAggregateChange.forSave(instance);
-		jdbcEntityInsertWriter.write(instance, aggregateChange);
+		RelationalPersistentEntity<T> persistentEntity = getRequiredPersistentEntity(instance);
+		T preparedInstance = instance;
+		if (persistentEntity.hasVersionProperty()) {
+			RelationalPersistentProperty versionProperty = persistentEntity.getRequiredVersionProperty();
+
+			long initialVersion = versionProperty.getActualType().isPrimitive() ? 1L : 0;
+
+			preparedInstance = RelationalEntityVersionUtils.setVersionNumberOnEntity( //
+					instance, initialVersion, persistentEntity, converter);
+		}
+		MutableAggregateChange<T> aggregateChange = MutableAggregateChange.forSave(preparedInstance);
+		jdbcEntityInsertWriter.write(preparedInstance, aggregateChange);
 		return aggregateChange;
 	}
 
 	private <T> MutableAggregateChange<T> createUpdateChange(T instance) {
 
-		MutableAggregateChange<T> aggregateChange = MutableAggregateChange.forSave(instance);
-		jdbcEntityUpdateWriter.write(instance, aggregateChange);
+		RelationalPersistentEntity<T> persistentEntity = getRequiredPersistentEntity(instance);
+		T preparedInstance = instance;
+		Number previousVersion = null;
+		if (persistentEntity.hasVersionProperty()) {
+			// If the root aggregate has a version property, increment it.
+			previousVersion = RelationalEntityVersionUtils.getVersionNumberFromEntity(instance,
+					persistentEntity, converter);
+
+			Assert.notNull(previousVersion, "The root aggregate cannot be updated because the version property is null.");
+
+			long newVersion = previousVersion.longValue() + 1;
+
+			preparedInstance = RelationalEntityVersionUtils.setVersionNumberOnEntity(instance, newVersion,
+					persistentEntity, converter);
+		}
+		MutableAggregateChange<T> aggregateChange = MutableAggregateChange.forSave(preparedInstance, previousVersion);
+		jdbcEntityUpdateWriter.write(preparedInstance, aggregateChange);
 		return aggregateChange;
+	}
+
+	@SuppressWarnings("unchecked")
+	private <T> RelationalPersistentEntity<T> getRequiredPersistentEntity(T instance) {
+		return (RelationalPersistentEntity<T>) context.getRequiredPersistentEntity(instance.getClass());
 	}
 
 	private <T> MutableAggregateChange<T> createDeletingChange(Object id, @Nullable T entity, Class<T> domainType) {
 
-		MutableAggregateChange<T> aggregateChange = MutableAggregateChange.forDelete(domainType, entity);
+		Number previousVersion = null;
+		if (entity != null) {
+			RelationalPersistentEntity<T> persistentEntity = getRequiredPersistentEntity(entity);
+			if (persistentEntity.hasVersionProperty()) {
+				previousVersion = RelationalEntityVersionUtils.getVersionNumberFromEntity(entity, persistentEntity, converter);
+			}
+		}
+		MutableAggregateChange<T> aggregateChange = MutableAggregateChange.forDelete(domainType, entity, previousVersion);
 		jdbcEntityDeleteWriter.write(id, aggregateChange);
 		return aggregateChange;
 	}

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/JdbcAggregateChangeExecutorContextImmutableUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/JdbcAggregateChangeExecutorContextImmutableUnitTests.java
@@ -64,7 +64,7 @@ public class JdbcAggregateChangeExecutorContextImmutableUnitTests {
 	}
 
 	@Test // DATAJDBC-453
-	public void afterInsertRootIdAndVersionMaybeUpdated() {
+	public void afterInsertRootIdMaybeUpdated() {
 
 		// note that the root entity isn't the original one, but a new instance with the version set.
 		when(accessStrategy.insert(any(DummyEntity.class), eq(DummyEntity.class), eq(Identifier.empty()),
@@ -76,10 +76,6 @@ public class JdbcAggregateChangeExecutorContextImmutableUnitTests {
 
 		assertThat(newRoot).isNotNull();
 		assertThat(newRoot.id).isEqualTo(23L);
-
-		newRoot = executionContext.populateRootVersionIfNecessary(newRoot);
-
-		assertThat(newRoot.version).isEqualTo(1);
 	}
 
 	@Test // DATAJDBC-453

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/JdbcAggregateChangeExecutorContextUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/JdbcAggregateChangeExecutorContextUnitTests.java
@@ -70,7 +70,7 @@ public class JdbcAggregateChangeExecutorContextUnitTests {
 	}
 
 	@Test // DATAJDBC-453
-	public void afterInsertRootIdAndVersionMaybeUpdated() {
+	public void afterInsertRootIdMaybeUpdated() {
 
 		when(accessStrategy.insert(root, DummyEntity.class, Identifier.empty(), IdValueSource.GENERATED)).thenReturn(23L);
 
@@ -80,22 +80,6 @@ public class JdbcAggregateChangeExecutorContextUnitTests {
 
 		assertThat(newRoot).isNull();
 		assertThat(root.id).isEqualTo(23L);
-
-		executionContext.populateRootVersionIfNecessary(root);
-
-		assertThat(root.version).isEqualTo(1);
-	}
-
-	@Test // DATAJDBC-507
-	public void afterInsertNotPrimitiveVersionShouldBeZero() {
-
-		DummyEntityNonPrimitiveVersion dummyEntityNonPrimitiveVersion = new DummyEntityNonPrimitiveVersion();
-
-		executionContext
-				.executeInsertRoot(new DbAction.InsertRoot<>(dummyEntityNonPrimitiveVersion, IdValueSource.GENERATED));
-		executionContext.populateRootVersionIfNecessary(dummyEntityNonPrimitiveVersion);
-
-		assertThat(dummyEntityNonPrimitiveVersion.version).isEqualTo(0);
 	}
 
 	@Test // DATAJDBC-453
@@ -218,17 +202,10 @@ public class JdbcAggregateChangeExecutorContextUnitTests {
 	private static class DummyEntity {
 
 		@Id Long id;
-		@Version long version;
 
 		Content content;
 
 		List<Content> list = new ArrayList<>();
-	}
-
-	private static class DummyEntityNonPrimitiveVersion {
-
-		@Id Long id;
-		@Version Long version;
 	}
 
 	private static class Content {

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/JdbcAggregateTemplateUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/JdbcAggregateTemplateUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,6 +58,7 @@ import org.springframework.data.relational.core.mapping.event.BeforeSaveCallback
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author Milan Milanov
+ * @author Chirag Tailor
  */
 @ExtendWith(MockitoExtension.class)
 public class JdbcAggregateTemplateUnitTests {

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-relational</artifactId>
-	<version>2.4.0-SNAPSHOT</version>
+	<version>2.4.0-1137-dup-constructor-calls-for-version-SNAPSHOT</version>
 
 	<name>Spring Data Relational</name>
 	<description>Spring Data Relational support</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.4.0-SNAPSHOT</version>
+		<version>2.4.0-1137-dup-constructor-calls-for-version-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/DbAction.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/DbAction.java
@@ -166,12 +166,20 @@ public interface DbAction<T> {
 
 		private final T entity;
 
-		public UpdateRoot(T entity) {
+		@Nullable private final Number previousVersion;
+
+		public UpdateRoot(T entity, @Nullable Number previousVersion) {
 			this.entity = entity;
+			this.previousVersion = previousVersion;
 		}
 
 		public T getEntity() {
 			return this.entity;
+		}
+
+		@Nullable
+		public Number getPreviousVersion() {
+			return previousVersion;
 		}
 
 		public String toString() {

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/DefaultAggregateChange.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/DefaultAggregateChange.java
@@ -41,11 +41,15 @@ class DefaultAggregateChange<T> implements MutableAggregateChange<T> {
 	/** Aggregate root, to which the change applies, if available */
 	private @Nullable T entity;
 
-	public DefaultAggregateChange(Kind kind, Class<T> entityType, @Nullable T entity) {
+	/** The previous version assigned to the instance being changed, if available */
+	@Nullable private final Number previousVersion;
+
+	public DefaultAggregateChange(Kind kind, Class<T> entityType, @Nullable T entity, @Nullable Number previousVersion) {
 
 		this.kind = kind;
 		this.entityType = entityType;
 		this.entity = entity;
+		this.previousVersion = previousVersion;
 	}
 
 	/**
@@ -93,6 +97,12 @@ class DefaultAggregateChange<T> implements MutableAggregateChange<T> {
 		}
 
 		this.entity = aggregateRoot;
+	}
+
+	@Nullable
+	@Override
+	public Number getPreviousVersion() {
+		return previousVersion;
 	}
 
 	/*

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/DefaultAggregateChange.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/DefaultAggregateChange.java
@@ -27,6 +27,7 @@ import org.springframework.util.Assert;
  *
  * @author Jens Schauder
  * @author Mark Paluch
+ * @author Chirag Tailor
  * @since 2.0
  */
 class DefaultAggregateChange<T> implements MutableAggregateChange<T> {

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/MutableAggregateChange.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/MutableAggregateChange.java
@@ -36,12 +36,25 @@ public interface MutableAggregateChange<T> extends AggregateChange<T> {
 	 * @return the {@link MutableAggregateChange} for saving the root {@code entity}.
 	 * @since 1.2
 	 */
-	@SuppressWarnings("unchecked")
 	static <T> MutableAggregateChange<T> forSave(T entity) {
+		return forSave(entity, null);
+	}
+
+	/**
+	 * Factory method to create an {@link MutableAggregateChange} for saving entities.
+	 *
+	 * @param entity aggregate root to save.
+	 * @param previousVersion the previous version assigned to the instance being saved. May be {@literal null}.
+	 * @param <T> entity type.
+	 * @return the {@link MutableAggregateChange} for saving the root {@code entity}.
+	 * @since 2.4
+	 */
+	@SuppressWarnings("unchecked")
+	static <T> MutableAggregateChange<T> forSave(T entity, @Nullable Number previousVersion) {
 
 		Assert.notNull(entity, "Entity must not be null");
 
-		return new DefaultAggregateChange<>(Kind.SAVE, (Class<T>) ClassUtils.getUserClass(entity), entity);
+		return new DefaultAggregateChange<>(Kind.SAVE, (Class<T>) ClassUtils.getUserClass(entity), entity, previousVersion);
 	}
 
 	/**
@@ -70,10 +83,24 @@ public interface MutableAggregateChange<T> extends AggregateChange<T> {
 	 * @since 1.2
 	 */
 	static <T> MutableAggregateChange<T> forDelete(Class<T> entityClass, @Nullable T entity) {
+		return forDelete(entityClass, entity, null);
+	}
+
+	/**
+	 * Factory method to create an {@link MutableAggregateChange} for deleting entities.
+	 *
+	 * @param entityClass aggregate root type.
+	 * @param entity aggregate root to delete.
+	 * @param previousVersion the previous version assigned to the instance being saved. May be {@literal null}.
+	 * @param <T> entity type.
+	 * @return the {@link MutableAggregateChange} for deleting the root {@code entity}.
+	 * @since 2.4
+	 */
+	static <T> MutableAggregateChange<T> forDelete(Class<T> entityClass, @Nullable T entity, @Nullable Number previousVersion) {
 
 		Assert.notNull(entityClass, "Entity class must not be null");
 
-		return new DefaultAggregateChange<>(Kind.DELETE, entityClass, entity);
+		return new DefaultAggregateChange<>(Kind.DELETE, entityClass, entity, previousVersion);
 	}
 
 	/**
@@ -89,4 +116,7 @@ public interface MutableAggregateChange<T> extends AggregateChange<T> {
 	 * @param aggregateRoot may be {@literal null} if the change refers to a list of aggregates or references it by id.
 	 */
 	void setEntity(@Nullable T aggregateRoot);
+
+	@Nullable
+	Number getPreviousVersion();
 }

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/MutableAggregateChange.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/MutableAggregateChange.java
@@ -24,6 +24,7 @@ import org.springframework.util.ClassUtils;
  *
  * @author Jens Schauder
  * @author Mark Paluch
+ * @author Chirag Tailor
  * @since 2.0
  */
 public interface MutableAggregateChange<T> extends AggregateChange<T> {

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/RelationalEntityDeleteWriter.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/RelationalEntityDeleteWriter.java
@@ -88,7 +88,7 @@ public class RelationalEntityDeleteWriter implements EntityWriter<Object, Mutabl
 		return actions;
 	}
 
-	private <T> List<DbAction<?>> deleteRoot(Object id, AggregateChange<T> aggregateChange) {
+	private <T> List<DbAction<?>> deleteRoot(Object id, MutableAggregateChange<T> aggregateChange) {
 
 		List<DbAction<?>> deleteReferencedActions = deleteReferencedEntities(id, aggregateChange);
 
@@ -98,7 +98,7 @@ public class RelationalEntityDeleteWriter implements EntityWriter<Object, Mutabl
 		}
 		actions.addAll(deleteReferencedActions);
 
-		actions.add(new DbAction.DeleteRoot<>(id, aggregateChange.getEntityType(), getVersion(aggregateChange)));
+		actions.add(new DbAction.DeleteRoot<>(id, aggregateChange.getEntityType(), aggregateChange.getPreviousVersion()));
 
 		return actions;
 	}
@@ -121,22 +121,4 @@ public class RelationalEntityDeleteWriter implements EntityWriter<Object, Mutabl
 		return actions;
 	}
 
-	@Nullable
-	private Number getVersion(AggregateChange<?> aggregateChange) {
-
-		RelationalPersistentEntity<?> persistentEntity = context
-				.getRequiredPersistentEntity(aggregateChange.getEntityType());
-		if (!persistentEntity.hasVersionProperty()) {
-			return null;
-		}
-
-		Object entity = aggregateChange.getEntity();
-
-		if (entity == null) {
-			return null;
-		}
-
-		return (Number) persistentEntity.getPropertyAccessor(entity)
-				.getProperty(persistentEntity.getRequiredVersionProperty());
-	}
 }

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/RelationalEntityDeleteWriter.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/RelationalEntityDeleteWriter.java
@@ -37,6 +37,7 @@ import org.springframework.util.Assert;
  * @author Bastian Wilhelm
  * @author Tyler Van Gorder
  * @author Myeonghyeon Lee
+ * @author Chirag Tailor
  */
 public class RelationalEntityDeleteWriter implements EntityWriter<Object, MutableAggregateChange<?>> {
 

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/WritingContext.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/WritingContext.java
@@ -52,6 +52,7 @@ class WritingContext {
 	private final Map<PathNode, DbAction<?>> previousActions = new HashMap<>();
 	private final Map<PersistentPropertyPath<RelationalPersistentProperty>, List<PathNode>> nodesCache = new HashMap<>();
 	private final IdValueSource rootIdValueSource;
+	@Nullable private final Number previousVersion;
 
 	WritingContext(RelationalMappingContext context, Object root, MutableAggregateChange<?> aggregateChange) {
 
@@ -59,6 +60,7 @@ class WritingContext {
 		this.root = root;
 		this.entity = aggregateChange.getEntity();
 		this.entityType = aggregateChange.getEntityType();
+		this.previousVersion = aggregateChange.getPreviousVersion();
 		this.rootIdValueSource = IdValueSource.forInstance(root,
 				context.getRequiredPersistentEntity(aggregateChange.getEntityType()));
 		this.paths = context.findPersistentPropertyPaths(entityType, (p) -> p.isEntity() && !p.isEmbedded());
@@ -88,7 +90,7 @@ class WritingContext {
 	List<DbAction<?>> update() {
 
 		List<DbAction<?>> actions = new ArrayList<>();
-		actions.add(setRootAction(new DbAction.UpdateRoot<>(entity)));
+		actions.add(setRootAction(new DbAction.UpdateRoot<>(entity, previousVersion)));
 		actions.addAll(deleteReferenced());
 		actions.addAll(insertReferenced());
 		return actions;
@@ -103,7 +105,7 @@ class WritingContext {
 			actions.addAll(insertReferenced());
 		} else {
 
-			actions.add(setRootAction(new DbAction.UpdateRoot<>(entity)));
+			actions.add(setRootAction(new DbAction.UpdateRoot<>(entity, previousVersion)));
 			actions.addAll(deleteReferenced());
 			actions.addAll(insertReferenced());
 		}

--- a/spring-data-relational/src/test/java/org/springframework/data/relational/core/conversion/RelationalEntityWriterUnitTests.java
+++ b/spring-data-relational/src/test/java/org/springframework/data/relational/core/conversion/RelationalEntityWriterUnitTests.java
@@ -85,7 +85,7 @@ public class RelationalEntityWriterUnitTests {
 
 		SingleReferenceEntity entity = new SingleReferenceEntity(null);
 		MutableAggregateChange<SingleReferenceEntity> aggregateChange = //
-				new DefaultAggregateChange<>(AggregateChange.Kind.SAVE, SingleReferenceEntity.class, entity);
+				new DefaultAggregateChange<>(AggregateChange.Kind.SAVE, SingleReferenceEntity.class, entity, null);
 
 		converter.write(entity, aggregateChange);
 
@@ -107,7 +107,7 @@ public class RelationalEntityWriterUnitTests {
 		PrimitiveLongIdEntity entity = new PrimitiveLongIdEntity();
 
 		MutableAggregateChange<PrimitiveLongIdEntity> aggregateChange = //
-				new DefaultAggregateChange<>(AggregateChange.Kind.SAVE, PrimitiveLongIdEntity.class, entity);
+				new DefaultAggregateChange<>(AggregateChange.Kind.SAVE, PrimitiveLongIdEntity.class, entity, null);
 
 		converter.write(entity, aggregateChange);
 
@@ -129,7 +129,7 @@ public class RelationalEntityWriterUnitTests {
 		PrimitiveIntIdEntity entity = new PrimitiveIntIdEntity();
 
 		MutableAggregateChange<PrimitiveIntIdEntity> aggregateChange = //
-				new DefaultAggregateChange<>(AggregateChange.Kind.SAVE, PrimitiveIntIdEntity.class, entity);
+				new DefaultAggregateChange<>(AggregateChange.Kind.SAVE, PrimitiveIntIdEntity.class, entity, null);
 
 		converter.write(entity, aggregateChange);
 
@@ -153,7 +153,7 @@ public class RelationalEntityWriterUnitTests {
 		entity.other = new Element(2L);
 
 		MutableAggregateChange<EmbeddedReferenceEntity> aggregateChange = //
-				new DefaultAggregateChange<>(AggregateChange.Kind.SAVE, EmbeddedReferenceEntity.class, entity);
+				new DefaultAggregateChange<>(AggregateChange.Kind.SAVE, EmbeddedReferenceEntity.class, entity, null);
 
 		converter.write(entity, aggregateChange);
 
@@ -177,7 +177,7 @@ public class RelationalEntityWriterUnitTests {
 		entity.other = new Element(null);
 
 		MutableAggregateChange<SingleReferenceEntity> aggregateChange = //
-				new DefaultAggregateChange<>(AggregateChange.Kind.SAVE, SingleReferenceEntity.class, entity);
+				new DefaultAggregateChange<>(AggregateChange.Kind.SAVE, SingleReferenceEntity.class, entity, null);
 
 		converter.write(entity, aggregateChange);
 
@@ -203,7 +203,7 @@ public class RelationalEntityWriterUnitTests {
 		entity.primitiveIntIdEntity = new PrimitiveIntIdEntity();
 
 		MutableAggregateChange<EntityWithReferencesToPrimitiveIdEntity> aggregateChange = //
-				new DefaultAggregateChange<>(AggregateChange.Kind.SAVE, EntityWithReferencesToPrimitiveIdEntity.class, entity);
+				new DefaultAggregateChange<>(AggregateChange.Kind.SAVE, EntityWithReferencesToPrimitiveIdEntity.class, entity, null);
 
 		converter.write(entity, aggregateChange);
 
@@ -230,7 +230,7 @@ public class RelationalEntityWriterUnitTests {
 		SingleReferenceEntity entity = new SingleReferenceEntity(SOME_ENTITY_ID);
 
 		MutableAggregateChange<SingleReferenceEntity> aggregateChange = //
-				new DefaultAggregateChange<>(AggregateChange.Kind.SAVE, SingleReferenceEntity.class, entity);
+				new DefaultAggregateChange<>(AggregateChange.Kind.SAVE, SingleReferenceEntity.class, entity, 1L);
 
 		converter.write(entity, aggregateChange);
 
@@ -239,10 +239,11 @@ public class RelationalEntityWriterUnitTests {
 						DbAction::getEntityType, //
 						DbActionTestSupport::extractPath, //
 						DbActionTestSupport::actualEntityType, //
-						DbActionTestSupport::isWithDependsOn) //
+						DbActionTestSupport::isWithDependsOn, //
+						dbAction -> dbAction instanceof UpdateRoot ? ((UpdateRoot<?>) dbAction).getPreviousVersion() : null) //
 				.containsExactly( //
-						tuple(UpdateRoot.class, SingleReferenceEntity.class, "", SingleReferenceEntity.class, false), //
-						tuple(Delete.class, Element.class, "other", null, false) //
+						tuple(UpdateRoot.class, SingleReferenceEntity.class, "", SingleReferenceEntity.class, false, 1L), //
+						tuple(Delete.class, Element.class, "other", null, false, null) //
 				);
 	}
 
@@ -253,7 +254,7 @@ public class RelationalEntityWriterUnitTests {
 		entity.other = new Element(null);
 
 		MutableAggregateChange<SingleReferenceEntity> aggregateChange = new DefaultAggregateChange<>(
-				AggregateChange.Kind.SAVE, SingleReferenceEntity.class, entity);
+				AggregateChange.Kind.SAVE, SingleReferenceEntity.class, entity, 1L);
 
 		converter.write(entity, aggregateChange);
 
@@ -276,7 +277,7 @@ public class RelationalEntityWriterUnitTests {
 
 		SetContainer entity = new SetContainer(null);
 		MutableAggregateChange<SetContainer> aggregateChange = new DefaultAggregateChange<>(AggregateChange.Kind.SAVE,
-				SetContainer.class, entity);
+				SetContainer.class, entity, null);
 
 		converter.write(entity, aggregateChange);
 
@@ -299,7 +300,7 @@ public class RelationalEntityWriterUnitTests {
 		entity.elements.add(new Element(null));
 
 		MutableAggregateChange<SetContainer> aggregateChange = new DefaultAggregateChange<>(AggregateChange.Kind.SAVE,
-				SetContainer.class, entity);
+				SetContainer.class, entity, null);
 		converter.write(entity, aggregateChange);
 
 		List<DbAction<?>> actions = extractActions(aggregateChange);
@@ -342,7 +343,7 @@ public class RelationalEntityWriterUnitTests {
 		);
 
 		MutableAggregateChange<CascadingReferenceEntity> aggregateChange = new DefaultAggregateChange<>(
-				AggregateChange.Kind.SAVE, CascadingReferenceEntity.class, entity);
+				AggregateChange.Kind.SAVE, CascadingReferenceEntity.class, entity, null);
 
 		converter.write(entity, aggregateChange);
 
@@ -404,7 +405,7 @@ public class RelationalEntityWriterUnitTests {
 		);
 
 		MutableAggregateChange<CascadingReferenceEntity> aggregateChange = new DefaultAggregateChange<>(
-				AggregateChange.Kind.SAVE, CascadingReferenceEntity.class, entity);
+				AggregateChange.Kind.SAVE, CascadingReferenceEntity.class, entity, 1L);
 
 		converter.write(entity, aggregateChange);
 
@@ -456,7 +457,7 @@ public class RelationalEntityWriterUnitTests {
 
 		MapContainer entity = new MapContainer(null);
 		MutableAggregateChange<MapContainer> aggregateChange = new DefaultAggregateChange<>(AggregateChange.Kind.SAVE,
-				MapContainer.class, entity);
+				MapContainer.class, entity, null);
 
 		converter.write(entity, aggregateChange);
 
@@ -476,7 +477,7 @@ public class RelationalEntityWriterUnitTests {
 		entity.elements.put("two", new Element(null));
 
 		MutableAggregateChange<MapContainer> aggregateChange = new DefaultAggregateChange<>(AggregateChange.Kind.SAVE,
-				MapContainer.class, entity);
+				MapContainer.class, entity, null);
 		converter.write(entity, aggregateChange);
 
 		List<DbAction<?>> actions = extractActions(aggregateChange);
@@ -520,7 +521,7 @@ public class RelationalEntityWriterUnitTests {
 		entity.elements.put("b", new Element(null));
 
 		MutableAggregateChange<MapContainer> aggregateChange = new DefaultAggregateChange<>(AggregateChange.Kind.SAVE,
-				MapContainer.class, entity);
+				MapContainer.class, entity, null);
 		converter.write(entity, aggregateChange);
 
 		List<DbAction<?>> actions = extractActions(aggregateChange);
@@ -560,7 +561,7 @@ public class RelationalEntityWriterUnitTests {
 
 		ListContainer entity = new ListContainer(null);
 		MutableAggregateChange<ListContainer> aggregateChange = new DefaultAggregateChange<>(AggregateChange.Kind.SAVE,
-				ListContainer.class, entity);
+				ListContainer.class, entity, null);
 
 		converter.write(entity, aggregateChange);
 
@@ -580,7 +581,7 @@ public class RelationalEntityWriterUnitTests {
 		entity.elements.add(new Element(null));
 
 		MutableAggregateChange<ListContainer> aggregateChange = new DefaultAggregateChange<>(AggregateChange.Kind.SAVE,
-				ListContainer.class, entity);
+				ListContainer.class, entity, null);
 		converter.write(entity, aggregateChange);
 
 		List<DbAction<?>> actions = extractActions(aggregateChange);
@@ -612,7 +613,7 @@ public class RelationalEntityWriterUnitTests {
 		entity.elements.put("one", new Element(null));
 
 		MutableAggregateChange<MapContainer> aggregateChange = new DefaultAggregateChange<>(AggregateChange.Kind.SAVE,
-				MapContainer.class, entity);
+				MapContainer.class, entity, 1L);
 
 		converter.write(entity, aggregateChange);
 
@@ -636,7 +637,7 @@ public class RelationalEntityWriterUnitTests {
 		entity.elements.add(new Element(null));
 
 		MutableAggregateChange<ListContainer> aggregateChange = new DefaultAggregateChange<>(AggregateChange.Kind.SAVE,
-				ListContainer.class, entity);
+				ListContainer.class, entity, 1L);
 
 		converter.write(entity, aggregateChange);
 
@@ -661,7 +662,7 @@ public class RelationalEntityWriterUnitTests {
 		listMapContainer.maps.get(0).elements.put("one", new Element(null));
 
 		MutableAggregateChange<ListMapContainer> aggregateChange = new DefaultAggregateChange<>(AggregateChange.Kind.SAVE,
-				ListMapContainer.class, listMapContainer);
+				ListMapContainer.class, listMapContainer, 1L);
 
 		converter.write(listMapContainer, aggregateChange);
 
@@ -689,7 +690,7 @@ public class RelationalEntityWriterUnitTests {
 		listMapContainer.maps.get(0).elements.put("one", new NoIdElement());
 
 		MutableAggregateChange<NoIdListMapContainer> aggregateChange = new DefaultAggregateChange<>(
-				AggregateChange.Kind.SAVE, NoIdListMapContainer.class, listMapContainer);
+				AggregateChange.Kind.SAVE, NoIdListMapContainer.class, listMapContainer, 1L);
 
 		converter.write(listMapContainer, aggregateChange);
 
@@ -716,7 +717,7 @@ public class RelationalEntityWriterUnitTests {
 		// the embedded is null !!!
 
 		MutableAggregateChange<EmbeddedReferenceChainEntity> aggregateChange = //
-				new DefaultAggregateChange<>(AggregateChange.Kind.SAVE, EmbeddedReferenceChainEntity.class, entity);
+				new DefaultAggregateChange<>(AggregateChange.Kind.SAVE, EmbeddedReferenceChainEntity.class, entity, null);
 
 		converter.write(entity, aggregateChange);
 
@@ -741,7 +742,7 @@ public class RelationalEntityWriterUnitTests {
 		// the embedded is null !!!
 
 		MutableAggregateChange<RootWithEmbeddedReferenceChainEntity> aggregateChange = //
-				new DefaultAggregateChange<>(AggregateChange.Kind.SAVE, RootWithEmbeddedReferenceChainEntity.class, root);
+				new DefaultAggregateChange<>(AggregateChange.Kind.SAVE, RootWithEmbeddedReferenceChainEntity.class, root, null);
 
 		converter.write(root, aggregateChange);
 
@@ -769,7 +770,7 @@ public class RelationalEntityWriterUnitTests {
 		root.elements.add(new Element(null));
 		root.elements.add(new Element(2L));
 		MutableAggregateChange<ListContainer> aggregateChange = //
-				new DefaultAggregateChange<>(AggregateChange.Kind.SAVE, ListContainer.class, root);
+				new DefaultAggregateChange<>(AggregateChange.Kind.SAVE, ListContainer.class, root, null);
 
 		converter.write(root, aggregateChange);
 
@@ -817,7 +818,7 @@ public class RelationalEntityWriterUnitTests {
 		entity.primitiveIntIdEntities.add(new PrimitiveIntIdEntity());
 
 		MutableAggregateChange<EntityWithReferencesToPrimitiveIdEntity> aggregateChange = //
-				new DefaultAggregateChange<>(AggregateChange.Kind.SAVE, EntityWithReferencesToPrimitiveIdEntity.class, entity);
+				new DefaultAggregateChange<>(AggregateChange.Kind.SAVE, EntityWithReferencesToPrimitiveIdEntity.class, entity, null);
 
 		converter.write(entity, aggregateChange);
 


### PR DESCRIPTION
This moves around existing behavior to populate the value of `@Version` annotated fields before execution of the `AggregateChange` instead of after. This is based on the idea that these values are determined by the module and not dependent on `AggregateChange` execution, unlike the values of `@Id` annotated fields. The value of `previousVersion` is determined at the same time, such that it can be used for update and delete actions on entities with `@Version`.

I originally did this refactor in the context of exploring a possible design for https://github.com/spring-projects/spring-data-relational/issues/537 where AggregateChange represents the change plan via DbAction for multiple entities and JdbcAggregateChangeExecutionContext is capable of being used for multiple roots. I later discovered that it is perhaps more relevant to https://github.com/spring-projects/spring-data-relational/issues/1137 so I isolated the work on its own branch to present for consideration here.

Related to https://github.com/spring-projects/spring-data-relational/pull/1150.
Closes https://github.com/spring-projects/spring-data-relational/issues/1137.