### PR TITLE
Vastly refactored property --> jdbc value mapping api

### DIFF
--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcConverter.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcConverter.java
@@ -125,6 +125,15 @@ public interface JdbcConverter extends RelationalConverter {
 	 */
 	SQLType getTargetSqlType(RelationalPersistentProperty property);
 
+	/**
+	 * The SQL type constant used when using this property as a parameter for a SQL statement.
+	 *
+	 * @return Must not be {@code null}.
+	 * @see java.sql.Types
+	 * @since 2.0
+	 */
+	SQLType getTargetSqlType(Class<?> property);
+
 	@Override
 	RelationalMappingContext getMappingContext();
 

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/QueryMapper.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/QueryMapper.java
@@ -381,10 +381,12 @@ public class QueryMapper {
 	 */
 	private JdbcValue getWriteValue(RelationalPersistentProperty property, Object value) {
 
+		Class<?> columnType = converter.getColumnType(property);
+
 		return converter.writeJdbcValue( //
 				value, //
-				converter.getColumnType(property), //
-				converter.getTargetSqlType(property) //
+		        columnType, //
+				converter.getTargetSqlType(columnType) //
 		);
 	}
 

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/AggregateReference.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/AggregateReference.java
@@ -15,8 +15,6 @@
  */
 package org.springframework.data.jdbc.core.mapping;
 
-import java.util.Objects;
-
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
@@ -27,6 +25,7 @@ import org.springframework.util.Assert;
  * @param <ID> the type of the id of the referenced aggregate root.
  * @author Jens Schauder
  * @author Myeonghyeon Lee
+ * @author Mikhail Polivakha
  * @since 1.0
  */
 public interface AggregateReference<T, ID> {
@@ -48,42 +47,15 @@ public interface AggregateReference<T, ID> {
 	 * @param <T>
 	 * @param <ID>
 	 */
-	class IdOnlyAggregateReference<T, ID> implements AggregateReference<T, ID> {
+	record IdOnlyAggregateReference<T, ID>(ID id) implements AggregateReference<T, ID> {
 
-		private final ID id;
-
-		public IdOnlyAggregateReference(ID id) {
-
+		public IdOnlyAggregateReference {
 			Assert.notNull(id, "Id must not be null");
-
-			this.id = id;
 		}
 
 		@Override
 		public ID getId() {
-			return id;
-		}
-
-		@Override
-		public boolean equals(@Nullable Object o) {
-
-			if (this == o)
-				return true;
-			if (o == null || getClass() != o.getClass())
-				return false;
-			IdOnlyAggregateReference<?, ?> that = (IdOnlyAggregateReference<?, ?>) o;
-			return id.equals(that.id);
-		}
-
-		@Override
-		public int hashCode() {
-			return Objects.hash(id);
-		}
-
-		@Override
-		public String toString() {
-
-			return "IdOnlyAggregateReference{" + "id=" + id + '}';
+			return id();
 		}
 	}
 }

--- a/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/convert/MappingR2dbcConverter.java
+++ b/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/convert/MappingR2dbcConverter.java
@@ -101,7 +101,7 @@ public class MappingR2dbcConverter extends MappingRelationalConverter implements
 			return type.cast(row);
 		}
 
-		if (getConversions().hasCustomReadTarget(Row.class, rawType)
+		if (getCustomConversions().hasCustomReadTarget(Row.class, rawType)
 				&& getConversionService().canConvert(Row.class, rawType)) {
 			return getConversionService().convert(row, rawType);
 		}
@@ -170,7 +170,7 @@ public class MappingR2dbcConverter extends MappingRelationalConverter implements
 
 		Class<?> userClass = ClassUtils.getUserClass(source);
 
-		Optional<Class<?>> customTarget = getConversions().getCustomWriteTarget(userClass, OutboundRow.class);
+		Optional<Class<?>> customTarget = getCustomConversions().getCustomWriteTarget(userClass, OutboundRow.class);
 		if (customTarget.isPresent()) {
 
 			OutboundRow result = getConversionService().convert(source, OutboundRow.class);
@@ -212,7 +212,7 @@ public class MappingR2dbcConverter extends MappingRelationalConverter implements
 				continue;
 			}
 
-			if (getConversions().isSimpleType(value.getClass())) {
+			if (getCustomConversions().isSimpleType(value.getClass())) {
 				writeSimpleInternal(sink, value, isNew, property);
 			} else {
 				writePropertyInternal(sink, value, isNew, property);
@@ -286,7 +286,7 @@ public class MappingR2dbcConverter extends MappingRelationalConverter implements
 
 			Class<?> elementType = element == null ? null : element.getClass();
 
-			if (elementType == null || getConversions().isSimpleType(elementType)) {
+			if (elementType == null || getCustomConversions().isSimpleType(elementType)) {
 				collection.add(getPotentiallyConvertedSimpleWrite(element,
 						componentType != null ? componentType.getType() : Object.class));
 			} else if (element instanceof Collection || elementType.isArray()) {
@@ -306,7 +306,7 @@ public class MappingR2dbcConverter extends MappingRelationalConverter implements
 
 	private Class<?> getPotentiallyConvertedSimpleNullType(Class<?> type) {
 
-		Optional<Class<?>> customTarget = getConversions().getCustomWriteTarget(type);
+		Optional<Class<?>> customTarget = getCustomConversions().getCustomWriteTarget(type);
 
 		if (customTarget.isPresent()) {
 			return customTarget.get();
@@ -353,7 +353,7 @@ public class MappingR2dbcConverter extends MappingRelationalConverter implements
 			}
 		}
 
-		Optional<Class<?>> customTarget = getConversions().getCustomWriteTarget(value.getClass());
+		Optional<Class<?>> customTarget = getCustomConversions().getCustomWriteTarget(value.getClass());
 
 		if (customTarget.isPresent()) {
 			return getConversionService().convert(value, customTarget.get());
@@ -393,7 +393,7 @@ public class MappingR2dbcConverter extends MappingRelationalConverter implements
 	@Override
 	public Class<?> getTargetType(Class<?> valueType) {
 
-		Optional<Class<?>> writeTarget = getConversions().getCustomWriteTarget(valueType);
+		Optional<Class<?>> writeTarget = getCustomConversions().getCustomWriteTarget(valueType);
 
 		return writeTarget.orElseGet(() -> {
 			return Enum.class.isAssignableFrom(valueType) ? String.class : valueType;
@@ -402,7 +402,7 @@ public class MappingR2dbcConverter extends MappingRelationalConverter implements
 
 	@Override
 	public boolean isSimpleType(Class<?> type) {
-		return getConversions().isSimpleType(type);
+		return getCustomConversions().isSimpleType(type);
 	}
 
 	// ----------------------------------

--- a/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/core/R2dbcEntityTemplate.java
+++ b/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/core/R2dbcEntityTemplate.java
@@ -852,7 +852,7 @@ public class R2dbcEntityTemplate implements R2dbcEntityOperations, BeanFactoryAw
 
 		// Bridge-code: Consider Converter<Row, T> until we have fully migrated to RowDocument
 		if (converter instanceof AbstractRelationalConverter relationalConverter
-				&& relationalConverter.getConversions().hasCustomReadTarget(Row.class, resultType)) {
+				&& relationalConverter.getCustomConversions().hasCustomReadTarget(Row.class, resultType)) {
 
 			ConversionService conversionService = relationalConverter.getConversionService();
 			rowMapper = (row, rowMetadata) -> (T) conversionService.convert(row, resultType);

--- a/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/repository/support/R2dbcRepositoryFactoryBeanUnitTests.java
+++ b/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/repository/support/R2dbcRepositoryFactoryBeanUnitTests.java
@@ -18,6 +18,7 @@ package org.springframework.data.r2dbc.repository.support;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.ListableBeanFactory;
@@ -26,6 +27,8 @@ import org.springframework.data.r2dbc.dialect.H2Dialect;
 import org.springframework.data.r2dbc.repository.R2dbcRepository;
 import org.springframework.data.spel.EvaluationContextProvider;
 import org.springframework.data.spel.ReactiveExtensionAwareEvaluationContextProvider;
+import org.springframework.data.repository.query.ReactiveExtensionAwareQueryMethodEvaluationContextProvider;
+import org.springframework.data.repository.query.ReactiveQueryMethodEvaluationContextProvider;
 import org.springframework.r2dbc.core.DatabaseClient;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -56,7 +59,5 @@ class R2dbcRepositoryFactoryBeanUnitTests {
 
 	static class Person {}
 
-	interface PersonRepository extends R2dbcRepository<Person, String>
-
-	{}
+	interface PersonRepository extends R2dbcRepository<Person, String> {}
 }

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/AbstractRelationalConverter.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/AbstractRelationalConverter.java
@@ -89,7 +89,7 @@ public abstract class AbstractRelationalConverter implements RelationalConverter
 		return conversionService;
 	}
 
-	public CustomConversions getConversions() {
+	public CustomConversions getCustomConversions() {
 		return conversions;
 	}
 


### PR DESCRIPTION
Hello @schauder !

I have finally came up with the draft solution of #1136 issue. All test cases are running fine, and now it is far more clear, at least from my perspective. I will provide the definitive guide on how this mapping from property --> JdbcValue looks now. You should focus your attention at 

```
createJdbcValue(@Nullable Object value, @Nullable Class<?> genericValueType, @NonNull Class<?> originalValueType)
```

method. This is where the new logic is implemented. Here is how it works:

1. If the provided value is `null`, then we just return `null` wrapped with `JdbcValue` with `SQLType` as of original type of a value. Here is interesting thing - in `java.sql.JDBCType` class there is a `NULL` type, and almost all databases can accept this type, except DB2, who want the original type of the value to be present here, so that's why we have to pass `originalValueType` as parameter here, unfortunately.

2. If it is not null, then we **immediately apply the conversions defined by user or by us**. This is important, since if user have defined the conversion from OffsetDateTime --> Timestamp, then he/she would expect that for field:
    ```
    Timestamp createdAt
    ```  
    for instance the conversion will be applied, which was not the case since we have converted the value ourselves first. That is 
    I think very-very important for related issues #1089 and #1127.
    
3. If resulting form covnertion value is `null` (and it was not `null`, we checked it previously), then we understand, that either from our own, or from user convertion the value was explicitly returned as `null`, so this is the result we or user wants, so we return `null` wrapped with `JdbcValue` with `SQLType` as of original type of a value (because of DB2 again).

4. If converted value is of type `JDBCType` (or original value can be of that type as well) - we just assume, and from previous code this **was** the case, that such value is a final result. So if user, or we, inside the framework, as a result of conversion return `JdbcValue`, then no further logic applied - just return the resulting `JdbcValue`.

5. If the converted, or original value is of type `AggregateReference` - then we recursively trying to create `JdbcValue` for `AggregateReference#id`, that logic I have just borrowed from `writeValue` method, because this seems to be correct.

6. Then, we need to understand, have we applied conversion or not. This part I think I should explain in details. 

If we have applied the conversion and we got any generic type, then it will not be possible to deduce this generic type in runtime, just due to type erasure in java, since variable is local. However, if the conversion was not applied and initially there were generic type, then we will be provided from outside with the initial generic type. This will give us more precise `JDBCType` in runtime. Otherwise we will just have `JDBCType.UNKNOWN`. For example, both now, and prior to my changes, if user will create a converter, that converts some value to `Set<String>` for instance (I would say it is very rare case, since we do not even have a test case in the project for this scenario), then framework will try to create ARRAY SQL with `typeName` as `UNKNOWN`, using this jdbc API:

```
Array createArrayOf(String typeName, Object[] elements)
```

Is that a problem? Yes, it is. Some Jdbc drivers accept this as array type, but some do not. So, here, we are limited to java restrictions, at least for now... So I decided to pass original generic type into method (if applicable for given value of course) because of this. Goal is to at least overcome this case when converted was not applied, which is the most often scenario.

The rest part is almost the same that was - if we have a collection as value, we convert it into array into the of most precise type we can. Then if the value is array we create SQL ARRAY value from it, which we used to as well. If value is simple - then I use `JdbcUtil` class, as the previous code did as well.

Please, let me know, what you think about it... I am sure there is a lot to discuss, but we need to refactor this, at least for our understanding... 