### PR TITLE
Use awaitSingle operator instead of awaitFirst

### DIFF
--- a/spring-data-r2dbc/src/main/kotlin/org/springframework/data/r2dbc/core/ReactiveSelectOperationExtensions.kt
+++ b/spring-data-r2dbc/src/main/kotlin/org/springframework/data/r2dbc/core/ReactiveSelectOperationExtensions.kt
@@ -17,13 +17,13 @@ package org.springframework.data.r2dbc.core
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.reactive.asFlow
-import kotlinx.coroutines.reactive.awaitFirstOrNull
 import kotlinx.coroutines.reactive.awaitSingle
+import kotlinx.coroutines.reactor.awaitSingleOrNull
 
 /**
  * Extensions for [ReactiveSelectOperation].
  *
- * @author Mark Paluch
+ * @author Mark Paluch, George Papadopoulos
  * @since 1.1
  */
 
@@ -49,7 +49,7 @@ suspend inline fun <reified T : Any> ReactiveSelectOperation.TerminatingSelect<T
  * Nullable Coroutines variant of [ReactiveSelectOperation.TerminatingSelect.one].
  */
 suspend inline fun <reified T : Any> ReactiveSelectOperation.TerminatingSelect<T>.awaitOneOrNull(): T? =
-		one().awaitFirstOrNull()
+		one().awaitSingleOrNull()
 
 /**
  * Non-nullable Coroutines variant of [ReactiveSelectOperation.TerminatingSelect.first].
@@ -61,7 +61,7 @@ suspend inline fun <reified T : Any> ReactiveSelectOperation.TerminatingSelect<T
  * Nullable Coroutines variant of [ReactiveSelectOperation.TerminatingSelect.first].
  */
 suspend inline fun <reified T : Any> ReactiveSelectOperation.TerminatingSelect<T>.awaitFirstOrNull(): T? =
-		first().awaitFirstOrNull()
+		first().awaitSingleOrNull()
 
 /**
  * Coroutines variant of [ReactiveSelectOperation.TerminatingSelect.count].


### PR DESCRIPTION
A minor refactoring to use `awaitSingleXxx` operators instead of `awaitFirstXxx`.

Operators `awaitFirstXxx` are going to be deprecated. Also, awaitFirst operator has no value on Mono types.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).