### PR TITLE
Fix docs on lifecycle events callbacks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-relational-parent</artifactId>
-	<version>2.4.0-SNAPSHOT</version>
+	<version>2.4.0-fix-docs-on-lifecycle-events-callbacks-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Relational Parent</name>

--- a/spring-data-jdbc-distribution/pom.xml
+++ b/spring-data-jdbc-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.4.0-SNAPSHOT</version>
+		<version>2.4.0-fix-docs-on-lifecycle-events-callbacks-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-jdbc</artifactId>
-	<version>2.4.0-SNAPSHOT</version>
+	<version>2.4.0-fix-docs-on-lifecycle-events-callbacks-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.4.0-SNAPSHOT</version>
+		<version>2.4.0-fix-docs-on-lifecycle-events-callbacks-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-relational</artifactId>
-	<version>2.4.0-SNAPSHOT</version>
+	<version>2.4.0-fix-docs-on-lifecycle-events-callbacks-SNAPSHOT</version>
 
 	<name>Spring Data Relational</name>
 	<description>Spring Data Relational support</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.4.0-SNAPSHOT</version>
+		<version>2.4.0-fix-docs-on-lifecycle-events-callbacks-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/event/BeforeConvertCallback.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/event/BeforeConvertCallback.java
@@ -19,7 +19,7 @@ import org.springframework.data.mapping.callback.EntityCallback;
 
 /**
  * An {@link EntityCallback} that gets invoked before the aggregate is converted into a database change. The decision if
- * the change will be an insert or update is made before this callback gets called.
+ * the change will be an insert or update is made after this callback gets called.
  *
  * @author Jens Schauder
  * @author Mark Paluch

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/event/BeforeSaveCallback.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/event/BeforeSaveCallback.java
@@ -32,8 +32,9 @@ public interface BeforeSaveCallback<T> extends EntityCallback<T> {
 	/**
 	 * Entity callback method invoked before an aggregate root is saved. Can return either the same or a modified instance
 	 * of the aggregate and can modify {@link MutableAggregateChange} contents. This method is called after converting the
-	 * {@code aggregate} to {@link MutableAggregateChange}. Changes to the aggregate are not taken into account for
-	 * saving. Use the {@link BeforeConvertCallback} to change the persistent the entity before being converted.
+	 * {@code aggregate} to {@link MutableAggregateChange}. Changes to the aggregate are not taken into account to decide
+	 * whether the change will be an insert or update. Use the {@link BeforeConvertCallback} to change the persistent the
+	 * entity before being converted.
 	 *
 	 * @param aggregate the aggregate.
 	 * @param aggregateChange the associated {@link MutableAggregateChange}.

--- a/src/main/asciidoc/jdbc.adoc
+++ b/src/main/asciidoc/jdbc.adoc
@@ -422,7 +422,7 @@ When your data base has an auto-increment column for the ID column, the generate
 One important constraint is that, after saving an entity, the entity must not be new any more.
 Note that whether an entity is new is part of the entity's state.
 With auto-increment columns, this happens automatically, because the ID gets set by Spring Data with the value from the ID column.
-If you are not using auto-increment columns, you can use a `BeforeSave` listener, which sets the ID of the entity (covered later in this document).
+If you are not using auto-increment columns, you can use a `BeforeConvert` listener, which sets the ID of the entity (covered later in this document).
 
 [[jdbc.entity-persistence.optimistic-locking]]
 === Optimistic Locking
@@ -865,7 +865,7 @@ The following table describes the available events:
  This is the correct event if you want to set an id programmatically.
 
 | {javadoc-base}/org/springframework/data/relational/core/mapping/event/BeforeSaveEvent.html[`BeforeSaveEvent`]
-| Before an aggregate root gets saved (that is, inserted or updated but after the decision about whether if it gets updated or deleted was made).
+| Before an aggregate root gets saved (that is, inserted or updated but after the decision about whether if it gets inserted or updated was made).
 
 | {javadoc-base}org/springframework/data/relational/core/mapping/event/AfterSaveEvent.html[`AfterSaveEvent`]
 | After an aggregate root gets saved (that is, inserted or updated).
@@ -900,7 +900,7 @@ Spring Data JDBC uses the `EntityCallback` API for its auditing support and reac
 This is the correct callback if you want to set an id programmatically.
 
 | {javadoc-base}/org/springframework/data/relational/core/mapping/event/BeforeSaveCallback.html[`BeforeSaveCallback`]
-| Before an aggregate root gets saved (that is, inserted or updated but after the decision about whether if it gets updated or deleted was made).
+| Before an aggregate root gets saved (that is, inserted or updated but after the decision about whether if it gets inserted or updated was made).
 
 | {javadoc-base}org/springframework/data/relational/core/mapping/event/AfterSaveCallback.html[`AfterSaveCallback`]
 | After an aggregate root gets saved (that is, inserted or updated).


### PR DESCRIPTION
The current documentation on `BeforeConvert` and `BeforeSave` lifecycle events/callbacks is either incorrect or misleading. These documentation changes aim to clarify how they work along with how they are intended to be used.