### PR TITLE
Fix to check for empty criteria

### DIFF
--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlGenerator.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlGenerator.java
@@ -56,6 +56,7 @@ import org.springframework.util.Assert;
  * @author Mikhail Polivakha
  * @author Chirag Tailor
  * @author Diego Krupitza
+ * @author Hari Ohm Prasath
  */
 class SqlGenerator {
 
@@ -941,7 +942,7 @@ class SqlGenerator {
 	SelectBuilder.SelectOrdered applyCriteria(@Nullable CriteriaDefinition criteria,
 			SelectBuilder.SelectWhere whereBuilder, MapSqlParameterSource parameterSource, Table table) {
 
-		return criteria != null //
+		return criteria != null && !criteria.isEmpty() // Check for null and empty criteria
 				? whereBuilder.where(queryMapper.getMappedObject(parameterSource, criteria, table, entity)) //
 				: whereBuilder;
 	}

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlGeneratorUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlGeneratorUnitTests.java
@@ -69,6 +69,7 @@ import org.springframework.lang.Nullable;
  * @author Mikhail Polivakha
  * @author Chirag Tailor
  * @author Diego Krupitza
+ * @author Hari Ohm Prasath
  */
 @SuppressWarnings("Convert2MethodRef")
 class SqlGeneratorUnitTests {
@@ -777,6 +778,15 @@ class SqlGeneratorUnitTests {
 
 		assertThat(parameterSource.getValues()) //
 				.containsOnly(entry("x_name", probe.name));
+	}
+
+	@Test // GH-1329
+	void selectWithOutAnyCriteriaTest() {
+		SqlGenerator sqlGenerator = createSqlGenerator(DummyEntity.class);
+		Query query = Query.query(Criteria.empty());
+		MapSqlParameterSource parameterSource = new MapSqlParameterSource();
+		String generatedSQL = sqlGenerator.selectByQuery(query, parameterSource);
+		assertThat(generatedSQL).isNotNull().doesNotContain("where");
 	}
 
 	@Test // GH-1192


### PR DESCRIPTION
Code changes to check for both `null` and empty criteria before proceeding to where clause generation, so we dont fail with `IllegalArgumentException`

https://github.com/spring-projects/spring-data-relational/issues/1329

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
