### PR TITLE
Fix broken join conditions with InlineQuery.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-relational-parent</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.0-1362-inline-query-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Relational Parent</name>

--- a/spring-data-jdbc-distribution/pom.xml
+++ b/spring-data-jdbc-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.0-1362-inline-query-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-jdbc</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.0-1362-inline-query-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.0-1362-inline-query-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-r2dbc/pom.xml
+++ b/spring-data-r2dbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-r2dbc</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.0-1362-inline-query-SNAPSHOT</version>
 
 	<name>Spring Data R2DBC</name>
 	<description>Spring Data module for R2DBC</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.0-1362-inline-query-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-relational</artifactId>
-	<version>3.0.0-SNAPSHOT</version>
+	<version>3.0.0-1362-inline-query-SNAPSHOT</version>
 
 	<name>Spring Data Relational</name>
 	<description>Spring Data Relational support</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.0.0-SNAPSHOT</version>
+		<version>3.0.0-1362-inline-query-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/ComparisonVisitor.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/ComparisonVisitor.java
@@ -39,7 +39,9 @@ class ComparisonVisitor extends FilteredSubtreeVisitor {
 	private @Nullable PartRenderer current;
 
 	ComparisonVisitor(RenderContext context, Comparison condition, RenderTarget target) {
+
 		super(it -> it == condition);
+
 		this.condition = condition;
 		this.target = target;
 		this.context = context;
@@ -47,12 +49,6 @@ class ComparisonVisitor extends FilteredSubtreeVisitor {
 
 	@Override
 	Delegation enterNested(Visitable segment) {
-
-		if (segment instanceof Condition) {
-			ConditionVisitor visitor = new ConditionVisitor(context);
-			current = visitor;
-			return Delegation.delegateTo(visitor);
-		}
 
 		if (segment instanceof Expression) {
 			ExpressionVisitor visitor = new ExpressionVisitor(context);

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/ExpressionVisitor.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/ExpressionVisitor.java
@@ -123,6 +123,11 @@ class ExpressionVisitor extends TypedSubtreeVisitor<Expression> implements PartR
 			return Delegation.delegateTo(visitor);
 		}
 
+		if (segment instanceof InlineQuery) {
+
+			NoopVisitor<InlineQuery> partRenderer = new NoopVisitor(InlineQuery.class);
+			return Delegation.delegateTo(partRenderer);
+		}
 		return super.enterNested(segment);
 	}
 

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/NoopVisitor.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/NoopVisitor.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.relational.core.sql.render;
+
+import org.springframework.data.relational.core.sql.Visitable;
+
+/**
+ * A visitor doing nothing.
+ *
+ * @param <T> visitable to be ignored by the NoopVisitor.
+ * @since 3.0
+ * @author Jens Schauder
+ */
+class NoopVisitor<T extends Visitable> extends TypedSubtreeVisitor<T> {
+	NoopVisitor(Class<T> type) {
+		super(type);
+	}
+}

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/TypedSubtreeVisitor.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/TypedSubtreeVisitor.java
@@ -55,6 +55,13 @@ abstract class TypedSubtreeVisitor<T extends Visitable> extends DelegatingVisito
 	}
 
 	/**
+	 * Creates a new {@link TypedSubtreeVisitor} with an explicitly provided type.
+	 */
+	TypedSubtreeVisitor(Class <T> type) {
+		this.type = ResolvableType.forType(type);
+	}
+
+	/**
 	 * {@link Visitor#enter(Visitable) Enter} callback for a {@link Visitable} that this {@link Visitor} is responsible
 	 * for. The default implementation retains delegation by default.
 	 *


### PR DESCRIPTION
Before this fix, whenever a column of an inline query was rendered the `InlineQuery` and all its children were visited, resulting in spurious output.
This is no prevented by injecting a NoopVisitor.

Supersedes #1362
