### PR TITLE
Batch non-root deletes across aggregates

### DIFF
--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/AggregateChangeExecutor.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/AggregateChangeExecutor.java
@@ -92,6 +92,8 @@ class AggregateChangeExecutor {
 				executionContext.executeUpdateRoot((DbAction.UpdateRoot<?>) action);
 			} else if (action instanceof DbAction.Delete) {
 				executionContext.executeDelete((DbAction.Delete<?>) action);
+			} else if (action instanceof DbAction.BatchDelete<?>) {
+				executionContext.executeBatchDelete((DbAction.BatchDelete<?>) action);
 			} else if (action instanceof DbAction.DeleteAll) {
 				executionContext.executeDeleteAll((DbAction.DeleteAll<?>) action);
 			} else if (action instanceof DbAction.DeleteRoot) {

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/JdbcAggregateChangeExecutionContext.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/JdbcAggregateChangeExecutionContext.java
@@ -135,6 +135,12 @@ class JdbcAggregateChangeExecutionContext {
 		accessStrategy.delete(delete.getRootId(), delete.getPropertyPath());
 	}
 
+	<T> void executeBatchDelete(DbAction.BatchDelete<T> batchDelete) {
+
+		List<Object> rootIds = batchDelete.getActions().stream().map(DbAction.Delete::getRootId).toList();
+		accessStrategy.delete(rootIds, batchDelete.getBatchValue());
+	}
+
 	<T> void executeDeleteAllRoot(DbAction.DeleteAllRoot<T> deleteAllRoot) {
 
 		accessStrategy.deleteAll(deleteAllRoot.getEntityType());

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/CascadingDataAccessStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/CascadingDataAccessStrategy.java
@@ -88,6 +88,11 @@ public class CascadingDataAccessStrategy implements DataAccessStrategy {
 	}
 
 	@Override
+	public void delete(Iterable<Object> rootIds, PersistentPropertyPath<RelationalPersistentProperty> propertyPath) {
+		collectVoid(das -> das.delete(rootIds, propertyPath));
+	}
+
+	@Override
 	public <T> void deleteAll(Class<T> domainType) {
 		collectVoid(das -> das.deleteAll(domainType));
 	}

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DataAccessStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DataAccessStrategy.java
@@ -152,6 +152,14 @@ public interface DataAccessStrategy extends RelationResolver {
 	void delete(Object rootId, PersistentPropertyPath<RelationalPersistentProperty> propertyPath);
 
 	/**
+	 * Deletes all entities reachable via {@literal propertyPath} from the instances identified by {@literal rootIds}.
+	 *
+	 * @param rootIds Ids of the root objects on which the {@literal propertyPath} is based. Must not be {@code null} or empty.
+	 * @param propertyPath Leading from the root object to the entities to be deleted. Must not be {@code null}.
+	 */
+	void delete(Iterable<Object> rootIds, PersistentPropertyPath<RelationalPersistentProperty> propertyPath);
+
+	/**
 	 * Deletes all entities of the given domain type.
 	 *
 	 * @param domainType the domain type for which to delete all entries. Must not be {@code null}.

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DefaultDataAccessStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DefaultDataAccessStrategy.java
@@ -197,6 +197,21 @@ public class DefaultDataAccessStrategy implements DataAccessStrategy {
 	}
 
 	@Override
+	public void delete(Iterable<Object> rootIds, PersistentPropertyPath<RelationalPersistentProperty> propertyPath) {
+
+		RelationalPersistentEntity<?> rootEntity = context
+				.getRequiredPersistentEntity(propertyPath.getBaseProperty().getOwner().getType());
+
+		RelationalPersistentProperty referencingProperty = propertyPath.getLeafProperty();
+		Assert.notNull(referencingProperty, "No property found matching the PropertyPath " + propertyPath);
+
+		String delete = sql(rootEntity.getType()).createDeleteInByPath(propertyPath);
+
+		SqlIdentifierParameterSource parameters = sqlParametersFactory.forQueryByIds(rootIds, rootEntity.getType());
+		operations.update(delete, parameters);
+	}
+
+	@Override
 	public <T> void deleteAll(Class<T> domainType) {
 		operations.getJdbcOperations().update(sql(domainType).createDeleteAllSql(null));
 	}

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DelegatingDataAccessStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DelegatingDataAccessStrategy.java
@@ -72,6 +72,11 @@ public class DelegatingDataAccessStrategy implements DataAccessStrategy {
 	}
 
 	@Override
+	public void delete(Iterable<Object> rootIds, PersistentPropertyPath<RelationalPersistentProperty> propertyPath) {
+		delegate.delete(rootIds, propertyPath);
+	}
+
+	@Override
 	public void delete(Object id, Class<?> domainType) {
 		delegate.delete(id, domainType);
 	}

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlGenerator.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlGenerator.java
@@ -360,7 +360,8 @@ class SqlGenerator {
 	}
 
 	/**
-	 * Create a {@code DELETE} query and filter by {@link PersistentPropertyPath}.
+	 * Create a {@code DELETE} query and filter by {@link PersistentPropertyPath} using {@code WHERE} with the {@code =}
+	 * operator.
 	 *
 	 * @param path must not be {@literal null}.
 	 * @return the statement as a {@link String}. Guaranteed to be not {@literal null}.
@@ -368,6 +369,18 @@ class SqlGenerator {
 	String createDeleteByPath(PersistentPropertyPath<RelationalPersistentProperty> path) {
 		return createDeleteByPathAndCriteria(new PersistentPropertyPathExtension(mappingContext, path),
 				filterColumn -> filterColumn.isEqualTo(getBindMarker(ROOT_ID_PARAMETER)));
+	}
+
+	/**
+	 * Create a {@code DELETE} query and filter by {@link PersistentPropertyPath} using {@code WHERE} with the {@code IN}
+	 * operator.
+	 *
+	 * @param path must not be {@literal null}.
+	 * @return the statement as a {@link String}. Guaranteed to be not {@literal null}.
+	 */
+	String createDeleteInByPath(PersistentPropertyPath<RelationalPersistentProperty> path) {
+		return createDeleteByPathAndCriteria(new PersistentPropertyPathExtension(mappingContext, path),
+				filterColumn -> filterColumn.in(getBindMarker(IDS_SQL_PARAMETER)));
 	}
 
 	private String createFindOneSql() {

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/mybatis/MyBatisDataAccessStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/mybatis/MyBatisDataAccessStrategy.java
@@ -219,6 +219,11 @@ public class MyBatisDataAccessStrategy implements DataAccessStrategy {
 	}
 
 	@Override
+	public void delete(Iterable<Object> rootIds, PersistentPropertyPath<RelationalPersistentProperty> propertyPath) {
+		rootIds.forEach(rootId -> delete(rootId, propertyPath));
+	}
+
+	@Override
 	public <T> void deleteAll(Class<T> domainType) {
 
 		String statement = namespace(domainType) + ".deleteAll";

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlGeneratorUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlGeneratorUnitTests.java
@@ -147,6 +147,14 @@ class SqlGeneratorUnitTests {
 		assertThat(sql).isEqualTo("DELETE FROM referenced_entity WHERE referenced_entity.dummy_entity = :rootId");
 	}
 
+	@Test // GH-537
+	void cascadingDeleteInByPathFirstLevel() {
+
+		String sql = sqlGenerator.createDeleteInByPath(getPath("ref", DummyEntity.class));
+
+		assertThat(sql).isEqualTo("DELETE FROM referenced_entity WHERE referenced_entity.dummy_entity IN (:ids)");
+	}
+
 	@Test // DATAJDBC-112
 	void cascadingDeleteByPathSecondLevel() {
 
@@ -154,6 +162,15 @@ class SqlGeneratorUnitTests {
 
 		assertThat(sql).isEqualTo(
 				"DELETE FROM second_level_referenced_entity WHERE second_level_referenced_entity.referenced_entity IN (SELECT referenced_entity.x_l1id FROM referenced_entity WHERE referenced_entity.dummy_entity = :rootId)");
+	}
+
+	@Test // GH-537
+	void cascadingDeleteInByPathSecondLevel() {
+
+		String sql = sqlGenerator.createDeleteInByPath(getPath("ref.further", DummyEntity.class));
+
+		assertThat(sql).isEqualTo(
+				"DELETE FROM second_level_referenced_entity WHERE second_level_referenced_entity.referenced_entity IN (SELECT referenced_entity.x_l1id FROM referenced_entity WHERE referenced_entity.dummy_entity IN (:ids))");
 	}
 
 	@Test // DATAJDBC-112

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/DbAction.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/DbAction.java
@@ -412,6 +412,18 @@ public interface DbAction<T> {
 	}
 
 	/**
+	 * Represents a batch delete statement for multiple entities that are reachable via a given path from the aggregate root.
+	 *
+	 * @param <T> type of the entity for which this represents a database interaction.
+	 * @since 3.0
+	 */
+	final class BatchDelete<T> extends BatchWithValue<T, Delete<T>, PersistentPropertyPath<RelationalPersistentProperty>> {
+		public BatchDelete(List<Delete<T>> actions) {
+			super(actions, Delete::getPropertyPath);
+		}
+	}
+
+	/**
 	 * An action depending on another action for providing additional information like the id of a parent entity.
 	 *
 	 * @author Jens Schauder


### PR DESCRIPTION
Follow on work to #1211 to batch non-root deletes across multiple aggregates via `CrudRepository#saveAll`.

Related to #537 