### PR TITLE
Remove unnecessary reification from Kotlin R2DBC extensions

### DIFF
--- a/spring-data-r2dbc/src/main/kotlin/org/springframework/data/r2dbc/core/ReactiveInsertOperationExtensions.kt
+++ b/spring-data-r2dbc/src/main/kotlin/org/springframework/data/r2dbc/core/ReactiveInsertOperationExtensions.kt
@@ -33,5 +33,5 @@ inline fun <reified T : Any> ReactiveInsertOperation.insert(): ReactiveInsertOpe
 /**
  * Coroutines variant of [ReactiveInsertOperation.TerminatingInsert.using].
  */
-suspend inline fun <reified T : Any> ReactiveInsertOperation.TerminatingInsert<T>.usingAndAwait(o: T): T =
+suspend fun <T : Any> ReactiveInsertOperation.TerminatingInsert<T>.usingAndAwait(o: T): T =
 		using(o).awaitSingle()

--- a/spring-data-r2dbc/src/main/kotlin/org/springframework/data/r2dbc/core/ReactiveSelectOperationExtensions.kt
+++ b/spring-data-r2dbc/src/main/kotlin/org/springframework/data/r2dbc/core/ReactiveSelectOperationExtensions.kt
@@ -42,25 +42,25 @@ inline fun <reified T : Any> ReactiveSelectOperation.SelectWithProjection<*>.asT
 /**
  * Non-nullable Coroutines variant of [ReactiveSelectOperation.TerminatingSelect.one].
  */
-suspend inline fun <reified T : Any> ReactiveSelectOperation.TerminatingSelect<T>.awaitOne(): T =
+suspend fun <T : Any> ReactiveSelectOperation.TerminatingSelect<T>.awaitOne(): T =
 		one().awaitSingle()
 
 /**
  * Nullable Coroutines variant of [ReactiveSelectOperation.TerminatingSelect.one].
  */
-suspend inline fun <reified T : Any> ReactiveSelectOperation.TerminatingSelect<T>.awaitOneOrNull(): T? =
+suspend fun <T : Any> ReactiveSelectOperation.TerminatingSelect<T>.awaitOneOrNull(): T? =
 		one().awaitFirstOrNull()
 
 /**
  * Non-nullable Coroutines variant of [ReactiveSelectOperation.TerminatingSelect.first].
  */
-suspend inline fun <reified T : Any> ReactiveSelectOperation.TerminatingSelect<T>.awaitFirst(): T =
+suspend fun <T : Any> ReactiveSelectOperation.TerminatingSelect<T>.awaitFirst(): T =
 		first().awaitSingle()
 
 /**
  * Nullable Coroutines variant of [ReactiveSelectOperation.TerminatingSelect.first].
  */
-suspend inline fun <reified T : Any> ReactiveSelectOperation.TerminatingSelect<T>.awaitFirstOrNull(): T? =
+suspend fun <T : Any> ReactiveSelectOperation.TerminatingSelect<T>.awaitFirstOrNull(): T? =
 		first().awaitFirstOrNull()
 
 /**


### PR DESCRIPTION
This allows calling the extensions from generic code that has erased types, for example:

```kotlin
class CustomRepository<T>(val type: Class<T>) {
    @Autowired
    lateinit var db: R2dbcEntityTemplate

    // Fails to compile currently because usingAndAwait requires a reified T
    suspend fun create(obj: T) = db.insert(type).usingAndAwait(obj)
}
```

I’m not sure what to do about tests. I could add new tests with erased types, but they would necessarily duplicate the existing tests that have reified types—and especially in `ReactiveSelectOperationExtensionsUnitTests`, that’s quite a lot of code; and the new tests would be verifying the same runtime behaviour as the old tests (as this change only affects compilability), so they’d become redundant. Alternatively, the existing tests could be tweaked to ensure the types are erased; or the ability to use erased types could go completely untested.

I’m also not sure whether this is an ABI-compatible change. If not, I assume it will have to wait until a major-enough release where ABI breaks are allowed.