### PR TITLE
Do not prefix unsafe order by expressions with table prefix.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-relational-parent</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-1512-drop-table-prefix-for-unsafe-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Relational Parent</name>

--- a/spring-data-jdbc-distribution/pom.xml
+++ b/spring-data-jdbc-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-1512-drop-table-prefix-for-unsafe-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-jdbc</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-1512-drop-table-prefix-for-unsafe-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-1512-drop-table-prefix-for-unsafe-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/QueryMapper.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/QueryMapper.java
@@ -93,6 +93,8 @@ public class QueryMapper {
 
 		for (Sort.Order order : sort) {
 
+			SqlSort.validate(order);
+
 			OrderByField simpleOrderByField = createSimpleOrderByField(table, entity, order);
 			OrderByField orderBy = simpleOrderByField
 					.withNullHandling(order.getNullHandling());
@@ -105,7 +107,9 @@ public class QueryMapper {
 
 	private OrderByField createSimpleOrderByField(Table table, RelationalPersistentEntity<?> entity, Sort.Order order) {
 
-		SqlSort.validate(order);
+		if (order instanceof SqlSort.SqlOrder sqlOrder && sqlOrder.isUnsafe()) {
+			return OrderByField.from(Expressions.just(sqlOrder.getProperty()));
+		}
 
 		Field field = createPropertyField(entity, SqlIdentifier.unquoted(order.getProperty()), this.mappingContext);
 		return OrderByField.from(table.column(field.getMappedColumnName()));

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/QueryMapperUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/QueryMapperUnitTests.java
@@ -430,7 +430,7 @@ public class QueryMapperUnitTests {
 
 		assertThat(fields) //
 				.extracting(Objects::toString) //
-				.containsExactly("tbl." + unsafeExpression + " ASC");
+				.containsExactly( unsafeExpression + " ASC");
 	}
 
 	private Condition map(Criteria criteria) {

--- a/spring-data-r2dbc/pom.xml
+++ b/spring-data-r2dbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-r2dbc</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-1512-drop-table-prefix-for-unsafe-SNAPSHOT</version>
 
 	<name>Spring Data R2DBC</name>
 	<description>Spring Data module for R2DBC</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-1512-drop-table-prefix-for-unsafe-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/query/QueryMapperUnitTests.java
+++ b/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/query/QueryMapperUnitTests.java
@@ -39,6 +39,7 @@ import org.springframework.data.relational.core.sql.Expression;
 import org.springframework.data.relational.core.sql.Functions;
 import org.springframework.data.relational.core.sql.OrderByField;
 import org.springframework.data.relational.core.sql.Table;
+import org.springframework.data.relational.domain.SqlSort;
 import org.springframework.r2dbc.core.Parameter;
 import org.springframework.r2dbc.core.binding.BindMarkersFactory;
 import org.springframework.r2dbc.core.binding.BindTarget;
@@ -438,6 +439,19 @@ class QueryMapperUnitTests {
 		assertThat(fields) //
 				.extracting(Objects::toString) //
 				.containsExactly("tbl.unknownField DESC");
+	}
+
+	@Test // GH-1512
+	public void shouldTablePrefixUnsafeOrderExpression() {
+
+		Sort sort = Sort.by(SqlSort.SqlOrder.desc("unknownField").withUnsafe());
+
+		List<OrderByField> fields = mapper.getMappedSort(Table.create("tbl"), sort,
+				mapper.getMappingContext().getRequiredPersistentEntity(Person.class));
+
+		assertThat(fields) //
+				.extracting(Objects::toString) //
+				.containsExactly("unknownField DESC");
 	}
 
 	@Test // GH-1507

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-relational</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-1512-drop-table-prefix-for-unsafe-SNAPSHOT</version>
 
 	<name>Spring Data Relational</name>
 	<description>Spring Data Relational support</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-1512-drop-table-prefix-for-unsafe-SNAPSHOT</version>
 	</parent>
 
 	<properties>


### PR DESCRIPTION
Such expressions now get passed on unchanged.

This also deprecates `org.springframework.data.r2dbc.query.QueryMapper.getMappedObject(Sort, RelationalPersistentEntity<?>)`.
It was only used in tests and translates an Order into another Order, which sounds wrong.

Closes https://github.com/spring-projects/spring-data-relational/issues/1512