### PR TITLE
Batch root deletes across aggregates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-relational-parent</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.0-537-batch-ops-across-aggregates-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Relational Parent</name>

--- a/spring-data-jdbc-distribution/pom.xml
+++ b/spring-data-jdbc-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.0-537-batch-ops-across-aggregates-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-jdbc</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.0-537-batch-ops-across-aggregates-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.0-537-batch-ops-across-aggregates-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/AggregateChangeExecutor.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/AggregateChangeExecutor.java
@@ -100,8 +100,6 @@ class AggregateChangeExecutor {
 				executionContext.executeDeleteRoot((DbAction.DeleteRoot<?>) action);
 			} else if (action instanceof DbAction.BatchDeleteRoot) {
 				executionContext.executeBatchDeleteRoot((DbAction.BatchDeleteRoot<?>) action);
-			} else if (action instanceof DbAction.BatchDeleteRootWithVersion) {
-				executionContext.executeBatchDeleteRootWithVersion((DbAction.BatchDeleteRootWithVersion<?>) action);
 			} else if (action instanceof DbAction.DeleteAllRoot) {
 				executionContext.executeDeleteAllRoot((DbAction.DeleteAllRoot<?>) action);
 			} else if (action instanceof DbAction.AcquireLockRoot) {

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/AggregateChangeExecutor.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/AggregateChangeExecutor.java
@@ -98,6 +98,10 @@ class AggregateChangeExecutor {
 				executionContext.executeDeleteAll((DbAction.DeleteAll<?>) action);
 			} else if (action instanceof DbAction.DeleteRoot) {
 				executionContext.executeDeleteRoot((DbAction.DeleteRoot<?>) action);
+			} else if (action instanceof DbAction.BatchDeleteRoot) {
+				executionContext.executeBatchDeleteRoot((DbAction.BatchDeleteRoot<?>) action);
+			} else if (action instanceof DbAction.BatchDeleteRootWithVersion) {
+				executionContext.executeBatchDeleteRootWithVersion((DbAction.BatchDeleteRootWithVersion<?>) action);
 			} else if (action instanceof DbAction.DeleteAllRoot) {
 				executionContext.executeDeleteAllRoot((DbAction.DeleteAllRoot<?>) action);
 			} else if (action instanceof DbAction.AcquireLockRoot) {

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/JdbcAggregateChangeExecutionContext.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/JdbcAggregateChangeExecutionContext.java
@@ -131,6 +131,18 @@ class JdbcAggregateChangeExecutionContext {
 		}
 	}
 
+	<T> void executeBatchDeleteRoot(DbAction.BatchDeleteRoot<T> batchDelete) {
+
+		List<Object> rootIds = batchDelete.getActions().stream().map(DbAction.DeleteRoot::getId).toList();
+		accessStrategy.delete(rootIds, batchDelete.getEntityType());
+	}
+
+	<T> void executeBatchDeleteRootWithVersion(DbAction.BatchDeleteRootWithVersion<T> batchDelete) {
+
+		List<Object> rootIds = batchDelete.getActions().stream().map(DbAction.DeleteRoot::getId).toList();
+		accessStrategy.deleteWithVersion(rootIds, batchDelete.getEntityType(), batchDelete.getBatchValue());
+	}
+
 	<T> void executeDelete(DbAction.Delete<T> delete) {
 
 		accessStrategy.delete(delete.getRootId(), delete.getPropertyPath());

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/JdbcAggregateChangeExecutionContext.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/JdbcAggregateChangeExecutionContext.java
@@ -137,12 +137,6 @@ class JdbcAggregateChangeExecutionContext {
 		accessStrategy.delete(rootIds, batchDelete.getEntityType());
 	}
 
-	<T> void executeBatchDeleteRootWithVersion(DbAction.BatchDeleteRootWithVersion<T> batchDelete) {
-
-		List<Object> rootIds = batchDelete.getActions().stream().map(DbAction.DeleteRoot::getId).toList();
-		accessStrategy.deleteWithVersion(rootIds, batchDelete.getEntityType(), batchDelete.getBatchValue());
-	}
-
 	<T> void executeDelete(DbAction.Delete<T> delete) {
 
 		accessStrategy.delete(delete.getRootId(), delete.getPropertyPath());

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/CascadingDataAccessStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/CascadingDataAccessStrategy.java
@@ -90,11 +90,6 @@ public class CascadingDataAccessStrategy implements DataAccessStrategy {
 	}
 
 	@Override
-	public <T> void deleteWithVersion(Iterable<Object> ids, Class<T> domainType, Number previousVersion) {
-		collectVoid(das -> das.deleteWithVersion(ids, domainType, previousVersion));
-	}
-
-	@Override
 	public void delete(Object rootId, PersistentPropertyPath<RelationalPersistentProperty> propertyPath) {
 		collectVoid(das -> das.delete(rootId, propertyPath));
 	}

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/CascadingDataAccessStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/CascadingDataAccessStrategy.java
@@ -80,8 +80,18 @@ public class CascadingDataAccessStrategy implements DataAccessStrategy {
 	}
 
 	@Override
+	public void delete(Iterable<Object> ids, Class<?> domainType) {
+		collectVoid(das -> das.delete(ids, domainType));
+	}
+
+	@Override
 	public <T> void deleteWithVersion(Object id, Class<T> domainType, Number previousVersion) {
 		collectVoid(das -> das.deleteWithVersion(id, domainType, previousVersion));
+	}
+
+	@Override
+	public <T> void deleteWithVersion(Iterable<Object> ids, Class<T> domainType, Number previousVersion) {
+		collectVoid(das -> das.deleteWithVersion(ids, domainType, previousVersion));
 	}
 
 	@Override

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DataAccessStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DataAccessStrategy.java
@@ -131,6 +131,20 @@ public interface DataAccessStrategy extends RelationResolver {
 	void delete(Object id, Class<?> domainType);
 
 	/**
+	 * Deletes multiple rows identified by the ids, from the table identified by the domainType. Does not handle cascading
+	 * deletes.
+	 * <P>
+	 * The statement will be of the form : {@code DELETE FROM … WHERE ID IN (:ids) } and throw an optimistic record
+	 * locking exception if no rows have been updated.
+	 *
+	 * @param ids the ids of the rows to be deleted. Must not be {@code null}.
+	 * @param domainType the type of entity to be deleted. Implicitly determines the table to operate on. Must not be
+	 *          {@code null}.
+	 * @since 3.0
+	 */
+	void delete(Iterable<Object> ids, Class<?> domainType);
+
+	/**
 	 * Deletes a single entity from the database and enforce optimistic record locking using the version property. Does
 	 * not handle cascading deletes.
 	 *
@@ -145,6 +159,20 @@ public interface DataAccessStrategy extends RelationResolver {
 	<T> void deleteWithVersion(Object id, Class<T> domainType, Number previousVersion);
 
 	/**
+	 * Deletes multiple entities from the database and enforces optimistic record locking using the version property. Does
+	 * not handle cascading deletes.
+	 *
+	 * @param ids the ids of the rows to be deleted. Must not be {@code null}.
+	 * @param domainType the type of entity to be deleted. Implicitly determines the table to operate on. Must not be
+	 *          {@code null}.
+	 * @param previousVersion The previous version assigned to the instance being saved.
+	 * @throws OptimisticLockingFailureException if the update fails to update at least one row assuming the the
+	 *           optimistic locking version check failed.
+	 * @since 3.0
+	 */
+	<T> void deleteWithVersion(Iterable<Object> ids, Class<T> domainType, Number previousVersion);
+
+	/**
 	 * Deletes all entities reachable via {@literal propertyPath} from the instance identified by {@literal rootId}.
 	 *
 	 * @param rootId Id of the root object on which the {@literal propertyPath} is based. Must not be {@code null}.
@@ -155,7 +183,8 @@ public interface DataAccessStrategy extends RelationResolver {
 	/**
 	 * Deletes all entities reachable via {@literal propertyPath} from the instances identified by {@literal rootIds}.
 	 *
-	 * @param rootIds Ids of the root objects on which the {@literal propertyPath} is based. Must not be {@code null} or empty.
+	 * @param rootIds Ids of the root objects on which the {@literal propertyPath} is based. Must not be {@code null} or
+	 *          empty.
 	 * @param propertyPath Leading from the root object to the entities to be deleted. Must not be {@code null}.
 	 */
 	void delete(Iterable<Object> rootIds, PersistentPropertyPath<RelationalPersistentProperty> propertyPath);

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DataAccessStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DataAccessStrategy.java
@@ -159,20 +159,6 @@ public interface DataAccessStrategy extends RelationResolver {
 	<T> void deleteWithVersion(Object id, Class<T> domainType, Number previousVersion);
 
 	/**
-	 * Deletes multiple entities from the database and enforces optimistic record locking using the version property. Does
-	 * not handle cascading deletes.
-	 *
-	 * @param ids the ids of the rows to be deleted. Must not be {@code null}.
-	 * @param domainType the type of entity to be deleted. Implicitly determines the table to operate on. Must not be
-	 *          {@code null}.
-	 * @param previousVersion The previous version assigned to the instance being saved.
-	 * @throws OptimisticLockingFailureException if the update fails to update at least one row assuming the the
-	 *           optimistic locking version check failed.
-	 * @since 3.0
-	 */
-	<T> void deleteWithVersion(Iterable<Object> ids, Class<T> domainType, Number previousVersion);
-
-	/**
 	 * Deletes all entities reachable via {@literal propertyPath} from the instance identified by {@literal rootId}.
 	 *
 	 * @param rootId Id of the root object on which the {@literal propertyPath} is based. Must not be {@code null}.

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DefaultDataAccessStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DefaultDataAccessStrategy.java
@@ -190,21 +190,6 @@ public class DefaultDataAccessStrategy implements DataAccessStrategy {
 	}
 
 	@Override
-	public <T> void deleteWithVersion(Iterable<Object> ids, Class<T> domainType, Number previousVersion) {
-
-		RelationalPersistentEntity<T> persistentEntity = getRequiredPersistentEntity(domainType);
-
-		SqlIdentifierParameterSource parameterSource = sqlParametersFactory.forQueryByIds(ids, domainType);
-		parameterSource.addValue(VERSION_SQL_PARAMETER, previousVersion);
-		int affectedRows = operations.update(sql(domainType).getDeleteByIdInAndVersion(), parameterSource);
-
-		if (affectedRows == 0) {
-			throw new OptimisticLockingFailureException(
-					String.format("Optimistic lock exception deleting entity of type %s.", persistentEntity.getName()));
-		}
-	}
-
-	@Override
 	public void delete(Object rootId, PersistentPropertyPath<RelationalPersistentProperty> propertyPath) {
 
 		RelationalPersistentEntity<?> rootEntity = context.getRequiredPersistentEntity(getBaseType(propertyPath));

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DelegatingDataAccessStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DelegatingDataAccessStrategy.java
@@ -82,8 +82,18 @@ public class DelegatingDataAccessStrategy implements DataAccessStrategy {
 	}
 
 	@Override
+	public void delete(Iterable<Object> ids, Class<?> domainType) {
+		delegate.delete(ids, domainType);
+	}
+
+	@Override
 	public <T> void deleteWithVersion(Object id, Class<T> domainType, Number previousVersion) {
 		delegate.deleteWithVersion(id, domainType, previousVersion);
+	}
+
+	@Override
+	public <T> void deleteWithVersion(Iterable<Object> ids, Class<T> domainType, Number previousVersion) {
+		delegate.deleteWithVersion(ids, domainType, previousVersion);
 	}
 
 	@Override

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DelegatingDataAccessStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DelegatingDataAccessStrategy.java
@@ -92,11 +92,6 @@ public class DelegatingDataAccessStrategy implements DataAccessStrategy {
 	}
 
 	@Override
-	public <T> void deleteWithVersion(Iterable<Object> ids, Class<T> domainType, Number previousVersion) {
-		delegate.deleteWithVersion(ids, domainType, previousVersion);
-	}
-
-	@Override
 	public <T> void deleteAll(Class<T> domainType) {
 		delegate.deleteAll(domainType);
 	}

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/mybatis/MyBatisDataAccessStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/mybatis/MyBatisDataAccessStrategy.java
@@ -207,11 +207,6 @@ public class MyBatisDataAccessStrategy implements DataAccessStrategy {
 	}
 
 	@Override
-	public <T> void deleteWithVersion(Iterable<Object> ids, Class<T> domainType, Number previousVersion) {
-		ids.forEach(id -> deleteWithVersion(id, domainType, previousVersion));
-	}
-
-	@Override
 	public void delete(Object rootId, PersistentPropertyPath<RelationalPersistentProperty> propertyPath) {
 
 		Class<?> ownerType = getOwnerTyp(propertyPath);

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/mybatis/MyBatisDataAccessStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/mybatis/MyBatisDataAccessStrategy.java
@@ -193,12 +193,22 @@ public class MyBatisDataAccessStrategy implements DataAccessStrategy {
 	}
 
 	@Override
+	public void delete(Iterable<Object> ids, Class<?> domainType) {
+		ids.forEach(id -> delete(id, domainType));
+	}
+
+	@Override
 	public <T> void deleteWithVersion(Object id, Class<T> domainType, Number previousVersion) {
 
 		String statement = namespace(domainType) + ".deleteWithVersion";
 		MyBatisContext parameter = new MyBatisContext(id, null, domainType,
 				Collections.singletonMap(VERSION_SQL_PARAMETER_NAME_OLD, previousVersion));
 		sqlSession().delete(statement, parameter);
+	}
+
+	@Override
+	public <T> void deleteWithVersion(Iterable<Object> ids, Class<T> domainType, Number previousVersion) {
+		ids.forEach(id -> deleteWithVersion(id, domainType, previousVersion));
 	}
 
 	@Override

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/JdbcAggregateTemplateIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/JdbcAggregateTemplateIntegrationTests.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -361,6 +362,25 @@ class JdbcAggregateTemplateIntegrationTests {
 			softly.assertThat(template.findAll(LegoSet.class)).extracting(l -> l.name).containsExactly("Some other Name");
 			softly.assertThat(template.findAll(Manual.class)).hasSize(1);
 		});
+	}
+
+	@Test
+	void saveAndDeleteAllByAggregateRootsWithVersion() {
+		AggregateWithImmutableVersion aggregate1 = new AggregateWithImmutableVersion(null, null);
+		AggregateWithImmutableVersion aggregate2 = new AggregateWithImmutableVersion(null, null);
+		AggregateWithImmutableVersion aggregate3 = new AggregateWithImmutableVersion(null, null);
+		Iterator<AggregateWithImmutableVersion> savedAggregatesIterator = template
+				.saveAll(List.of(aggregate1, aggregate2, aggregate3)).iterator();
+		AggregateWithImmutableVersion savedAggregate1 = savedAggregatesIterator.next();
+		AggregateWithImmutableVersion twiceSavedAggregate2 = template.save(savedAggregatesIterator.next());
+		AggregateWithImmutableVersion twiceSavedAggregate3 = template.save(savedAggregatesIterator.next());
+
+		assertThat(template.count(AggregateWithImmutableVersion.class)).isEqualTo(3);
+
+		template.deleteAll(List.of(savedAggregate1, twiceSavedAggregate2, twiceSavedAggregate3),
+				AggregateWithImmutableVersion.class);
+
+		assertThat(template.count(AggregateWithImmutableVersion.class)).isEqualTo(0);
 	}
 
 	@Test // DATAJDBC-112

--- a/spring-data-r2dbc/pom.xml
+++ b/spring-data-r2dbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-r2dbc</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.0-537-batch-ops-across-aggregates-SNAPSHOT</version>
 
 	<name>Spring Data R2DBC</name>
 	<description>Spring Data module for R2DBC</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.0-537-batch-ops-across-aggregates-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-relational</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.0-537-batch-ops-across-aggregates-SNAPSHOT</version>
 
 	<name>Spring Data Relational</name>
 	<description>Spring Data Relational support</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.0-537-batch-ops-across-aggregates-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/DbAction.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/DbAction.java
@@ -432,6 +432,18 @@ public interface DbAction<T> {
 		}
 	}
 
+	final class BatchDeleteRootWithVersion<T> extends BatchWithValue<T, DeleteRoot<T>, Number> {
+		public BatchDeleteRootWithVersion(List<DeleteRoot<T>> actions) {
+			super(actions, DeleteRoot::getPreviousVersion);
+		}
+	}
+
+	final class BatchDeleteRoot<T> extends BatchWithValue<T, DeleteRoot<T>, Class<T>> {
+		public BatchDeleteRoot(List<DeleteRoot<T>> actions) {
+			super(actions, DeleteRoot::getEntityType);
+		}
+	}
+
 	/**
 	 * An action depending on another action for providing additional information like the id of a parent entity.
 	 *

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/DbAction.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/DbAction.java
@@ -432,12 +432,12 @@ public interface DbAction<T> {
 		}
 	}
 
-	final class BatchDeleteRootWithVersion<T> extends BatchWithValue<T, DeleteRoot<T>, Number> {
-		public BatchDeleteRootWithVersion(List<DeleteRoot<T>> actions) {
-			super(actions, DeleteRoot::getPreviousVersion);
-		}
-	}
-
+	/**
+	 * Represents a batch delete statement for multiple entities that are aggregate roots.
+	 *
+	 * @param <T> type of the entity for which this represents a database interaction.
+	 * @since 3.0
+	 */
 	final class BatchDeleteRoot<T> extends BatchWithValue<T, DeleteRoot<T>, Class<T>> {
 		public BatchDeleteRoot(List<DeleteRoot<T>> actions) {
 			super(actions, DeleteRoot::getEntityType);


### PR DESCRIPTION
Follow on work to #1211 to batch root deletes across multiple aggregates via `CrudRepository#deleteAll`.

Related to #537 