### PR TITLE
Favor `SqlIdentifier.getReference()` instead of `getReference(IdentifierProcessing)`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-relational-parent</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.0-1110-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Relational Parent</name>

--- a/spring-data-jdbc-distribution/pom.xml
+++ b/spring-data-jdbc-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.0-1110-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-jdbc</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.0-1110-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.0-1110-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/IdGeneratingBatchInsertStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/IdGeneratingBatchInsertStrategy.java
@@ -79,7 +79,7 @@ class IdGeneratingBatchInsertStrategy implements BatchInsertStrategy {
 			Map<String, Object> keys = keyList.get(i);
 			if (keys.size() > 1) {
 				if (idColumn != null) {
-					ids[i] = keys.get(idColumn.getReference(dialect.getIdentifierProcessing()));
+					ids[i] = keys.get(idColumn.getReference());
 				}
 			} else {
 				ids[i] = keys.entrySet().stream().findFirst() //
@@ -93,7 +93,7 @@ class IdGeneratingBatchInsertStrategy implements BatchInsertStrategy {
 	private String[] getKeyColumnNames() {
 
 		return Optional.ofNullable(idColumn)
-				.map(idColumn -> new String[] { idColumn.getReference(dialect.getIdentifierProcessing()) })
+				.map(idColumn -> new String[] { idColumn.getReference() })
 				.orElse(new String[0]);
 	}
 }

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/IdGeneratingInsertStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/IdGeneratingInsertStrategy.java
@@ -79,13 +79,13 @@ class IdGeneratingInsertStrategy implements InsertStrategy {
 				return null;
 			}
 
-			return keys.get(idColumn.getReference(dialect.getIdentifierProcessing()));
+			return keys.get(idColumn.getReference());
 		}
 	}
 
 	private String[] getKeyColumnNames() {
 		return Optional.ofNullable(idColumn)
-				.map(idColumn -> new String[] { idColumn.getReference(dialect.getIdentifierProcessing()) })
+				.map(idColumn -> new String[] { idColumn.getReference() })
 				.orElse(new String[0]);
 	}
 }

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcBackReferencePropertyValueProvider.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcBackReferencePropertyValueProvider.java
@@ -50,7 +50,7 @@ class JdbcBackReferencePropertyValueProvider implements PropertyValueProvider<Re
 	@Override
 	public <T> T getPropertyValue(RelationalPersistentProperty property) {
 		return (T) resultSet
-				.getObject(basePath.extendBy(property).getReverseColumnNameAlias().getReference(identifierProcessing));
+				.getObject(basePath.extendBy(property).getReverseColumnNameAlias().getReference());
 	}
 
 	public JdbcBackReferencePropertyValueProvider extendBy(RelationalPersistentProperty property) {

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcPropertyValueProvider.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcPropertyValueProvider.java
@@ -62,7 +62,7 @@ class JdbcPropertyValueProvider implements PropertyValueProvider<RelationalPersi
 	}
 
 	private String getColumnName(RelationalPersistentProperty property) {
-		return basePath.extendBy(property).getColumnAlias().getReference(identifierProcessing);
+		return basePath.extendBy(property).getColumnAlias().getReference();
 	}
 
 	public JdbcPropertyValueProvider extendBy(RelationalPersistentProperty property) {

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/MapEntityRowMapper.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/MapEntityRowMapper.java
@@ -53,7 +53,7 @@ class MapEntityRowMapper<T> implements RowMapper<Map.Entry<Object, T>> {
 	@Override
 	public Map.Entry<Object, T> mapRow(ResultSet rs, int rowNum) throws SQLException {
 
-		Object key = rs.getObject(keyColumn.getReference(identifierProcessing));
+		Object key = rs.getObject(keyColumn.getReference());
 		return new HashMap.SimpleEntry<>(key, mapEntity(rs, key));
 	}
 

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlGenerator.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlGenerator.java
@@ -772,7 +772,7 @@ class SqlGenerator {
 	}
 
 	private String renderReference(SqlIdentifier identifier) {
-		return identifier.getReference(renderContext.getIdentifierProcessing());
+		return identifier.getReference();
 	}
 
 	private List<OrderByField> extractOrderByFields(Sort sort) {

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlIdentifierParameterSource.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlIdentifierParameterSource.java
@@ -68,7 +68,7 @@ class SqlIdentifierParameterSource extends AbstractSqlParameterSource {
 	void addValue(SqlIdentifier identifier, Object value, int sqlType) {
 
 		identifiers.add(identifier);
-		String name = BindParameterNameSanitizer.sanitize(identifier.getReference(identifierProcessing));
+		String name = BindParameterNameSanitizer.sanitize(identifier.getReference());
 		namesToValues.put(name, value);
 		registerSqlType(name, sqlType);
 	}
@@ -77,7 +77,7 @@ class SqlIdentifierParameterSource extends AbstractSqlParameterSource {
 
 		for (SqlIdentifier identifier : others.getIdentifiers()) {
 
-			String name = identifier.getReference(identifierProcessing);
+			String name = identifier.getReference();
 			addValue(identifier, others.getValue(name), others.getSqlType(name));
 		}
 	}

--- a/spring-data-r2dbc/pom.xml
+++ b/spring-data-r2dbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-r2dbc</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.0-1110-SNAPSHOT</version>
 
 	<name>Spring Data R2DBC</name>
 	<description>Spring Data module for R2DBC</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.0-1110-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/dialect/H2Dialect.java
+++ b/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/dialect/H2Dialect.java
@@ -47,7 +47,7 @@ public class H2Dialect extends org.springframework.data.relational.core.dialect.
 
 	@Override
 	public String renderForGeneratedValues(SqlIdentifier identifier) {
-		return identifier.getReference(getIdentifierProcessing());
+		return identifier.getReference();
 	}
 
 	@Override

--- a/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/dialect/MySqlDialect.java
+++ b/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/dialect/MySqlDialect.java
@@ -95,7 +95,7 @@ public class MySqlDialect extends org.springframework.data.relational.core.diale
 
 	@Override
 	public String renderForGeneratedValues(SqlIdentifier identifier) {
-		return identifier.getReference(getIdentifierProcessing());
+		return identifier.getReference();
 	}
 
 	/**

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-relational</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.0-1110-SNAPSHOT</version>
 
 	<name>Spring Data Relational</name>
 	<description>Spring Data Relational support</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.1.0-SNAPSHOT</version>
+		<version>3.1.0-1110-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/DerivedSqlIdentifier.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/DerivedSqlIdentifier.java
@@ -65,7 +65,7 @@ class DerivedSqlIdentifier implements SqlIdentifier {
 	}
 
 	@Override
-	@Deprecated(since="3.0.5", forRemoval = false)
+	@Deprecated(since="3.1", forRemoval = true)
 	public String getReference(IdentifierProcessing processing) {
 		return toSql(processing);
 	}

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/DerivedSqlIdentifier.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/DerivedSqlIdentifier.java
@@ -65,8 +65,9 @@ class DerivedSqlIdentifier implements SqlIdentifier {
 	}
 
 	@Override
+	@Deprecated(since="3.0.5", forRemoval = false)
 	public String getReference(IdentifierProcessing processing) {
-		return this.name;
+		return toSql(processing);
 	}
 
 	@Override

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/NamingStrategy.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/NamingStrategy.java
@@ -84,7 +84,7 @@ public interface NamingStrategy {
 
 		Assert.notNull(property, "Property must not be null");
 
-		return property.getOwner().getTableName().getReference(IdentifierProcessing.NONE);
+		return property.getOwner().getTableName().getReference();
 	}
 
 	default String getReverseColumnName(PersistentPropertyPathExtension path) {

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/PersistentPropertyPathExtension.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/PersistentPropertyPathExtension.java
@@ -482,7 +482,7 @@ public class PersistentPropertyPathExtension {
 
 		SqlIdentifier tableAlias = getTableAlias();
 		return tableAlias == null ? columnName
-				: columnName.transform(name -> tableAlias.getReference(IdentifierProcessing.NONE) + "_" + name);
+				: columnName.transform(name -> tableAlias.getReference() + "_" + name);
 	}
 
 	@Override

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/CompositeSqlIdentifier.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/CompositeSqlIdentifier.java
@@ -66,6 +66,7 @@ class CompositeSqlIdentifier implements SqlIdentifier {
 	}
 
 	@Override
+	@Deprecated(since="3.0.5", forRemoval = false)
 	public String getReference(IdentifierProcessing processing) {
 		throw new UnsupportedOperationException("Composite SQL Identifiers can't be used for reference name retrieval");
 	}

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/CompositeSqlIdentifier.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/CompositeSqlIdentifier.java
@@ -66,7 +66,7 @@ class CompositeSqlIdentifier implements SqlIdentifier {
 	}
 
 	@Override
-	@Deprecated(since="3.0.5", forRemoval = false)
+	@Deprecated(since="3.1", forRemoval = true)
 	public String getReference(IdentifierProcessing processing) {
 		throw new UnsupportedOperationException("Composite SQL Identifiers can't be used for reference name retrieval");
 	}

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/DefaultSqlIdentifier.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/DefaultSqlIdentifier.java
@@ -61,7 +61,7 @@ class DefaultSqlIdentifier implements SqlIdentifier {
 	}
 
 	@Override
-	@Deprecated(since="3.0.5", forRemoval = false)
+	@Deprecated(since="3.1", forRemoval = true)
 	public String getReference(IdentifierProcessing processing) {
 		return toSql(processing);
 	}

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/DefaultSqlIdentifier.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/DefaultSqlIdentifier.java
@@ -57,12 +57,13 @@ class DefaultSqlIdentifier implements SqlIdentifier {
 
 	@Override
 	public String toSql(IdentifierProcessing processing) {
-		return quoted ? processing.quote(getReference(processing)) : getReference(processing);
+		return quoted ? processing.quote(name) : name;
 	}
 
 	@Override
+	@Deprecated(since="3.0.5", forRemoval = false)
 	public String getReference(IdentifierProcessing processing) {
-		return name;
+		return toSql(processing);
 	}
 
 	@Override

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/SqlIdentifier.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/SqlIdentifier.java
@@ -78,17 +78,16 @@ public interface SqlIdentifier extends Streamable<SqlIdentifier> {
 	 * Return the reference name after applying {@link IdentifierProcessing} rules. The reference name is used for
 	 * programmatic access to the object identified by this {@link SqlIdentifier}.
 	 *
-	 * @deprecated Use the toSql(IdentifierProcessing processing) method instead.
-	 *
 	 * @param processing identifier processing rules.
 	 * @return
+	 * @deprecated since 3.1, use the #getReference() method instead.
 	 */
-	@Deprecated(since="3.0.5", forRemoval = false)
+	@Deprecated(since="3.1", forRemoval = true)
 	String getReference(IdentifierProcessing processing);
 
 	/**
-	 * Return the reference name without any further transformation. The reference name is used for programmatic access to
-	 * the object identified by this {@link SqlIdentifier}.
+	 * Use this method whenever accessing a column in a ResultSet and we do not want any quoting applied. The
+	 * reference name is used for programmatic access to the object identified by this {@link SqlIdentifier}.
 	 *
 	 * @return
 	 * @see IdentifierProcessing#NONE
@@ -98,8 +97,9 @@ public interface SqlIdentifier extends Streamable<SqlIdentifier> {
 	}
 
 	/**
-	 * Return the identifier for SQL usage after applying {@link IdentifierProcessing} rules. The identifier name is used
-	 * to construct SQL statements.
+	 * Use this method when rendering an identifier in SQL statements as in:
+	 * <pre><code>select yourColumn from someTable</code></pre>
+	 * {@link IdentifierProcessing} rules are applied to the identifier.
 	 *
 	 * @param processing identifier processing rules.
 	 * @return

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/SqlIdentifier.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/SqlIdentifier.java
@@ -26,7 +26,7 @@ import org.springframework.data.util.Streamable;
  * from a {@link String name} with specifying whether the name should be quoted or unquoted.
  * <p>
  * {@link SqlIdentifier} renders its name using {@link IdentifierProcessing} rules. Use
- * {@link #getReference(IdentifierProcessing)} to refer to an object using the identifier when e.g. obtaining values
+ * {@link #getReference()} to refer to an object using the identifier when e.g. obtaining values
  * from a result or providing values for a prepared statement. {@link #toSql(IdentifierProcessing)} renders the
  * identifier for SQL statement usage.
  * <p>
@@ -39,6 +39,7 @@ import org.springframework.data.util.Streamable;
  *
  * @author Jens Schauder
  * @author Mark Paluch
+ * @author Kurt Niemi
  * @since 2.0
  */
 public interface SqlIdentifier extends Streamable<SqlIdentifier> {
@@ -77,9 +78,12 @@ public interface SqlIdentifier extends Streamable<SqlIdentifier> {
 	 * Return the reference name after applying {@link IdentifierProcessing} rules. The reference name is used for
 	 * programmatic access to the object identified by this {@link SqlIdentifier}.
 	 *
+	 * @deprecated Use the toSql(IdentifierProcessing processing) method instead.
+	 *
 	 * @param processing identifier processing rules.
 	 * @return
 	 */
+	@Deprecated(since="3.0.5", forRemoval = false)
 	String getReference(IdentifierProcessing processing);
 
 	/**
@@ -90,7 +94,7 @@ public interface SqlIdentifier extends Streamable<SqlIdentifier> {
 	 * @see IdentifierProcessing#NONE
 	 */
 	default String getReference() {
-		return getReference(IdentifierProcessing.NONE);
+		return toSql(IdentifierProcessing.NONE);
 	}
 
 	/**

--- a/spring-data-relational/src/test/java/org/springframework/data/relational/core/mapping/DerivedSqlIdentifierUnitTests.java
+++ b/spring-data-relational/src/test/java/org/springframework/data/relational/core/mapping/DerivedSqlIdentifierUnitTests.java
@@ -41,7 +41,8 @@ public class DerivedSqlIdentifierUnitTests {
 		SqlIdentifier identifier = new DerivedSqlIdentifier("someName", true);
 
 		assertThat(identifier.toSql(BRACKETS_LOWER_CASE)).isEqualTo("[somename]");
-		assertThat(identifier.getReference(BRACKETS_LOWER_CASE)).isEqualTo("someName");
+		assertThat(identifier.getReference(BRACKETS_LOWER_CASE)).isEqualTo("[somename]");
+		assertThat(identifier.getReference()).isEqualTo("someName");
 
 	}
 
@@ -52,7 +53,8 @@ public class DerivedSqlIdentifierUnitTests {
 		String sql = identifier.toSql(BRACKETS_LOWER_CASE);
 
 		assertThat(sql).isEqualTo("somename");
-		assertThat(identifier.getReference(BRACKETS_LOWER_CASE)).isEqualTo("someName");
+		assertThat(identifier.getReference(BRACKETS_LOWER_CASE)).isEqualTo("somename");
+		assertThat(identifier.getReference()).isEqualTo("someName");
 	}
 
 	@Test // DATAJDBC-386

--- a/spring-data-relational/src/test/java/org/springframework/data/relational/core/sql/SqlIdentifierUnitTests.java
+++ b/spring-data-relational/src/test/java/org/springframework/data/relational/core/sql/SqlIdentifierUnitTests.java
@@ -40,7 +40,8 @@ public class SqlIdentifierUnitTests {
 		SqlIdentifier identifier = quoted("someName");
 
 		assertThat(identifier.toSql(BRACKETS_LOWER_CASE)).isEqualTo("[someName]");
-		assertThat(identifier.getReference(BRACKETS_LOWER_CASE)).isEqualTo("someName");
+		assertThat(identifier.getReference(BRACKETS_LOWER_CASE)).isEqualTo("[someName]");
+		assertThat(identifier.getReference()).isEqualTo("someName");
 	}
 
 	@Test // DATAJDBC-386
@@ -51,6 +52,7 @@ public class SqlIdentifierUnitTests {
 
 		assertThat(sql).isEqualTo("someName");
 		assertThat(identifier.getReference(BRACKETS_LOWER_CASE)).isEqualTo("someName");
+		assertThat(identifier.getReference()).isEqualTo("someName");
 	}
 
 	@Test // DATAJDBC-386


### PR DESCRIPTION
Change to deprecate redundant getReference(IdentifierProcessing) method.

I split out the commits to make this change easier to review.

The first commit after the branch preparation outlines the changes to actual implementation. Second commit is Unit Tests supporting change, and third commit is change/eliminate all usages of the deprecated API.

I fixed the implementation of the deprecated method to actually use the IdentifierProcessing parameter. If we want to leave the implementation unchanged, please let me know.

Will squash commits after making any other needed changes.