### PR TITLE
Add failing test with multiple joins and `InlineQuery`

### DIFF
--- a/spring-data-relational/src/test/java/org/springframework/data/relational/core/sql/render/SelectRendererUnitTests.java
+++ b/spring-data-relational/src/test/java/org/springframework/data/relational/core/sql/render/SelectRendererUnitTests.java
@@ -239,11 +239,10 @@ class SelectRendererUnitTests {
 		BindMarker merchantIdMarker = SQL.bindMarker(":merchantId");
 
 		Select innerSelect = Select.builder()
-				.select(customerDetails.column("user_id").as("user_id"), customerDetails.column("user_id").as("name"))
+				.select(customerDetails.column("user_id").as("user_id"))
 				.from(customerDetails).join(merchantCustomers)
-				.on(merchantCustomers.column("user_id").isEqualTo(customerDetails.column("user_id"))).where(
-						customerDetails.column("user_id").isEqualTo(merchantCustomers.column("user_id"))
-								.and(merchantCustomers.column("merchant_id").isEqualTo(merchantIdMarker))).build();
+				.on(merchantCustomers.column("user_id").isEqualTo(customerDetails.column("user_id")))
+				.build();
 
 		InlineQuery innerTable = InlineQuery.create(innerSelect, "inner");
 
@@ -256,10 +255,9 @@ class SelectRendererUnitTests {
 
 		assertThat(sql).isEqualTo("SELECT merchants_customers.* FROM merchants_customers " + //
 				"JOIN (" + //
-				"SELECT customer_details.user_id AS user_id, customer_details.user_id AS name " + //
+				"SELECT customer_details.user_id AS user_id " + //
 				"FROM customer_details " + //
-				"JOIN merchants_customers ON merchants_customers.user_id = customer_details.user_id " + //
-				"WHERE customer_details.user_id = merchants_customers.user_id AND merchants_customers.merchant_id = :merchantId" + //
+				"JOIN merchants_customers ON merchants_customers.user_id = customer_details.user_id" + //
 				") inner " + //
 				"ON inner.user_id = merchants_customers.user_id");
 	}


### PR DESCRIPTION
I'm not sure yet how I should approach this problem, but it seems that somehow where clauses of the inline query are partly reused in the outer query, resulting in invalid SQL.

To clarify, the test result is:

```
org.opentest4j.AssertionFailedError: 
expected: "SELECT merchants_customers.* FROM merchants_customers JOIN (SELECT customer_details.user_id AS user_id FROM customer_details JOIN merchants_customers ON merchants_customers.user_id = customer_details.user_id) inner ON inner.user_id = merchants_customers.user_id"
 but was: "SELECT merchants_customers.* FROM merchants_customers JOIN (SELECT customer_details.user_id AS user_id FROM customer_details JOIN merchants_customers ON merchants_customers.user_id = customer_details.user_id) inner ON merchants_customers.merchant_id = :merchantId = merchants_customers.user_id"
```

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
