### PR TITLE
Batch root inserts across aggregates

### DIFF
--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/AggregateChangeExecutor.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/AggregateChangeExecutor.java
@@ -82,6 +82,8 @@ class AggregateChangeExecutor {
 		try {
 			if (action instanceof DbAction.InsertRoot) {
 				executionContext.executeInsertRoot((DbAction.InsertRoot<?>) action);
+			} else if (action instanceof DbAction.BatchInsertRoot<?>) {
+				executionContext.executeBatchInsertRoot((DbAction.BatchInsertRoot<?>) action);
 			} else if (action instanceof DbAction.Insert) {
 				executionContext.executeInsert((DbAction.Insert<?>) action);
 			} else if (action instanceof DbAction.BatchInsert) {

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/JdbcAggregateChangeExecutionContext.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/JdbcAggregateChangeExecutionContext.java
@@ -75,6 +75,20 @@ class JdbcAggregateChangeExecutionContext {
 		add(new DbActionExecutionResult(insert, id));
 	}
 
+	<T> void executeBatchInsertRoot(DbAction.BatchInsertRoot<T> batchInsertRoot) {
+
+		List<DbAction.InsertRoot<T>> inserts = batchInsertRoot.getActions();
+		List<InsertSubject<T>> insertSubjects = inserts.stream()
+				.map(insert -> InsertSubject.describedBy(insert.getEntity(), Identifier.empty())).collect(Collectors.toList());
+
+		Object[] ids = accessStrategy.insert(insertSubjects, batchInsertRoot.getEntityType(),
+				batchInsertRoot.getBatchValue());
+
+		for (int i = 0; i < inserts.size(); i++) {
+			add(new DbActionExecutionResult(inserts.get(i), ids.length > 0 ? ids[i] : null));
+		}
+	}
+
 	<T> void executeInsert(DbAction.Insert<T> insert) {
 
 		Identifier parentKeys = getParentKeys(insert, converter);

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/DbAction.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/DbAction.java
@@ -400,6 +400,18 @@ public interface DbAction<T> {
 	}
 
 	/**
+	 * Represents a batch insert statement for a multiple entities that are aggregate roots.
+	 *
+	 * @param <T> type of the entity for which this represents a database interaction.
+	 * @since 3.0
+	 */
+	final class BatchInsertRoot<T> extends BatchWithValue<T, InsertRoot<T>, IdValueSource> {
+		public BatchInsertRoot(List<InsertRoot<T>> actions) {
+			super(actions, InsertRoot::getIdValueSource);
+		}
+	}
+
+	/**
 	 * An action depending on another action for providing additional information like the id of a parent entity.
 	 *
 	 * @author Jens Schauder

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/SaveBatchingAggregateChange.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/SaveBatchingAggregateChange.java
@@ -43,7 +43,8 @@ public class SaveBatchingAggregateChange<T> implements BatchingAggregateChange<T
 			Comparator.comparing(PersistentPropertyPath::getLength);
 
 	private final Class<T> entityType;
-	private final List<DbAction.WithRoot<?>> rootActions = new ArrayList<>();
+	private final List<DbAction<?>> rootActions = new ArrayList<>();
+	private final List<DbAction.InsertRoot<T>> insertRootBatchCandidates = new ArrayList<>();
 	private final Map<PersistentPropertyPath<RelationalPersistentProperty>, Map<IdValueSource, List<DbAction.Insert<Object>>>> insertActions = //
 			new HashMap<>();
 	private final Map<PersistentPropertyPath<RelationalPersistentProperty>, List<DbAction.Delete<?>>> deleteActions = //
@@ -69,11 +70,15 @@ public class SaveBatchingAggregateChange<T> implements BatchingAggregateChange<T
 		Assert.notNull(consumer, "Consumer must not be null.");
 
 		rootActions.forEach(consumer);
+		if (insertRootBatchCandidates.size() > 1) {
+			consumer.accept(new DbAction.BatchInsertRoot<>(insertRootBatchCandidates));
+		} else {
+			insertRootBatchCandidates.forEach(consumer);
+		}
 		deleteActions.entrySet().stream().sorted(Map.Entry.comparingByKey(pathLengthComparator.reversed()))
 				.forEach((entry) -> entry.getValue().forEach(consumer));
-		insertActions.entrySet().stream().sorted(Map.Entry.comparingByKey(pathLengthComparator))
-				.forEach((entry) -> entry.getValue()
-						.forEach((idValueSource, inserts) -> {
+		insertActions.entrySet().stream().sorted(Map.Entry.comparingByKey(pathLengthComparator)).forEach((entry) -> entry
+				.getValue().forEach((idValueSource, inserts) -> {
 							if (inserts.size() > 1) {
 								consumer.accept(new DbAction.BatchInsert<>(inserts));
 							} else {
@@ -86,15 +91,32 @@ public class SaveBatchingAggregateChange<T> implements BatchingAggregateChange<T
 	public void add(RootAggregateChange<T> aggregateChange) {
 
 		aggregateChange.forEachAction(action -> {
-			if (action instanceof DbAction.WithRoot<?> rootAction) {
+			if (action instanceof DbAction.UpdateRoot<?> rootAction) {
+				commitBatchCandidates();
 				rootActions.add(rootAction);
-			} else if (action instanceof DbAction.Insert<?>) {
+			} else if (action instanceof DbAction.InsertRoot<?> rootAction) {
+				if (!insertRootBatchCandidates.isEmpty() && !insertRootBatchCandidates.get(0).getIdValueSource().equals(rootAction.getIdValueSource())) {
+					commitBatchCandidates();
+				}
+				//noinspection unchecked
+				insertRootBatchCandidates.add((DbAction.InsertRoot<T>) rootAction);
+			} else if (action instanceof DbAction.Insert<?> insertAction) {
 				// noinspection unchecked
-				addInsert((DbAction.Insert<Object>) action);
+				addInsert((DbAction.Insert<Object>) insertAction);
 			} else if (action instanceof DbAction.Delete<?> deleteAction) {
 				addDelete(deleteAction);
 			}
 		});
+	}
+
+	private void commitBatchCandidates() {
+
+		if (insertRootBatchCandidates.size() > 1) {
+			rootActions.add(new DbAction.BatchInsertRoot<>(List.copyOf(insertRootBatchCandidates)));
+		} else {
+			rootActions.addAll(insertRootBatchCandidates);
+		}
+		insertRootBatchCandidates.clear();
 	}
 
 	private void addInsert(DbAction.Insert<Object> action) {
@@ -103,11 +125,10 @@ public class SaveBatchingAggregateChange<T> implements BatchingAggregateChange<T
 		insertActions.merge(propertyPath,
 				new HashMap<>(singletonMap(action.getIdValueSource(), new ArrayList<>(singletonList(action)))),
 				(map, mapDefaultValue) -> {
-					map.merge(action.getIdValueSource(), new ArrayList<>(singletonList(action)),
-							(actions, listDefaultValue) -> {
-								actions.add(action);
-								return actions;
-							});
+					map.merge(action.getIdValueSource(), new ArrayList<>(singletonList(action)), (actions, listDefaultValue) -> {
+						actions.add(action);
+						return actions;
+					});
 					return map;
 				});
 	}

--- a/spring-data-relational/src/test/java/org/springframework/data/relational/core/conversion/DbActionTestSupport.java
+++ b/spring-data-relational/src/test/java/org/springframework/data/relational/core/conversion/DbActionTestSupport.java
@@ -52,12 +52,12 @@ class DbActionTestSupport {
 	@Nullable
 	static IdValueSource insertIdValueSource(DbAction<?> action) {
 
-		if (action instanceof DbAction.InsertRoot) {
-			return ((DbAction.InsertRoot<?>) action).getIdValueSource();
-		} else if (action instanceof DbAction.Insert) {
-			return ((DbAction.Insert<?>) action).getIdValueSource();
+		if (action instanceof DbAction.WithEntity<?>) {
+			return ((DbAction.WithEntity<?>) action).getIdValueSource();
 		} else if (action instanceof DbAction.BatchInsert) {
 			return ((DbAction.BatchInsert<?>) action).getBatchValue();
+		} else if (action instanceof DbAction.BatchInsertRoot<?>) {
+			return ((DbAction.BatchInsertRoot<?>) action).getBatchValue();
 		} else {
 			return null;
 		}

--- a/spring-data-relational/src/test/java/org/springframework/data/relational/core/conversion/RelationalEntityWriterUnitTests.java
+++ b/spring-data-relational/src/test/java/org/springframework/data/relational/core/conversion/RelationalEntityWriterUnitTests.java
@@ -255,7 +255,7 @@ public class RelationalEntityWriterUnitTests {
 						DbActionTestSupport::isWithDependsOn, //
 						DbActionTestSupport::insertIdValueSource) //
 				.containsExactly( //
-						tuple(UpdateRoot.class, SingleReferenceEntity.class, "", SingleReferenceEntity.class, false, null), //
+						tuple(UpdateRoot.class, SingleReferenceEntity.class, "", SingleReferenceEntity.class, false, IdValueSource.PROVIDED), //
 						tuple(Delete.class, Element.class, "other", null, false, null), //
 						tuple(Insert.class, Element.class, "other", Element.class, true, IdValueSource.GENERATED) //
 				);
@@ -371,7 +371,7 @@ public class RelationalEntityWriterUnitTests {
 				DbActionTestSupport::isWithDependsOn, //
 				DbActionTestSupport::insertIdValueSource) //
 				.containsExactly( //
-						tuple(UpdateRoot.class, CascadingReferenceEntity.class, "", CascadingReferenceEntity.class, false, null), //
+						tuple(UpdateRoot.class, CascadingReferenceEntity.class, "", CascadingReferenceEntity.class, false, IdValueSource.PROVIDED), //
 						tuple(Delete.class, Element.class, "other.element", null, false, null),
 						tuple(Delete.class, CascadingReferenceMiddleElement.class, "other", null, false, null),
 						tuple(Insert.class, CascadingReferenceMiddleElement.class, "other", CascadingReferenceMiddleElement.class,
@@ -530,7 +530,7 @@ public class RelationalEntityWriterUnitTests {
 						DbActionTestSupport::extractPath, //
 						DbActionTestSupport::insertIdValueSource) //
 				.containsExactly( //
-						tuple(UpdateRoot.class, MapContainer.class, null, "", null), //
+						tuple(UpdateRoot.class, MapContainer.class, null, "", IdValueSource.PROVIDED), //
 						tuple(Delete.class, Element.class, null, "elements", null), //
 						tuple(Insert.class, Element.class, "one", "elements", IdValueSource.GENERATED) //
 				);
@@ -553,7 +553,7 @@ public class RelationalEntityWriterUnitTests {
 						DbActionTestSupport::extractPath, //
 						DbActionTestSupport::insertIdValueSource) //
 				.containsExactly( //
-						tuple(UpdateRoot.class, ListContainer.class, null, "", null), //
+						tuple(UpdateRoot.class, ListContainer.class, null, "", IdValueSource.PROVIDED), //
 						tuple(Delete.class, Element.class, null, "elements", null), //
 						tuple(Insert.class, Element.class, 0, "elements", IdValueSource.GENERATED) //
 				);
@@ -578,7 +578,7 @@ public class RelationalEntityWriterUnitTests {
 						DbActionTestSupport::extractPath, //
 						DbActionTestSupport::insertIdValueSource) //
 				.containsExactly( //
-						tuple(UpdateRoot.class, ListMapContainer.class, null, null, "", null), //
+						tuple(UpdateRoot.class, ListMapContainer.class, null, null, "", IdValueSource.PROVIDED), //
 						tuple(Delete.class, Element.class, null, null, "maps.elements", null), //
 						tuple(Delete.class, MapContainer.class, null, null, "maps", null), //
 						tuple(Insert.class, MapContainer.class, 0, null, "maps", IdValueSource.PROVIDED), //
@@ -606,7 +606,7 @@ public class RelationalEntityWriterUnitTests {
 						DbActionTestSupport::extractPath, //
 						DbActionTestSupport::insertIdValueSource) //
 				.containsExactly( //
-						tuple(UpdateRoot.class, NoIdListMapContainer.class, null, null, "", null), //
+						tuple(UpdateRoot.class, NoIdListMapContainer.class, null, null, "", IdValueSource.PROVIDED), //
 						tuple(Delete.class, NoIdElement.class, null, null, "maps.elements", null), //
 						tuple(Delete.class, NoIdMapContainer.class, null, null, "maps", null), //
 						tuple(Insert.class, NoIdMapContainer.class, 0, null, "maps", IdValueSource.NONE), //


### PR DESCRIPTION
Follow on work to #1211 to batch root inserts across multiple aggregates via `CrudRepository#saveAll`.

Related to #537 