### PR TITLE
Enhanced @Query documentation

### DIFF
--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/AbstractJdbcQuery.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/AbstractJdbcQuery.java
@@ -82,10 +82,6 @@ public abstract class AbstractJdbcQuery implements RepositoryQuery {
 	protected JdbcQueryExecution<?> getQueryExecution(JdbcQueryMethod queryMethod,
 			@Nullable ResultSetExtractor<?> extractor, RowMapper<?> rowMapper) {
 
-		if (queryMethod.isModifyingQuery()) {
-			return createModifyingQueryExecutor();
-		}
-
 		if (queryMethod.isCollectionQuery()) {
 			return extractor != null ? getQueryExecution(extractor) : collectionQuery(rowMapper);
 		}
@@ -97,7 +93,7 @@ public abstract class AbstractJdbcQuery implements RepositoryQuery {
 		return extractor != null ? getQueryExecution(extractor) : singleObjectQuery(rowMapper);
 	}
 
-	private JdbcQueryExecution<Object> createModifyingQueryExecutor() {
+	protected JdbcQueryExecution<Object> createModifyingQueryExecutor() {
 
 		return (query, parameters) -> {
 

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/Query.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/Query.java
@@ -29,6 +29,18 @@ import org.springframework.jdbc.core.RowMapper;
  * Annotation to provide SQL statements that will get used for executing the method. The SQL statement may contain named
  * parameters as supported by {@link org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate}. Those
  * parameters will get bound to the arguments of the annotated method.
+ * <p>
+ * You can also specify the way to extract data from {@link java.sql.ResultSet}. There are 4 attribute of this
+ * annotation you can set to do that:
+ * <p>
+ * 1. {@link #resultSetExtractorRef()}
+ * 2. {@link #resultSetExtractorClass()}
+ * 3. {@link #rowMapperRef()}
+ * 4. {@link #rowMapperClass()}
+ *
+ * The annotation attributes above are listed in their preference order, that is - the {@link #resultSetExtractorRef()},
+ * has the highest privilege and, will suppress any other 3 attribute from above, and consequently {@link #rowMapperClass()}
+ * has the lowest privilege and will be used if any of three above are not specified.
  *
  * @author Jens Schauder
  * @author Moises Cisneros
@@ -52,28 +64,23 @@ public @interface Query {
 	String name() default "";
 
 	/**
-	 * Optional {@link RowMapper} to use to convert the result of the query to domain class instances. Cannot be used
-	 * along with {@link #resultSetExtractorClass()} only one of the two can be set.
+	 * Optional {@link RowMapper} to use to convert the result of the query to domain class instances.
 	 */
 	Class<? extends RowMapper> rowMapperClass() default RowMapper.class;
 
 	/**
-	 * Optional name of a bean of type {@link RowMapper} to use to convert the result of the query to domain class instances. Cannot be used
-	 * along with {@link #resultSetExtractorClass()} only one of the two can be set.
-	 *
+	 * Optional name of a bean of type {@link RowMapper} to use to convert the result of the query to domain class instances.
 	 * @since 2.1
 	 */
 	String rowMapperRef() default "";
 
 	/**
-	 * Optional {@link ResultSetExtractor} to use to convert the result of the query to domain class instances. Cannot be
-	 * used along with {@link #rowMapperClass()} only one of the two can be set.
+	 * Optional {@link ResultSetExtractor} to use to convert the result of the query to domain class instances.
 	 */
 	Class<? extends ResultSetExtractor> resultSetExtractorClass() default ResultSetExtractor.class;
 
 	/**
-	 * Optional name of a bean of type {@link ResultSetExtractor} to use to convert the result of the query to domain class instances. Cannot be
-	 * used along with {@link #rowMapperClass()} only one of the two can be set.
+	 * Optional name of a bean of type {@link ResultSetExtractor} to use to convert the result of the query to domain class instances.
 	 *
 	 * @since 2.1
 	 */


### PR DESCRIPTION
I have enhanced `@Query` annotation doc and slightly refactored the `AbstractJdbcQuery` to avoid creation of unnecessary `RowMapper`s and `ResultSetExtractor`s in case the query is intended for modification.