### PR TITLE
Support readonly properties for references.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-relational-parent</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.0-1249-readonly-reference-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Relational Parent</name>

--- a/spring-data-jdbc-distribution/pom.xml
+++ b/spring-data-jdbc-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.0-1249-readonly-reference-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-jdbc</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.0-1249-readonly-reference-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.0-1249-readonly-reference-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-r2dbc/pom.xml
+++ b/spring-data-r2dbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-r2dbc</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.0-1249-readonly-reference-SNAPSHOT</version>
 
 	<name>Spring Data R2DBC</name>
 	<description>Spring Data module for R2DBC</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.0-1249-readonly-reference-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-relational</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.0-1249-readonly-reference-SNAPSHOT</version>
 
 	<name>Spring Data Relational</name>
 	<description>Spring Data Relational support</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.0-1249-readonly-reference-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/RelationalEntityDeleteWriter.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/RelationalEntityDeleteWriter.java
@@ -21,8 +21,10 @@ import java.util.List;
 
 import org.springframework.data.convert.EntityWriter;
 import org.springframework.data.mapping.PersistentProperty;
+import org.springframework.data.relational.core.mapping.PersistentPropertyPathExtension;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
+import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
@@ -72,8 +74,10 @@ public class RelationalEntityDeleteWriter implements EntityWriter<Object, Mutabl
 
 		List<DbAction<?>> deleteReferencedActions = new ArrayList<>();
 
-		context.findPersistentPropertyPaths(entityType, PersistentProperty::isEntity)
-				.filter(p -> !p.getRequiredLeafProperty().isEmbedded()).forEach(p -> deleteReferencedActions.add(new DbAction.DeleteAll<>(p)));
+		context.findPersistentPropertyPaths(entityType, PersistentProperty::isEntity) //
+				.filter(p -> !p.getRequiredLeafProperty().isEmbedded() //
+						&& PersistentPropertyPathExtension.isWritable(p)) //
+				.forEach(p -> deleteReferencedActions.add(new DbAction.DeleteAll<>(p)));
 
 		Collections.reverse(deleteReferencedActions);
 
@@ -114,8 +118,10 @@ public class RelationalEntityDeleteWriter implements EntityWriter<Object, Mutabl
 
 		List<DbAction<?>> actions = new ArrayList<>();
 
-		context.findPersistentPropertyPaths(aggregateChange.getEntityType(), PersistentProperty::isEntity)
-				.filter(p -> !p.getRequiredLeafProperty().isEmbedded()).forEach(p -> actions.add(new DbAction.Delete<>(id, p)));
+		context.findPersistentPropertyPaths(aggregateChange.getEntityType(), p -> p.isEntity()) //
+				.filter(p -> !p.getRequiredLeafProperty().isEmbedded() //
+						&& PersistentPropertyPathExtension.isWritable(p)) //
+				.forEach(p -> actions.add(new DbAction.Delete<>(id, p)));
 
 		Collections.reverse(actions);
 

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/WritingContext.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/WritingContext.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.springframework.data.mapping.PersistentPropertyPath;
-import org.springframework.data.mapping.PersistentPropertyPaths;
+import org.springframework.data.relational.core.mapping.PersistentPropertyPathExtension;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
@@ -47,7 +47,7 @@ class WritingContext<T> {
 	private final RelationalMappingContext context;
 	private final T root;
 	private final Class<T> entityType;
-	private final PersistentPropertyPaths<?, RelationalPersistentProperty> paths;
+	private final List<PersistentPropertyPath<RelationalPersistentProperty>> paths;
 	private final Map<PathNode, DbAction<?>> previousActions = new HashMap<>();
 	private final Map<PersistentPropertyPath<RelationalPersistentProperty>, List<PathNode>> nodesCache = new HashMap<>();
 	private final IdValueSource rootIdValueSource;
@@ -63,7 +63,9 @@ class WritingContext<T> {
 		this.aggregateChange = aggregateChange;
 		this.rootIdValueSource = IdValueSource.forInstance(root,
 				context.getRequiredPersistentEntity(aggregateChange.getEntityType()));
-		this.paths = context.findPersistentPropertyPaths(entityType, (p) -> p.isEntity() && !p.isEmbedded() && p.isWritable());
+		this.paths = context.findPersistentPropertyPaths(entityType, (p) -> p.isEntity() && !p.isEmbedded()) //
+				.filter(PersistentPropertyPathExtension::isWritable) //
+				.stream().toList();
 	}
 
 	/**

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/WritingContext.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/WritingContext.java
@@ -63,7 +63,7 @@ class WritingContext<T> {
 		this.aggregateChange = aggregateChange;
 		this.rootIdValueSource = IdValueSource.forInstance(root,
 				context.getRequiredPersistentEntity(aggregateChange.getEntityType()));
-		this.paths = context.findPersistentPropertyPaths(entityType, (p) -> p.isEntity() && !p.isEmbedded());
+		this.paths = context.findPersistentPropertyPaths(entityType, (p) -> p.isEntity() && !p.isEmbedded() && p.isWritable());
 	}
 
 	/**

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/PersistentPropertyPathExtension.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/PersistentPropertyPathExtension.java
@@ -80,6 +80,11 @@ public class PersistentPropertyPathExtension {
 		this.path = path;
 	}
 
+	public static boolean isWritable(PersistentPropertyPath<? extends RelationalPersistentProperty> path) {
+
+		return path.isEmpty() || (path.getRequiredLeafProperty().isWritable() && isWritable(path.getParentPath()));
+	}
+
 	/**
 	 * Returns {@literal true} exactly when the path is non empty and the leaf property an embedded one.
 	 *

--- a/spring-data-relational/src/test/java/org/springframework/data/relational/core/conversion/RelationalEntityInsertWriterUnitTests.java
+++ b/spring-data-relational/src/test/java/org/springframework/data/relational/core/conversion/RelationalEntityInsertWriterUnitTests.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.ReadOnlyProperty;
 import org.springframework.data.relational.core.conversion.DbAction.InsertRoot;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 
@@ -74,6 +75,7 @@ public class RelationalEntityInsertWriterUnitTests {
 				);
 
 	}
+
 
 	private List<DbAction<?>> extractActions(MutableAggregateChange<?> aggregateChange) {
 

--- a/src/main/asciidoc/jdbc.adoc
+++ b/src/main/asciidoc/jdbc.adoc
@@ -417,12 +417,23 @@ include::{spring-data-commons-docs}/is-new-state-detection.adoc[leveloffset=+2]
 Spring Data JDBC uses the ID to identify entities.
 The ID of an entity must be annotated with Spring Data's https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/annotation/Id.html[`@Id`] annotation.
 
-When your data base has an auto-increment column for the ID column, the generated value gets set in the entity after inserting it into the database.
+When your database has an auto-increment column for the ID column, the generated value gets set in the entity after inserting it into the database.
 
 One important constraint is that, after saving an entity, the entity must not be new any more.
 Note that whether an entity is new is part of the entity's state.
 With auto-increment columns, this happens automatically, because the ID gets set by Spring Data with the value from the ID column.
 If you are not using auto-increment columns, you can use a `BeforeConvert` listener, which sets the ID of the entity (covered later in this document).
+
+[[jdbc.entity-persistence.read-only-properties]]
+=== Read Only Properties
+
+Attributes annotated with `@ReadOnlyProperty` will not be written to the database by Spring Data JDBC, but they will be read when an entity gets loaded.
+
+Spring Data JDBC will not automatically reload an entity after writing it.
+Therefore, you have to reload it explicitly if you want to see data that was generated in the database for such columns.
+
+If the annotated attribute is an entity or collection of entities, it is represented by one or more separate rows in separate tables.
+Spring Data JDBC will not perform any insert, delete or update for these rows.
 
 [[jdbc.entity-persistence.optimistic-locking]]
 === Optimistic Locking


### PR DESCRIPTION
The `@ReadOnlyProperty` annotation is now honoured for references to entities or collections of entities.

For tables mapped to such annotated references, no insert, delete or update statements will be created.
The user has to maintain that data through some other means.
These could be triggers or external process or `ON DELETE CASCADE` configuration in the database schema.

Closes #1249