### PR TITLE
Add missing appendix in spring-data-r2dbc

### DIFF
--- a/spring-data-r2dbc/src/main/asciidoc/index.adoc
+++ b/spring-data-r2dbc/src/main/asciidoc/index.adoc
@@ -48,6 +48,7 @@ include::reference/kotlin.adoc[leveloffset=+1]
 = Appendix
 
 :numbered!:
+include::{spring-data-commons-docs}/repository-namespace-reference.adoc[leveloffset=+1]
 include::{spring-data-commons-docs}/repository-query-keywords-reference.adoc[leveloffset=+1]
 include::{spring-data-commons-docs}/repository-query-return-types-reference.adoc[leveloffset=+1]
 include::reference/r2dbc-upgrading.adoc[leveloffset=+1]


### PR DESCRIPTION
There is a missing appendix in [11. Working with Spring Data Repositories](https://docs.spring.io/spring-data/r2dbc/docs/current/reference/html/#repositories).

I've added the line by referring to [Spring Data JDBC docs](https://docs.spring.io/spring-data/jdbc/docs/current/reference/html/#repositories) ([file](https://github.com/spring-projects/spring-data-relational/blob/main/src/main/asciidoc/index.adoc#appendix)).