### PR TITLE
Correct behaviour of NOOP deletes to match the specification in CrudRepository.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-relational-parent</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.0-1313-noop-deletes-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Relational Parent</name>

--- a/spring-data-jdbc-distribution/pom.xml
+++ b/spring-data-jdbc-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.0-1313-noop-deletes-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-jdbc</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.0-1313-noop-deletes-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.0-1313-noop-deletes-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/AggregateChangeExecutor.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/AggregateChangeExecutor.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.jdbc.core;
 
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.data.jdbc.core.convert.DataAccessStrategy;
 import org.springframework.data.jdbc.core.convert.JdbcConverter;
 import org.springframework.data.relational.core.conversion.AggregateChange;
@@ -110,6 +111,10 @@ class AggregateChangeExecutor {
 				throw new RuntimeException("unexpected action");
 			}
 		} catch (Exception e) {
+
+			if (e instanceof OptimisticLockingFailureException) {
+				throw e;
+			}
 			throw new DbActionExecutionException(action, e);
 		}
 	}

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/JdbcAggregateOperations.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/JdbcAggregateOperations.java
@@ -17,6 +17,7 @@ package org.springframework.data.jdbc.core;
 
 import java.util.Optional;
 
+import org.springframework.dao.IncorrectUpdateSemanticsDataAccessException;
 import org.springframework.data.domain.Example;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -41,6 +42,8 @@ public interface JdbcAggregateOperations {
 	 * @param instance the aggregate root of the aggregate to be saved. Must not be {@code null}.
 	 * @param <T> the type of the aggregate root.
 	 * @return the saved instance.
+	 * @throws IncorrectUpdateSemanticsDataAccessException when the instance is determined to be not new and the resulting
+	 *           update does not update any rows.
 	 */
 	<T> T save(T instance);
 
@@ -50,6 +53,8 @@ public interface JdbcAggregateOperations {
 	 * @param instances the aggregate roots to be saved. Must not be {@code null}.
 	 * @param <T> the type of the aggregate root.
 	 * @return the saved instances.
+	 * @throws IncorrectUpdateSemanticsDataAccessException when at least one instance is determined to be not new and the
+	 *           resulting update does not update any rows.
 	 * @since 3.0
 	 */
 	<T> Iterable<T> saveAll(Iterable<T> instances);
@@ -78,6 +83,11 @@ public interface JdbcAggregateOperations {
 
 	/**
 	 * Deletes a single Aggregate including all entities contained in that aggregate.
+	 * <p>
+	 * Since no version attribute is provided this method will never throw a
+	 * {@link org.springframework.dao.OptimisticLockingFailureException}. If no rows match the generated delete operation
+	 * this fact will be silently ignored.
+	 * </p>
 	 *
 	 * @param id the id of the aggregate root of the aggregate to be deleted. Must not be {@code null}.
 	 * @param domainType the type of the aggregate root.
@@ -87,7 +97,12 @@ public interface JdbcAggregateOperations {
 
 	/**
 	 * Deletes all aggregates identified by their aggregate root ids.
-	 *
+	 * <p>
+	 * Since no version attribute is provided this method will never throw a
+	 * {@link org.springframework.dao.OptimisticLockingFailureException}. If no rows match the generated delete operation
+	 * this fact will be silently ignored.
+	 * </p>
+	 * 
 	 * @param ids the ids of the aggregate roots of the aggregates to be deleted. Must not be {@code null}.
 	 * @param domainType the type of the aggregate root.
 	 * @param <T> the type of the aggregate root.
@@ -100,6 +115,9 @@ public interface JdbcAggregateOperations {
 	 * @param aggregateRoot to delete. Must not be {@code null}.
 	 * @param domainType the type of the aggregate root. Must not be {@code null}.
 	 * @param <T> the type of the aggregate root.
+	 * @throws org.springframework.dao.OptimisticLockingFailureException when {@literal T} has a version attribute and the
+	 *           version attribute of the provided entity does not match the version attribute in the database, or when
+	 *           there is no aggregate root with matching id. In other cases a NOOP delete is silently ignored.
 	 */
 	<T> void delete(T aggregateRoot, Class<T> domainType);
 
@@ -116,6 +134,9 @@ public interface JdbcAggregateOperations {
 	 * @param aggregateRoots to delete. Must not be {@code null}.
 	 * @param domainType type of the aggregate roots to be deleted. Must not be {@code null}.
 	 * @param <T> the type of the aggregate roots.
+	 * @throws org.springframework.dao.OptimisticLockingFailureException when {@literal T} has a version attribute and for at least on entity the
+	 *           version attribute of the entity does not match the version attribute in the database, or when
+	 *           there is no aggregate root with matching id. In other cases a NOOP delete is silently ignored.
 	 */
 	<T> void deleteAll(Iterable<? extends T> aggregateRoots, Class<T> domainType);
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/JdbcAggregateTemplateIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/JdbcAggregateTemplateIntegrationTests.java
@@ -866,11 +866,11 @@ class JdbcAggregateTemplateIntegrationTests {
 
 		assertThatThrownBy(() -> template.save(new AggregateWithImmutableVersion(id, 0L)))
 				.describedAs("saving an aggregate with an outdated version should raise an exception")
-				.hasRootCauseInstanceOf(OptimisticLockingFailureException.class);
+				.isInstanceOf(OptimisticLockingFailureException.class);
 
 		assertThatThrownBy(() -> template.save(new AggregateWithImmutableVersion(id, 2L)))
 				.describedAs("saving an aggregate with a future version should raise an exception")
-				.hasRootCauseInstanceOf(OptimisticLockingFailureException.class);
+				.isInstanceOf(OptimisticLockingFailureException.class);
 	}
 
 	@Test // GH-1137
@@ -915,12 +915,12 @@ class JdbcAggregateTemplateIntegrationTests {
 		assertThatThrownBy(
 				() -> template.delete(new AggregateWithImmutableVersion(id, 0L), AggregateWithImmutableVersion.class))
 						.describedAs("deleting an aggregate with an outdated version should raise an exception")
-						.hasRootCauseInstanceOf(OptimisticLockingFailureException.class);
+						.isInstanceOf(OptimisticLockingFailureException.class);
 
 		assertThatThrownBy(
 				() -> template.delete(new AggregateWithImmutableVersion(id, 2L), AggregateWithImmutableVersion.class))
 						.describedAs("deleting an aggregate with a future version should raise an exception")
-						.hasRootCauseInstanceOf(OptimisticLockingFailureException.class);
+						.isInstanceOf(OptimisticLockingFailureException.class);
 
 		// This should succeed
 		template.delete(aggregate, AggregateWithImmutableVersion.class);
@@ -1060,12 +1060,12 @@ class JdbcAggregateTemplateIntegrationTests {
 		reloadedAggregate.setVersion(toConcreteNumber.apply(initialId));
 		assertThatThrownBy(() -> template.save(reloadedAggregate))
 				.withFailMessage("saving an aggregate with an outdated version should raise an exception")
-				.hasRootCauseInstanceOf(OptimisticLockingFailureException.class);
+				.isInstanceOf(OptimisticLockingFailureException.class);
 
 		reloadedAggregate.setVersion(toConcreteNumber.apply(initialId + 2));
 		assertThatThrownBy(() -> template.save(reloadedAggregate))
 				.withFailMessage("saving an aggregate with a future version should raise an exception")
-				.hasRootCauseInstanceOf(OptimisticLockingFailureException.class);
+				.isInstanceOf(OptimisticLockingFailureException.class);
 	}
 
 	private Long count(String tableName) {

--- a/spring-data-r2dbc/pom.xml
+++ b/spring-data-r2dbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-r2dbc</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.0-1313-noop-deletes-SNAPSHOT</version>
 
 	<name>Spring Data R2DBC</name>
 	<description>Spring Data module for R2DBC</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.0-1313-noop-deletes-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-relational</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.0-1313-noop-deletes-SNAPSHOT</version>
 
 	<name>Spring Data Relational</name>
 	<description>Spring Data Relational support</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.0-1313-noop-deletes-SNAPSHOT</version>
 	</parent>
 
 	<properties>


### PR DESCRIPTION
Delete operations that receive a version attribute throw an `OptimisticFailureException` when they delete zero rows.
Otherwise, the NOOP delete gets silently ignored.

Note that save operations that are determined to be an update because the aggregate is not new will still throw an `IncorrectUpdateSemanticsDataAccessException` if they fail to update any row.
This is somewhat asymmetric to the delete-behaviour.
But with a delete the intended result is achieved: the aggregate is gone from the database.
For save operations the intended result is not achieved, hence the exception.

Closes https://github.com/spring-projects/spring-data-relational/issues/1313