### PR TITLE
Issue/refactor path extension

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-relational-parent</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-refactor-path-extension-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Relational Parent</name>

--- a/spring-data-jdbc-distribution/pom.xml
+++ b/spring-data-jdbc-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-refactor-path-extension-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-jdbc</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-refactor-path-extension-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-refactor-path-extension-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/JdbcAggregateChangeExecutionContext.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/JdbcAggregateChangeExecutionContext.java
@@ -203,7 +203,7 @@ class JdbcAggregateChangeExecutionContext {
 			return action;
 		}
 
-		if (idPath.matches(withDependingOn.getPropertyPath())) {
+		if (idPath.equals(context.getAggregatePath(withDependingOn.getPropertyPath()))) {
 			return action;
 		}
 

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/JdbcAggregateChangeExecutionContext.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/JdbcAggregateChangeExecutionContext.java
@@ -33,6 +33,7 @@ import org.springframework.data.relational.core.conversion.DbAction;
 import org.springframework.data.relational.core.conversion.DbActionExecutionResult;
 import org.springframework.data.relational.core.conversion.IdValueSource;
 import org.springframework.data.relational.core.mapping.AggregatePath;
+import org.springframework.data.relational.core.mapping.AggregatePathUtil;
 import org.springframework.data.relational.core.mapping.PersistentPropertyPathExtension;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
@@ -188,7 +189,7 @@ class JdbcAggregateChangeExecutionContext {
 
 	private Object getParentId(DbAction.WithDependingOn<?> action) {
 
-		DbAction.WithEntity<?> idOwningAction = getIdOwningAction(action, context.getAggregatePath(action.getPropertyPath()).getIdDefiningParentPath());
+		DbAction.WithEntity<?> idOwningAction = getIdOwningAction(action, AggregatePathUtil.getIdDefiningParentPath(context.getAggregatePath(action.getPropertyPath())));
 
 		return getPotentialGeneratedIdFrom(idOwningAction);
 	}

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/BasicJdbcConverter.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/BasicJdbcConverter.java
@@ -396,7 +396,7 @@ public class BasicJdbcConverter extends BasicRelationalConverter implements Jdbc
 		private <S> ReadingContext<S> extendBy(RelationalPersistentProperty property) {
 			return new ReadingContext<>(
 					(RelationalPersistentEntity<S>) getMappingContext().getRequiredPersistentEntity(property.getActualType()),
-					rootPath.extendBy(property), path.extendBy(property), identifier, key,
+					rootPath.append(property), path.append(property), identifier, key,
 					propertyValueProvider.extendBy(property), backReferencePropertyValueProvider.extendBy(property), accessor);
 		}
 
@@ -457,9 +457,9 @@ public class BasicJdbcConverter extends BasicRelationalConverter implements Jdbc
 
 			Identifier identifier = id == null //
 					? this.identifier.withPart(rootPath.getQualifierColumn(), key, Object.class) //
-					: Identifier.of(rootPath.extendBy(property).getReverseColumnName(), id, Object.class);
+					: Identifier.of(rootPath.append(property).getReverseColumnName(), id, Object.class);
 
-			PersistentPropertyPath<? extends RelationalPersistentProperty> propertyPath = path.extendBy(property)
+			PersistentPropertyPath<? extends RelationalPersistentProperty> propertyPath = path.append(property)
 					.getRequiredPersistentPropertyPath();
 
 			return relationResolver.findAllByPath(identifier, propertyPath);

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/BasicJdbcConverter.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/BasicJdbcConverter.java
@@ -48,6 +48,7 @@ import org.springframework.data.mapping.model.SpELExpressionParameterValueProvid
 import org.springframework.data.relational.core.conversion.BasicRelationalConverter;
 import org.springframework.data.relational.core.conversion.RelationalConverter;
 import org.springframework.data.relational.core.mapping.AggregatePath;
+import org.springframework.data.relational.core.mapping.AggregatePathUtil;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
@@ -456,8 +457,8 @@ public class BasicJdbcConverter extends BasicRelationalConverter implements Jdbc
 		private Iterable<Object> resolveRelation(@Nullable Object id, RelationalPersistentProperty property) {
 
 			Identifier identifier = id == null //
-					? this.identifier.withPart(rootPath.getQualifierColumn(), key, Object.class) //
-					: Identifier.of(rootPath.append(property).getReverseColumnName(), id, Object.class);
+					? this.identifier.withPart(AggregatePathUtil.getQualifierColumn(rootPath), key, Object.class) //
+					: Identifier.of(AggregatePathUtil.getReverseColumnName(rootPath.append(property)), id, Object.class);
 
 			PersistentPropertyPath<? extends RelationalPersistentProperty> propertyPath = path.append(property)
 					.getRequiredPersistentPropertyPath();

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/BasicJdbcConverter.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/BasicJdbcConverter.java
@@ -25,7 +25,6 @@ import java.util.Optional;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.core.convert.ConverterNotFoundException;
@@ -48,10 +47,11 @@ import org.springframework.data.mapping.model.SpELExpressionParameterValueProvid
 import org.springframework.data.relational.core.conversion.BasicRelationalConverter;
 import org.springframework.data.relational.core.conversion.RelationalConverter;
 import org.springframework.data.relational.core.mapping.AggregatePath;
-import org.springframework.data.relational.core.mapping.AggregatePathUtil;
+import org.springframework.data.relational.core.mapping.ForeignTableDetector;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
+import org.springframework.data.relational.core.mapping.SingleColumnAggregatePath;
 import org.springframework.data.relational.core.sql.IdentifierProcessing;
 import org.springframework.data.util.TypeInformation;
 import org.springframework.lang.Nullable;
@@ -457,8 +457,8 @@ public class BasicJdbcConverter extends BasicRelationalConverter implements Jdbc
 		private Iterable<Object> resolveRelation(@Nullable Object id, RelationalPersistentProperty property) {
 
 			Identifier identifier = id == null //
-					? this.identifier.withPart(AggregatePathUtil.getQualifierColumn(rootPath), key, Object.class) //
-					: Identifier.of(AggregatePathUtil.getReverseColumnName(rootPath.append(property)), id, Object.class);
+					? this.identifier.withPart(ForeignTableDetector.of(rootPath).getQualifierColumn(), key, Object.class) //
+					: Identifier.of(SingleColumnAggregatePath.of(rootPath.append(property)).getReverseColumnName(), id, Object.class);
 
 			PersistentPropertyPath<? extends RelationalPersistentProperty> propertyPath = path.append(property)
 					.getRequiredPersistentPropertyPath();

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DefaultDataAccessStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DefaultDataAccessStrategy.java
@@ -29,7 +29,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.mapping.PersistentPropertyPath;
 import org.springframework.data.relational.core.conversion.IdValueSource;
 import org.springframework.data.relational.core.mapping.AggregatePath;
-import org.springframework.data.relational.core.mapping.AggregatePathUtil;
+import org.springframework.data.relational.core.mapping.ForeignTableDetector;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
@@ -399,8 +399,7 @@ public class DefaultDataAccessStrategy implements DataAccessStrategy {
 
 	private RowMapper<?> getMapEntityRowMapper(AggregatePath path, Identifier identifier) {
 
-		SqlIdentifier keyColumn = AggregatePathUtil.getQualifierColumn(path);
-		Assert.notNull(keyColumn, () -> "KeyColumn must not be null for " + path);
+		SqlIdentifier keyColumn = ForeignTableDetector.of(path).getQualifierColumn();
 
 		return new MapEntityRowMapper<>(path, converter, identifier, keyColumn);
 	}

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DefaultDataAccessStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DefaultDataAccessStrategy.java
@@ -29,7 +29,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.mapping.PersistentPropertyPath;
 import org.springframework.data.relational.core.conversion.IdValueSource;
 import org.springframework.data.relational.core.mapping.AggregatePath;
-import org.springframework.data.relational.core.mapping.PersistentPropertyPathExtension;
+import org.springframework.data.relational.core.mapping.AggregatePathUtil;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
@@ -399,7 +399,7 @@ public class DefaultDataAccessStrategy implements DataAccessStrategy {
 
 	private RowMapper<?> getMapEntityRowMapper(AggregatePath path, Identifier identifier) {
 
-		SqlIdentifier keyColumn = path.getQualifierColumn();
+		SqlIdentifier keyColumn = AggregatePathUtil.getQualifierColumn(path);
 		Assert.notNull(keyColumn, () -> "KeyColumn must not be null for " + path);
 
 		return new MapEntityRowMapper<>(path, converter, identifier, keyColumn);

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/EntityRowMapper.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/EntityRowMapper.java
@@ -17,6 +17,7 @@ package org.springframework.data.jdbc.core.convert;
 
 import java.sql.ResultSet;
 
+import org.springframework.data.relational.core.mapping.AggregatePath;
 import org.springframework.data.relational.core.mapping.PersistentPropertyPathExtension;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
 import org.springframework.jdbc.core.RowMapper;
@@ -35,12 +36,27 @@ import org.springframework.jdbc.core.RowMapper;
 public class EntityRowMapper<T> implements RowMapper<T> {
 
 	private final RelationalPersistentEntity<T> entity;
-	private final PersistentPropertyPathExtension path;
+	private final AggregatePath path;
 	private final JdbcConverter converter;
 	private final Identifier identifier;
 
+	/**
+	 *
+	 *
+	 * @deprecated use {@link EntityRowMapper#EntityRowMapper(AggregatePath, JdbcConverter, Identifier)} instead
+	 */
+	@Deprecated(since = "3.2", forRemoval = true)
 	@SuppressWarnings("unchecked")
 	public EntityRowMapper(PersistentPropertyPathExtension path, JdbcConverter converter, Identifier identifier) {
+
+		this.entity = (RelationalPersistentEntity<T>) path.getLeafEntity();
+		this.path = path.getAggregatePath();
+		this.converter = converter;
+		this.identifier = identifier;
+	}
+
+	@SuppressWarnings("unchecked")
+	public EntityRowMapper(AggregatePath path, JdbcConverter converter, Identifier identifier) {
 
 		this.entity = (RelationalPersistentEntity<T>) path.getLeafEntity();
 		this.path = path;

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcBackReferencePropertyValueProvider.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcBackReferencePropertyValueProvider.java
@@ -17,9 +17,7 @@ package org.springframework.data.jdbc.core.convert;
 
 import org.springframework.data.mapping.model.PropertyValueProvider;
 import org.springframework.data.relational.core.mapping.AggregatePath;
-import org.springframework.data.relational.core.mapping.PersistentPropertyPathExtension;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
-import org.springframework.data.relational.core.sql.IdentifierProcessing;
 
 /**
  * {@link PropertyValueProvider} obtaining values from a {@link ResultSetAccessor}. For a given id property it provides
@@ -47,10 +45,10 @@ class JdbcBackReferencePropertyValueProvider implements PropertyValueProvider<Re
 
 	@Override
 	public <T> T getPropertyValue(RelationalPersistentProperty property) {
-		return (T) resultSet.getObject(basePath.extendBy(property).getReverseColumnNameAlias().getReference());
+		return (T) resultSet.getObject(basePath.append(property).getReverseColumnNameAlias().getReference());
 	}
 
 	public JdbcBackReferencePropertyValueProvider extendBy(RelationalPersistentProperty property) {
-		return new JdbcBackReferencePropertyValueProvider(basePath.extendBy(property), resultSet);
+		return new JdbcBackReferencePropertyValueProvider(basePath.append(property), resultSet);
 	}
 }

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcBackReferencePropertyValueProvider.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcBackReferencePropertyValueProvider.java
@@ -16,6 +16,7 @@
 package org.springframework.data.jdbc.core.convert;
 
 import org.springframework.data.mapping.model.PropertyValueProvider;
+import org.springframework.data.relational.core.mapping.AggregatePath;
 import org.springframework.data.relational.core.mapping.PersistentPropertyPathExtension;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
 import org.springframework.data.relational.core.sql.IdentifierProcessing;
@@ -31,14 +32,14 @@ import org.springframework.data.relational.core.sql.IdentifierProcessing;
  */
 class JdbcBackReferencePropertyValueProvider implements PropertyValueProvider<RelationalPersistentProperty> {
 
-	private final PersistentPropertyPathExtension basePath;
+	private final AggregatePath basePath;
 	private final ResultSetAccessor resultSet;
 
 	/**
 	 * @param basePath path from the aggregate root relative to which all properties get resolved.
 	 * @param resultSet the {@link ResultSetAccessor} from which to obtain the actual values.
 	 */
-	JdbcBackReferencePropertyValueProvider(PersistentPropertyPathExtension basePath, ResultSetAccessor resultSet) {
+	JdbcBackReferencePropertyValueProvider(AggregatePath basePath, ResultSetAccessor resultSet) {
 
 		this.resultSet = resultSet;
 		this.basePath = basePath;

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcBackReferencePropertyValueProvider.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcBackReferencePropertyValueProvider.java
@@ -17,6 +17,7 @@ package org.springframework.data.jdbc.core.convert;
 
 import org.springframework.data.mapping.model.PropertyValueProvider;
 import org.springframework.data.relational.core.mapping.AggregatePath;
+import org.springframework.data.relational.core.mapping.AggregatePathUtil;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
 
 /**
@@ -45,7 +46,7 @@ class JdbcBackReferencePropertyValueProvider implements PropertyValueProvider<Re
 
 	@Override
 	public <T> T getPropertyValue(RelationalPersistentProperty property) {
-		return (T) resultSet.getObject(basePath.append(property).getReverseColumnNameAlias().getReference());
+		return (T) resultSet.getObject(AggregatePathUtil.getReverseColumnNameAlias(basePath.append(property)).getReference());
 	}
 
 	public JdbcBackReferencePropertyValueProvider extendBy(RelationalPersistentProperty property) {

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcConverter.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcConverter.java
@@ -19,8 +19,11 @@ import java.sql.ResultSet;
 import java.sql.SQLType;
 
 import org.springframework.data.jdbc.core.mapping.JdbcValue;
+import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.relational.core.conversion.RelationalConverter;
+import org.springframework.data.relational.core.mapping.AggregatePath;
 import org.springframework.data.relational.core.mapping.PersistentPropertyPathExtension;
+import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
 import org.springframework.data.util.TypeInformation;
@@ -67,8 +70,24 @@ public interface JdbcConverter extends RelationalConverter {
 	 * @param key primary key.
 	 * @param <T>
 	 * @return
+	 * @deprecated use {@link #mapRow(AggregatePath, ResultSet, Identifier, Object)} instead.
 	 */
-	<T> T mapRow(PersistentPropertyPathExtension path, ResultSet resultSet, Identifier identifier, Object key);
+	@Deprecated(since = "3.2", forRemoval = true)
+	default <T> T mapRow(PersistentPropertyPathExtension path, ResultSet resultSet, Identifier identifier, Object key){
+		return mapRow(path.getAggregatePath(), resultSet, identifier, key);
+	};
+
+	/**
+	 * Read the current row from {@link ResultSet} to an {@link AggregatePath#getLeafEntity()} entity}.
+	 *
+	 * @param path path to the owning property.
+	 * @param resultSet the {@link ResultSet} to read from.
+	 * @param identifier entity identifier.
+	 * @param key primary key.
+	 * @param <T>
+	 * @return
+	 */
+	<T> T mapRow(AggregatePath path, ResultSet resultSet, Identifier identifier, Object key);
 
 	/**
 	 * The type to be used to store this property in the database. Multidimensional arrays are unwrapped to reflect a
@@ -88,4 +107,7 @@ public interface JdbcConverter extends RelationalConverter {
 	 * @since 2.0
 	 */
 	SQLType getTargetSqlType(RelationalPersistentProperty property);
+
+	@Override
+	RelationalMappingContext getMappingContext();
 }

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcIdentifierBuilder.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcIdentifierBuilder.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.jdbc.core.convert;
 
+import org.springframework.data.relational.core.mapping.AggregatePath;
 import org.springframework.data.relational.core.mapping.PersistentPropertyPathExtension;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -39,8 +40,19 @@ public class JdbcIdentifierBuilder {
 
 	/**
 	 * Creates ParentKeys with backreference for the given path and value of the parents id.
+	 *
+	 * @deprecated Use {@link #forBackReferences(JdbcConverter, AggregatePath, Object)} instead.
 	 */
+	@Deprecated(since = "3.2", forRemoval = true)
 	public static JdbcIdentifierBuilder forBackReferences(JdbcConverter converter, PersistentPropertyPathExtension path,
+			@Nullable Object value) {
+		return forBackReferences(converter, path.getAggregatePath(), value);
+	}
+
+	/**
+	 * Creates ParentKeys with backreference for the given path and value of the parents id.
+	 */
+	public static JdbcIdentifierBuilder forBackReferences(JdbcConverter converter, AggregatePath path,
 			@Nullable Object value) {
 
 		Identifier identifier = Identifier.of( //
@@ -59,7 +71,21 @@ public class JdbcIdentifierBuilder {
 	 * @param value map key or list index qualifying the map identified by {@code path}. Must not be {@literal null}.
 	 * @return this builder. Guaranteed to be not {@literal null}.
 	 */
+	@Deprecated
 	public JdbcIdentifierBuilder withQualifier(PersistentPropertyPathExtension path, Object value) {
+
+		return withQualifier(path.getAggregatePath(), value);
+	}
+
+
+	/**
+	 * Adds a qualifier to the identifier to build. A qualifier is a map key or a list index.
+	 *
+	 * @param path path to the map that gets qualified by {@code value}. Must not be {@literal null}.
+	 * @param value map key or list index qualifying the map identified by {@code path}. Must not be {@literal null}.
+	 * @return this builder. Guaranteed to be not {@literal null}.
+	 */
+	public JdbcIdentifierBuilder withQualifier(AggregatePath path, Object value) {
 
 		Assert.notNull(path, "Path must not be null");
 		Assert.notNull(value, "Value must not be null");

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcIdentifierBuilder.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcIdentifierBuilder.java
@@ -16,6 +16,7 @@
 package org.springframework.data.jdbc.core.convert;
 
 import org.springframework.data.relational.core.mapping.AggregatePath;
+import org.springframework.data.relational.core.mapping.AggregatePathUtil;
 import org.springframework.data.relational.core.mapping.PersistentPropertyPathExtension;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -56,9 +57,9 @@ public class JdbcIdentifierBuilder {
 			@Nullable Object value) {
 
 		Identifier identifier = Identifier.of( //
-				path.getReverseColumnName(), //
+				AggregatePathUtil.getReverseColumnName(path), //
 				value, //
-				converter.getColumnType(path.getIdDefiningParentPath().getRequiredIdProperty()) //
+				converter.getColumnType(AggregatePathUtil.getIdDefiningParentPath(path).getRequiredIdProperty()) //
 		);
 
 		return new JdbcIdentifierBuilder(identifier);
@@ -77,7 +78,6 @@ public class JdbcIdentifierBuilder {
 		return withQualifier(path.getAggregatePath(), value);
 	}
 
-
 	/**
 	 * Adds a qualifier to the identifier to build. A qualifier is a map key or a list index.
 	 *
@@ -90,7 +90,8 @@ public class JdbcIdentifierBuilder {
 		Assert.notNull(path, "Path must not be null");
 		Assert.notNull(value, "Value must not be null");
 
-		identifier = identifier.withPart(path.getQualifierColumn(), value, path.getQualifierColumnType());
+		identifier = identifier.withPart(AggregatePathUtil.getQualifierColumn(path), value,
+				AggregatePathUtil.getQualifierColumnType(path));
 
 		return this;
 	}

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcIdentifierBuilder.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcIdentifierBuilder.java
@@ -17,6 +17,7 @@ package org.springframework.data.jdbc.core.convert;
 
 import org.springframework.data.relational.core.mapping.AggregatePath;
 import org.springframework.data.relational.core.mapping.AggregatePathUtil;
+import org.springframework.data.relational.core.mapping.ForeignTableDetector;
 import org.springframework.data.relational.core.mapping.PersistentPropertyPathExtension;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -89,9 +90,12 @@ public class JdbcIdentifierBuilder {
 
 		Assert.notNull(path, "Path must not be null");
 		Assert.notNull(value, "Value must not be null");
+		Assert.isTrue(path.isQualified(),
+				() -> String.format("AggregatePath %s must be be a Map or Collection-like property", path));
 
-		identifier = identifier.withPart(AggregatePathUtil.getQualifierColumn(path), value,
-				AggregatePathUtil.getQualifierColumnType(path));
+		// TODO: What if the path is a root?
+		ForeignTableDetector ft = ForeignTableDetector.of(path);
+		identifier = identifier.withPart(ft.getQualifierColumn(), value, ft.getQualifierColumnType());
 
 		return this;
 	}

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcPropertyValueProvider.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcPropertyValueProvider.java
@@ -57,10 +57,10 @@ class JdbcPropertyValueProvider implements PropertyValueProvider<RelationalPersi
 	}
 
 	private String getColumnName(RelationalPersistentProperty property) {
-		return basePath.extendBy(property).getColumnAlias().getReference();
+		return basePath.append(property).getColumnAlias().getReference();
 	}
 
 	public JdbcPropertyValueProvider extendBy(RelationalPersistentProperty property) {
-		return new JdbcPropertyValueProvider(basePath.extendBy(property), resultSet);
+		return new JdbcPropertyValueProvider(basePath.append(property), resultSet);
 	}
 }

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcPropertyValueProvider.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcPropertyValueProvider.java
@@ -16,9 +16,8 @@
 package org.springframework.data.jdbc.core.convert;
 
 import org.springframework.data.mapping.model.PropertyValueProvider;
-import org.springframework.data.relational.core.mapping.PersistentPropertyPathExtension;
+import org.springframework.data.relational.core.mapping.AggregatePath;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
-import org.springframework.data.relational.core.sql.IdentifierProcessing;
 
 /**
  * {@link PropertyValueProvider} obtaining values from a {@link ResultSetAccessor}.
@@ -29,15 +28,14 @@ import org.springframework.data.relational.core.sql.IdentifierProcessing;
  */
 class JdbcPropertyValueProvider implements PropertyValueProvider<RelationalPersistentProperty> {
 
-	private final PersistentPropertyPathExtension basePath;
+	private final AggregatePath basePath;
 	private final ResultSetAccessor resultSet;
 
 	/**
 	 * @param basePath path from the aggregate root relative to which all properties get resolved.
 	 * @param resultSet the {@link ResultSetAccessor} from which to obtain the actual values.
 	 */
-	JdbcPropertyValueProvider(PersistentPropertyPathExtension basePath,
-			ResultSetAccessor resultSet) {
+	JdbcPropertyValueProvider(AggregatePath basePath, ResultSetAccessor resultSet) {
 
 		this.resultSet = resultSet;
 		this.basePath = basePath;

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcPropertyValueProvider.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcPropertyValueProvider.java
@@ -17,7 +17,7 @@ package org.springframework.data.jdbc.core.convert;
 
 import org.springframework.data.mapping.model.PropertyValueProvider;
 import org.springframework.data.relational.core.mapping.AggregatePath;
-import org.springframework.data.relational.core.mapping.AggregatePathUtil;
+import org.springframework.data.relational.core.mapping.ColumnDetector;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
 
 /**
@@ -58,7 +58,7 @@ class JdbcPropertyValueProvider implements PropertyValueProvider<RelationalPersi
 	}
 
 	private String getColumnName(RelationalPersistentProperty property) {
-		return AggregatePathUtil.getColumnAlias(basePath.append(property)).getReference();
+		return ColumnDetector.of(basePath.append(property)).getColumnAlias().getReference();
 	}
 
 	public JdbcPropertyValueProvider extendBy(RelationalPersistentProperty property) {

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcPropertyValueProvider.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcPropertyValueProvider.java
@@ -17,6 +17,7 @@ package org.springframework.data.jdbc.core.convert;
 
 import org.springframework.data.mapping.model.PropertyValueProvider;
 import org.springframework.data.relational.core.mapping.AggregatePath;
+import org.springframework.data.relational.core.mapping.AggregatePathUtil;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
 
 /**
@@ -57,7 +58,7 @@ class JdbcPropertyValueProvider implements PropertyValueProvider<RelationalPersi
 	}
 
 	private String getColumnName(RelationalPersistentProperty property) {
-		return basePath.append(property).getColumnAlias().getReference();
+		return AggregatePathUtil.getColumnAlias(basePath.append(property)).getReference();
 	}
 
 	public JdbcPropertyValueProvider extendBy(RelationalPersistentProperty property) {

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/MapEntityRowMapper.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/MapEntityRowMapper.java
@@ -20,6 +20,7 @@ import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.springframework.data.relational.core.mapping.AggregatePath;
 import org.springframework.data.relational.core.mapping.PersistentPropertyPathExtension;
 import org.springframework.data.relational.core.sql.IdentifierProcessing;
 import org.springframework.data.relational.core.sql.SqlIdentifier;
@@ -35,12 +36,13 @@ import org.springframework.jdbc.core.RowMapper;
  */
 class MapEntityRowMapper<T> implements RowMapper<Map.Entry<Object, T>> {
 
-	private final PersistentPropertyPathExtension path;
+	private final AggregatePath path;
 	private final JdbcConverter converter;
 	private final Identifier identifier;
 	private final SqlIdentifier keyColumn;
 
-	MapEntityRowMapper(PersistentPropertyPathExtension path, JdbcConverter converter, Identifier identifier, SqlIdentifier keyColumn) {
+	MapEntityRowMapper(AggregatePath path, JdbcConverter converter, Identifier identifier, SqlIdentifier keyColumn) {
+
 		this.path = path;
 		this.converter = converter;
 		this.identifier = identifier;

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlContext.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlContext.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.jdbc.core.convert;
 
+import org.springframework.data.relational.core.mapping.AggregatePath;
 import org.springframework.data.relational.core.mapping.PersistentPropertyPathExtension;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
 import org.springframework.data.relational.core.sql.Column;
@@ -52,18 +53,18 @@ class SqlContext {
 		return table;
 	}
 
-	Table getTable(PersistentPropertyPathExtension path) {
+	Table getTable(AggregatePath path) {
 
 		SqlIdentifier tableAlias = path.getTableAlias();
 		Table table = Table.create(path.getQualifiedTableName());
 		return tableAlias == null ? table : table.as(tableAlias);
 	}
 
-	Column getColumn(PersistentPropertyPathExtension path) {
+	Column getColumn(AggregatePath path) {
 		return getTable(path).column(path.getColumnName()).as(path.getColumnAlias());
 	}
 
-	Column getReverseColumn(PersistentPropertyPathExtension path) {
+	Column getReverseColumn(AggregatePath path) {
 		return getTable(path).column(path.getReverseColumnName()).as(path.getReverseColumnNameAlias());
 	}
 }

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlContext.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlContext.java
@@ -16,7 +16,7 @@
 package org.springframework.data.jdbc.core.convert;
 
 import org.springframework.data.relational.core.mapping.AggregatePath;
-import org.springframework.data.relational.core.mapping.PersistentPropertyPathExtension;
+import org.springframework.data.relational.core.mapping.AggregatePathUtil;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
 import org.springframework.data.relational.core.sql.Column;
 import org.springframework.data.relational.core.sql.SqlIdentifier;
@@ -55,16 +55,17 @@ class SqlContext {
 
 	Table getTable(AggregatePath path) {
 
-		SqlIdentifier tableAlias = path.getTableAlias();
-		Table table = Table.create(path.getQualifiedTableName());
+		SqlIdentifier tableAlias = AggregatePathUtil.getTableAlias(path);
+		Table table = Table.create(AggregatePathUtil.getQualifiedTableName(path));
 		return tableAlias == null ? table : table.as(tableAlias);
 	}
 
 	Column getColumn(AggregatePath path) {
-		return getTable(path).column(path.getColumnName()).as(path.getColumnAlias());
+		return getTable(path).column(AggregatePathUtil.getColumnName(path)).as(AggregatePathUtil.getColumnAlias(path));
 	}
 
 	Column getReverseColumn(AggregatePath path) {
-		return getTable(path).column(path.getReverseColumnName()).as(path.getReverseColumnNameAlias());
+		return getTable(path).column(AggregatePathUtil.getReverseColumnName(path))
+				.as(AggregatePathUtil.getReverseColumnNameAlias(path));
 	}
 }

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlContext.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlContext.java
@@ -17,7 +17,9 @@ package org.springframework.data.jdbc.core.convert;
 
 import org.springframework.data.relational.core.mapping.AggregatePath;
 import org.springframework.data.relational.core.mapping.AggregatePathUtil;
+import org.springframework.data.relational.core.mapping.ColumnDetector;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
+import org.springframework.data.relational.core.mapping.TableAccessor;
 import org.springframework.data.relational.core.sql.Column;
 import org.springframework.data.relational.core.sql.SqlIdentifier;
 import org.springframework.data.relational.core.sql.Table;
@@ -54,14 +56,19 @@ class SqlContext {
 	}
 
 	Table getTable(AggregatePath path) {
+		return getTable(TableAccessor.of(path));
+	}
 
-		SqlIdentifier tableAlias = AggregatePathUtil.getTableAlias(path);
-		Table table = Table.create(AggregatePathUtil.getQualifiedTableName(path));
+	Table getTable(TableAccessor tableAccessor) {
+
+		SqlIdentifier tableAlias = tableAccessor.findTableAlias();
+		Table table = Table.create(tableAccessor.getQualifiedTableName());
 		return tableAlias == null ? table : table.as(tableAlias);
 	}
 
 	Column getColumn(AggregatePath path) {
-		return getTable(path).column(AggregatePathUtil.getColumnName(path)).as(AggregatePathUtil.getColumnAlias(path));
+		ColumnDetector detector = ColumnDetector.of(path);
+		return getTable(path).column(detector.getColumnName()).as(detector.getColumnAlias());
 	}
 
 	Column getReverseColumn(AggregatePath path) {

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/JdbcQueryCreator.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/JdbcQueryCreator.java
@@ -29,6 +29,8 @@ import org.springframework.data.relational.core.dialect.Dialect;
 import org.springframework.data.relational.core.dialect.RenderContextFactory;
 import org.springframework.data.relational.core.mapping.AggregatePath;
 import org.springframework.data.relational.core.mapping.AggregatePathUtil;
+import org.springframework.data.relational.core.mapping.ColumnDetector;
+import org.springframework.data.relational.core.mapping.ForeignTableDetector;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
@@ -318,12 +320,13 @@ class JdbcQueryCreator extends RelationalQueryCreator<ParametrizedQuery> {
 		Table currentTable = sqlContext.getTable(path);
 
 		AggregatePath idDefiningParentPath = AggregatePathUtil.getIdDefiningParentPath(path);
+		ColumnDetector parentDetector = ColumnDetector.of(path);
 		Table parentTable = sqlContext.getTable(idDefiningParentPath);
 
 		return new Join( //
 				currentTable, //
-				currentTable.column(AggregatePathUtil.getReverseColumnName(path)), //
-				parentTable.column(AggregatePathUtil.getIdColumnName(idDefiningParentPath)) //
+				currentTable.column(ForeignTableDetector.of(path).getReverseColumnName()), //
+				parentTable.column(parentDetector.getIdColumnName()) //
 		);
 	}
 

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/JdbcQueryCreator.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/JdbcQueryCreator.java
@@ -28,6 +28,7 @@ import org.springframework.data.mapping.PersistentPropertyPath;
 import org.springframework.data.relational.core.dialect.Dialect;
 import org.springframework.data.relational.core.dialect.RenderContextFactory;
 import org.springframework.data.relational.core.mapping.AggregatePath;
+import org.springframework.data.relational.core.mapping.AggregatePathUtil;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
@@ -296,7 +297,7 @@ class JdbcQueryCreator extends RelationalQueryCreator<ParametrizedQuery> {
 
 			if (path.isQualified() //
 					|| path.isCollectionLike() //
-					|| path.hasIdProperty() //
+					|| AggregatePathUtil.hasIdProperty(path) //
 			) {
 				return null;
 			}
@@ -316,13 +317,13 @@ class JdbcQueryCreator extends RelationalQueryCreator<ParametrizedQuery> {
 
 		Table currentTable = sqlContext.getTable(path);
 
-		AggregatePath idDefiningParentPath = path.getIdDefiningParentPath();
+		AggregatePath idDefiningParentPath = AggregatePathUtil.getIdDefiningParentPath(path);
 		Table parentTable = sqlContext.getTable(idDefiningParentPath);
 
 		return new Join( //
 				currentTable, //
-				currentTable.column(path.getReverseColumnName()), //
-				parentTable.column(idDefiningParentPath.getIdColumnName()) //
+				currentTable.column(AggregatePathUtil.getReverseColumnName(path)), //
+				parentTable.column(AggregatePathUtil.getIdColumnName(idDefiningParentPath)) //
 		);
 	}
 

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/SqlContext.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/SqlContext.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.jdbc.repository.query;
 
+import org.springframework.data.relational.core.mapping.AggregatePath;
 import org.springframework.data.relational.core.mapping.PersistentPropertyPathExtension;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
 import org.springframework.data.relational.core.sql.Column;
@@ -53,18 +54,18 @@ class SqlContext {
 		return table;
 	}
 
-	Table getTable(PersistentPropertyPathExtension path) {
+	Table getTable(AggregatePath path) {
 
 		SqlIdentifier tableAlias = path.getTableAlias();
 		Table table = Table.create(path.getQualifiedTableName());
 		return tableAlias == null ? table : table.as(tableAlias);
 	}
 
-	Column getColumn(PersistentPropertyPathExtension path) {
+	Column getColumn(AggregatePath path) {
 		return getTable(path).column(path.getColumnName()).as(path.getColumnAlias());
 	}
 
-	Column getReverseColumn(PersistentPropertyPathExtension path) {
+	Column getReverseColumn(AggregatePath path) {
 		return getTable(path).column(path.getReverseColumnName()).as(path.getReverseColumnNameAlias());
 	}
 }

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/SqlContext.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/SqlContext.java
@@ -17,10 +17,10 @@ package org.springframework.data.jdbc.repository.query;
 
 import org.springframework.data.relational.core.mapping.AggregatePath;
 import org.springframework.data.relational.core.mapping.AggregatePathUtil;
-import org.springframework.data.relational.core.mapping.PersistentPropertyPathExtension;
+import org.springframework.data.relational.core.mapping.ColumnDetector;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
+import org.springframework.data.relational.core.mapping.TableAccessor;
 import org.springframework.data.relational.core.sql.Column;
-import org.springframework.data.relational.core.sql.SqlIdentifier;
 import org.springframework.data.relational.core.sql.Table;
 
 /**
@@ -57,16 +57,25 @@ class SqlContext {
 
 	Table getTable(AggregatePath path) {
 
-		SqlIdentifier tableAlias = AggregatePathUtil.getTableAlias(path);
-		Table table = Table.create(AggregatePathUtil.getQualifiedTableName(path));
-		return tableAlias == null ? table : table.as(tableAlias);
+		TableAccessor accessor = TableAccessor.of(path);
+		Table table = Table.create(accessor.getQualifiedTableName());
+
+		if (accessor.hasTableAlias()) {
+			return table.as(accessor.findTableAlias());
+		}
+
+		return table;
 	}
 
 	Column getColumn(AggregatePath path) {
-		return getTable(path).column(AggregatePathUtil.getColumnName(path)).as(AggregatePathUtil.getColumnAlias(path));
+
+		ColumnDetector detector = ColumnDetector.of(path);
+
+		return getTable(path).column(detector.getColumnName()).as(detector.getColumnAlias());
 	}
 
 	Column getReverseColumn(AggregatePath path) {
-		return getTable(path).column(AggregatePathUtil.getReverseColumnName(path)).as(AggregatePathUtil.getReverseColumnNameAlias(path));
+		return getTable(path).column(AggregatePathUtil.getReverseColumnName(path))
+				.as(AggregatePathUtil.getReverseColumnNameAlias(path));
 	}
 }

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/SqlContext.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/SqlContext.java
@@ -16,6 +16,7 @@
 package org.springframework.data.jdbc.repository.query;
 
 import org.springframework.data.relational.core.mapping.AggregatePath;
+import org.springframework.data.relational.core.mapping.AggregatePathUtil;
 import org.springframework.data.relational.core.mapping.PersistentPropertyPathExtension;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
 import org.springframework.data.relational.core.sql.Column;
@@ -56,16 +57,16 @@ class SqlContext {
 
 	Table getTable(AggregatePath path) {
 
-		SqlIdentifier tableAlias = path.getTableAlias();
-		Table table = Table.create(path.getQualifiedTableName());
+		SqlIdentifier tableAlias = AggregatePathUtil.getTableAlias(path);
+		Table table = Table.create(AggregatePathUtil.getQualifiedTableName(path));
 		return tableAlias == null ? table : table.as(tableAlias);
 	}
 
 	Column getColumn(AggregatePath path) {
-		return getTable(path).column(path.getColumnName()).as(path.getColumnAlias());
+		return getTable(path).column(AggregatePathUtil.getColumnName(path)).as(AggregatePathUtil.getColumnAlias(path));
 	}
 
 	Column getReverseColumn(AggregatePath path) {
-		return getTable(path).column(path.getReverseColumnName()).as(path.getReverseColumnNameAlias());
+		return getTable(path).column(AggregatePathUtil.getReverseColumnName(path)).as(AggregatePathUtil.getReverseColumnNameAlias(path));
 	}
 }

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/JdbcAggregateChangeExecutorContextImmutableUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/JdbcAggregateChangeExecutorContextImmutableUnitTests.java
@@ -37,7 +37,7 @@ import org.springframework.data.mapping.PersistentPropertyPath;
 import org.springframework.data.mapping.PersistentPropertyPaths;
 import org.springframework.data.relational.core.conversion.DbAction;
 import org.springframework.data.relational.core.conversion.IdValueSource;
-import org.springframework.data.relational.core.mapping.PersistentPropertyPathExtension;
+import org.springframework.data.relational.core.mapping.AggregatePath;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
 import org.springframework.lang.Nullable;
@@ -160,8 +160,8 @@ public class JdbcAggregateChangeExecutorContextImmutableUnitTests {
 				key == null ? emptyMap() : singletonMap(toPath(propertyName), key), IdValueSource.GENERATED);
 	}
 
-	PersistentPropertyPathExtension toPathExt(String path) {
-		return new PersistentPropertyPathExtension(context, getPersistentPropertyPath(path));
+	AggregatePath toAggregatePath(String path) {
+		return context.getAggregatePath(getPersistentPropertyPath(path));
 	}
 
 	PersistentPropertyPath<RelationalPersistentProperty> getPersistentPropertyPath(String propertyName) {
@@ -169,7 +169,7 @@ public class JdbcAggregateChangeExecutorContextImmutableUnitTests {
 	}
 
 	Identifier createBackRef(long value) {
-		return JdbcIdentifierBuilder.forBackReferences(converter, toPathExt("content"), value).build();
+		return JdbcIdentifierBuilder.forBackReferences(converter, toAggregatePath("content"), value).build();
 	}
 
 	PersistentPropertyPath<RelationalPersistentProperty> toPath(String path) {

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/JdbcAggregateChangeExecutorContextUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/JdbcAggregateChangeExecutorContextUnitTests.java
@@ -36,7 +36,7 @@ import org.springframework.data.mapping.PersistentPropertyPath;
 import org.springframework.data.mapping.PersistentPropertyPaths;
 import org.springframework.data.relational.core.conversion.DbAction;
 import org.springframework.data.relational.core.conversion.IdValueSource;
-import org.springframework.data.relational.core.mapping.PersistentPropertyPathExtension;
+import org.springframework.data.relational.core.mapping.AggregatePath;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
 import org.springframework.data.relational.core.sql.SqlIdentifier;
@@ -250,8 +250,8 @@ public class JdbcAggregateChangeExecutorContextUnitTests {
 				key == null ? emptyMap() : singletonMap(toPath(propertyName), key), idValueSource);
 	}
 
-	PersistentPropertyPathExtension toPathExt(String path) {
-		return new PersistentPropertyPathExtension(context, getPersistentPropertyPath(path));
+	AggregatePath toAggregatePath(String path) {
+		return context.getAggregatePath(getPersistentPropertyPath(path));
 	}
 
 	PersistentPropertyPath<RelationalPersistentProperty> getPersistentPropertyPath(String propertyName) {
@@ -259,7 +259,7 @@ public class JdbcAggregateChangeExecutorContextUnitTests {
 	}
 
 	Identifier createBackRef(long value) {
-		return forBackReferences(converter, toPathExt("content"), value).build();
+		return forBackReferences(converter, toAggregatePath("content"), value).build();
 	}
 
 	PersistentPropertyPath<RelationalPersistentProperty> toPath(String path) {

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/PersistentPropertyPathExtensionUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/PersistentPropertyPathExtensionUnitTests.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.jdbc.core;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.SoftAssertions.*;
 import static org.springframework.data.relational.core.sql.SqlIdentifier.*;
 
@@ -238,6 +239,14 @@ public class PersistentPropertyPathExtensionUnitTests {
 		});
 	}
 
+	@Test // GH-1525
+	void getAggregatePath() {
+		assertThat(extPath("withId").getAggregatePath()).isNotNull();
+	}
+	@Test // GH-1525
+	void getAggregatePathFromRoot() {
+		assertThat(extPath(entity).getAggregatePath()).isNotNull();
+	}
 	private PersistentPropertyPathExtension extPath(RelationalPersistentEntity<?> entity) {
 		return new PersistentPropertyPathExtension(context, entity);
 	}
@@ -247,7 +256,7 @@ public class PersistentPropertyPathExtensionUnitTests {
 	}
 
 	PersistentPropertyPath<RelationalPersistentProperty> createSimplePath(String path) {
-		return PropertyPathTestingUtils.toPath(path, DummyEntity.class, context);
+		return PersistentPropertyPathTestUtils.getPath(path, DummyEntity.class, context);
 	}
 
 	@SuppressWarnings("unused")

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/PersistentPropertyPathTestUtils.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/PersistentPropertyPathTestUtils.java
@@ -29,14 +29,18 @@ import org.springframework.data.relational.core.mapping.RelationalPersistentProp
  * @author Jens Schauder
  */
 @UtilityClass
-public class PropertyPathTestingUtils {
+public class PersistentPropertyPathTestUtils {
 
-	public static PersistentPropertyPath<RelationalPersistentProperty> toPath(String path, Class source,
-																			  RelationalMappingContext context) {
+	public static PersistentPropertyPath<RelationalPersistentProperty> getPath(String path, Class source,
+																			   RelationalMappingContext context) {
 
 		PersistentPropertyPaths<?, RelationalPersistentProperty> persistentPropertyPaths = context
 				.findPersistentPropertyPaths(source, p -> true);
 
-		return persistentPropertyPaths.filter(p -> p.toDotPath().equals(path)).stream().findFirst().orElse(null);
+		return persistentPropertyPaths
+				.filter(p -> p.toDotPath().equals(path))
+				.stream()
+				.findFirst()
+				.orElse(null);
 	}
 }

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/JdbcIdentifierBuilderUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/JdbcIdentifierBuilderUnitTests.java
@@ -16,7 +16,6 @@
 package org.springframework.data.jdbc.core.convert;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.springframework.data.jdbc.core.PropertyPathTestingUtils.*;
 import static org.springframework.data.relational.core.sql.SqlIdentifier.*;
 
 import java.util.List;
@@ -25,8 +24,9 @@ import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.jdbc.core.PersistentPropertyPathTestUtils;
 import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
-import org.springframework.data.relational.core.mapping.PersistentPropertyPathExtension;
+import org.springframework.data.relational.core.mapping.AggregatePath;
 
 /**
  * Unit tests for the {@link JdbcIdentifierBuilder}.
@@ -55,7 +55,7 @@ public class JdbcIdentifierBuilderUnitTests {
 	@Test // DATAJDBC-326
 	public void qualifiersForMaps() {
 
-		PersistentPropertyPathExtension path = getPath("children");
+		AggregatePath path = getPath("children");
 
 		Identifier identifier = JdbcIdentifierBuilder //
 				.forBackReferences(converter, path, "parent-eins") //
@@ -73,7 +73,7 @@ public class JdbcIdentifierBuilderUnitTests {
 	@Test // DATAJDBC-326
 	public void qualifiersForLists() {
 
-		PersistentPropertyPathExtension path = getPath("moreChildren");
+		AggregatePath path = getPath("moreChildren");
 
 		Identifier identifier = JdbcIdentifierBuilder //
 				.forBackReferences(converter, path, "parent-eins") //
@@ -116,8 +116,8 @@ public class JdbcIdentifierBuilderUnitTests {
 				);
 	}
 
-	private PersistentPropertyPathExtension getPath(String dotPath) {
-		return new PersistentPropertyPathExtension(context, toPath(dotPath, DummyEntity.class, context));
+	private AggregatePath getPath(String dotPath) {
+		return context.getAggregatePath(PersistentPropertyPathTestUtils.getPath(dotPath, DummyEntity.class, context));
 	}
 
 	@SuppressWarnings("unused")

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlGeneratorContextBasedNamingStrategyUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlGeneratorContextBasedNamingStrategyUnitTests.java
@@ -26,8 +26,8 @@ import org.assertj.core.api.SoftAssertions;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.jdbc.core.PersistentPropertyPathTestUtils;
 import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
-import org.springframework.data.jdbc.core.mapping.PersistentPropertyPathTestUtils;
 import org.springframework.data.mapping.PersistentPropertyPath;
 import org.springframework.data.relational.core.mapping.NamingStrategy;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
@@ -157,7 +157,7 @@ public class SqlGeneratorContextBasedNamingStrategyUnitTests {
 	}
 
 	private PersistentPropertyPath<RelationalPersistentProperty> getPath(String path) {
-		return PersistentPropertyPathTestUtils.getPath(this.context, path, DummyEntity.class);
+		return PersistentPropertyPathTestUtils.getPath(path, DummyEntity.class, this.context);
 	}
 
 	/**

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlGeneratorEmbeddedUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlGeneratorEmbeddedUnitTests.java
@@ -23,12 +23,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.jdbc.core.PropertyPathTestingUtils;
+import org.springframework.data.jdbc.core.PersistentPropertyPathTestUtils;
 import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Embedded;
 import org.springframework.data.relational.core.mapping.Embedded.OnEmpty;
-import org.springframework.data.relational.core.mapping.PersistentPropertyPathExtension;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
 import org.springframework.data.relational.core.sql.Aliased;
@@ -177,7 +176,7 @@ public class SqlGeneratorEmbeddedUnitTests {
 	public void deleteByPath() {
 
 		final String sql = sqlGenerator
-				.createDeleteByPath(PropertyPathTestingUtils.toPath("embedded.other", DummyEntity2.class, context));
+				.createDeleteByPath(PersistentPropertyPathTestUtils.getPath("embedded.other", DummyEntity2.class, context));
 
 		assertThat(sql).containsSequence("DELETE FROM other_entity", //
 				"WHERE", //
@@ -295,7 +294,7 @@ public class SqlGeneratorEmbeddedUnitTests {
 
 	private SqlGenerator.Join generateJoin(String path, Class<?> type) {
 		return createSqlGenerator(type)
-				.getJoin(new PersistentPropertyPathExtension(context, PropertyPathTestingUtils.toPath(path, type, context)));
+				.getJoin(context.getAggregatePath(PersistentPropertyPathTestUtils.getPath(path, type, context)));
 	}
 
 	@Nullable
@@ -310,13 +309,14 @@ public class SqlGeneratorEmbeddedUnitTests {
 	private org.springframework.data.relational.core.sql.Column generatedColumn(String path, Class<?> type) {
 
 		return createSqlGenerator(type)
-				.getColumn(new PersistentPropertyPathExtension(context, PropertyPathTestingUtils.toPath(path, type, context)));
+				.getColumn(context.getAggregatePath(PersistentPropertyPathTestUtils.getPath(path, type, context)));
 	}
 
 	@SuppressWarnings("unused")
 	static class DummyEntity {
 
-		@Column("id1") @Id Long id;
+		@Column("id1")
+		@Id Long id;
 
 		@Embedded(onEmpty = OnEmpty.USE_NULL, prefix = "prefix_") CascadedEmbedded prefixedEmbeddable;
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlGeneratorFixedNamingStrategyUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlGeneratorFixedNamingStrategyUnitTests.java
@@ -21,8 +21,8 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.data.annotation.Id;
+import org.springframework.data.jdbc.core.PersistentPropertyPathTestUtils;
 import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
-import org.springframework.data.jdbc.core.mapping.PersistentPropertyPathTestUtils;
 import org.springframework.data.mapping.PersistentPropertyPath;
 import org.springframework.data.relational.core.dialect.AnsiDialect;
 import org.springframework.data.relational.core.mapping.NamingStrategy;
@@ -70,7 +70,7 @@ class SqlGeneratorFixedNamingStrategyUnitTests {
 		}
 	};
 
-	private RelationalMappingContext context = new JdbcMappingContext();
+	private RelationalMappingContext context;
 
 	@Test // DATAJDBC-107
 	void findOneWithOverriddenFixedTableName() {
@@ -122,7 +122,7 @@ class SqlGeneratorFixedNamingStrategyUnitTests {
 		String sql = sqlGenerator.createDeleteByPath(getPath("ref"));
 
 		assertThat(sql).isEqualTo("DELETE FROM \"FIXEDCUSTOMSCHEMA\".\"FIXEDCUSTOMTABLEPREFIX_REFERENCEDENTITY\" "
-				+ "WHERE \"FIXEDCUSTOMSCHEMA\".\"FIXEDCUSTOMTABLEPREFIX_REFERENCEDENTITY\".\"DUMMY_ENTITY\" = :rootId");
+				+ "WHERE \"FIXEDCUSTOMSCHEMA\".\"FIXEDCUSTOMTABLEPREFIX_REFERENCEDENTITY\".\"FIXEDCUSTOMTABLEPREFIX_DUMMYENTITY\" = :rootId");
 	}
 
 	@Test // DATAJDBC-107
@@ -137,7 +137,7 @@ class SqlGeneratorFixedNamingStrategyUnitTests {
 						+ "WHERE \"FIXEDCUSTOMSCHEMA\".\"FIXEDCUSTOMTABLEPREFIX_SECONDLEVELREFERENCEDENTITY\".\"FIXEDCUSTOMTABLEPREFIX_REFERENCEDENTITY\" IN "
 						+ "(SELECT \"FIXEDCUSTOMSCHEMA\".\"FIXEDCUSTOMTABLEPREFIX_REFERENCEDENTITY\".\"FIXEDCUSTOMPROPERTYPREFIX_L1ID\" "
 						+ "FROM \"FIXEDCUSTOMSCHEMA\".\"FIXEDCUSTOMTABLEPREFIX_REFERENCEDENTITY\" "
-						+ "WHERE \"FIXEDCUSTOMSCHEMA\".\"FIXEDCUSTOMTABLEPREFIX_REFERENCEDENTITY\".\"DUMMY_ENTITY\" = :rootId)");
+						+ "WHERE \"FIXEDCUSTOMSCHEMA\".\"FIXEDCUSTOMTABLEPREFIX_REFERENCEDENTITY\".\"FIXEDCUSTOMTABLEPREFIX_DUMMYENTITY\" = :rootId)");
 	}
 
 	@Test // DATAJDBC-107
@@ -158,7 +158,7 @@ class SqlGeneratorFixedNamingStrategyUnitTests {
 		String sql = sqlGenerator.createDeleteAllSql(getPath("ref"));
 
 		assertThat(sql).isEqualTo("DELETE FROM \"FIXEDCUSTOMSCHEMA\".\"FIXEDCUSTOMTABLEPREFIX_REFERENCEDENTITY\" "
-				+ "WHERE \"FIXEDCUSTOMSCHEMA\".\"FIXEDCUSTOMTABLEPREFIX_REFERENCEDENTITY\".\"DUMMY_ENTITY\" IS NOT NULL");
+				+ "WHERE \"FIXEDCUSTOMSCHEMA\".\"FIXEDCUSTOMTABLEPREFIX_REFERENCEDENTITY\".\"FIXEDCUSTOMTABLEPREFIX_DUMMYENTITY\" IS NOT NULL");
 	}
 
 	@Test // DATAJDBC-107
@@ -173,7 +173,7 @@ class SqlGeneratorFixedNamingStrategyUnitTests {
 						+ "WHERE \"FIXEDCUSTOMSCHEMA\".\"FIXEDCUSTOMTABLEPREFIX_SECONDLEVELREFERENCEDENTITY\".\"FIXEDCUSTOMTABLEPREFIX_REFERENCEDENTITY\" IN "
 						+ "(SELECT \"FIXEDCUSTOMSCHEMA\".\"FIXEDCUSTOMTABLEPREFIX_REFERENCEDENTITY\".\"FIXEDCUSTOMPROPERTYPREFIX_L1ID\" "
 						+ "FROM \"FIXEDCUSTOMSCHEMA\".\"FIXEDCUSTOMTABLEPREFIX_REFERENCEDENTITY\" "
-						+ "WHERE \"FIXEDCUSTOMSCHEMA\".\"FIXEDCUSTOMTABLEPREFIX_REFERENCEDENTITY\".\"DUMMY_ENTITY\" IS NOT NULL)");
+						+ "WHERE \"FIXEDCUSTOMSCHEMA\".\"FIXEDCUSTOMTABLEPREFIX_REFERENCEDENTITY\".\"FIXEDCUSTOMTABLEPREFIX_DUMMYENTITY\" IS NOT NULL)");
 	}
 
 	@Test // DATAJDBC-113
@@ -188,7 +188,7 @@ class SqlGeneratorFixedNamingStrategyUnitTests {
 	}
 
 	private PersistentPropertyPath<RelationalPersistentProperty> getPath(String path) {
-		return PersistentPropertyPathTestUtils.getPath(context, path, DummyEntity.class);
+		return PersistentPropertyPathTestUtils.getPath(path, DummyEntity.class, context);
 	}
 
 	/**
@@ -196,7 +196,7 @@ class SqlGeneratorFixedNamingStrategyUnitTests {
 	 */
 	private SqlGenerator configureSqlGenerator(NamingStrategy namingStrategy) {
 
-		RelationalMappingContext context = new JdbcMappingContext(namingStrategy);
+		context = new JdbcMappingContext(namingStrategy);
 		JdbcConverter converter = new BasicJdbcConverter(context, (identifier, path) -> {
 			throw new UnsupportedOperationException();
 		});

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlGeneratorUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlGeneratorUnitTests.java
@@ -32,10 +32,9 @@ import org.springframework.data.annotation.Version;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.jdbc.core.PropertyPathTestingUtils;
+import org.springframework.data.jdbc.core.PersistentPropertyPathTestUtils;
 import org.springframework.data.jdbc.core.mapping.AggregateReference;
 import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
-import org.springframework.data.jdbc.core.mapping.PersistentPropertyPathTestUtils;
 import org.springframework.data.mapping.PersistentPropertyPath;
 import org.springframework.data.relational.core.dialect.AnsiDialect;
 import org.springframework.data.relational.core.dialect.Dialect;
@@ -736,7 +735,7 @@ class SqlGeneratorUnitTests {
 	@Nullable
 	private SqlGenerator.Join generateJoin(String path, Class<?> type) {
 		return createSqlGenerator(type, AnsiDialect.INSTANCE)
-				.getJoin(new PersistentPropertyPathExtension(context, PropertyPathTestingUtils.toPath(path, type, context)));
+				.getJoin(context.getAggregatePath(PersistentPropertyPathTestUtils.getPath(path, type, context)));
 	}
 
 	@Test // DATAJDBC-340
@@ -934,12 +933,12 @@ class SqlGeneratorUnitTests {
 	@Nullable
 	private org.springframework.data.relational.core.sql.Column generatedColumn(String path, Class<?> type) {
 
-		return createSqlGenerator(type, AnsiDialect.INSTANCE)
-				.getColumn(new PersistentPropertyPathExtension(context, PropertyPathTestingUtils.toPath(path, type, context)));
+		return createSqlGenerator(type, AnsiDialect.INSTANCE).getColumn(
+				context.getAggregatePath(PersistentPropertyPathTestUtils.getPath(path, type, context)));
 	}
 
 	private PersistentPropertyPath<RelationalPersistentProperty> getPath(String path, Class<?> baseType) {
-		return PersistentPropertyPathTestUtils.getPath(context, path, baseType);
+		return PersistentPropertyPathTestUtils.getPath(path, baseType, context);
 	}
 
 	@SuppressWarnings("unused")

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/mapping/BasicJdbcPersistentPropertyUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/mapping/BasicJdbcPersistentPropertyUnitTests.java
@@ -31,6 +31,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mapping.PersistentPropertyPath;
+import org.springframework.data.relational.core.mapping.AggregatePath;
 import org.springframework.data.relational.core.mapping.BasicRelationalPersistentProperty;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.MappedCollection;
@@ -65,7 +66,7 @@ public class BasicJdbcPersistentPropertyUnitTests {
 
 		String propertyName = "someList";
 		RelationalPersistentProperty listProperty = entity.getRequiredPersistentProperty(propertyName);
-		PersistentPropertyPathExtension path = getPersistentPropertyPath(DummyEntity.class, propertyName);
+		AggregatePath path = getPersistentPropertyPath(DummyEntity.class, propertyName);
 
 		assertThat(listProperty.getReverseColumnName(path)).isEqualTo(quoted("dummy_column_name"));
 		assertThat(listProperty.getKeyColumn()).isEqualTo(quoted("dummy_key_column_name"));
@@ -78,7 +79,7 @@ public class BasicJdbcPersistentPropertyUnitTests {
 		RelationalPersistentProperty listProperty = context //
 				.getRequiredPersistentEntity(WithCollections.class) //
 				.getRequiredPersistentProperty(propertyName);
-		PersistentPropertyPathExtension path = getPersistentPropertyPath(DummyEntity.class, propertyName);
+		AggregatePath path = getPersistentPropertyPath(DummyEntity.class, propertyName);
 
 		assertThat(listProperty.getKeyColumn()).isEqualTo(quoted("WITH_COLLECTIONS_KEY"));
 		assertThat(listProperty.getReverseColumnName(path)).isEqualTo(quoted("some_value"));
@@ -90,7 +91,7 @@ public class BasicJdbcPersistentPropertyUnitTests {
 		RelationalPersistentProperty listProperty = context //
 				.getRequiredPersistentEntity(WithCollections.class) //
 				.getRequiredPersistentProperty("overrideList");
-		PersistentPropertyPathExtension path = getPersistentPropertyPath(WithCollections.class, "overrideList");
+		AggregatePath path = getPersistentPropertyPath(WithCollections.class, "overrideList");
 
 		assertThat(listProperty.getKeyColumn()).isEqualTo(quoted("override_key"));
 		assertThat(listProperty.getReverseColumnName(path)).isEqualTo(quoted("override_id"));
@@ -128,12 +129,13 @@ public class BasicJdbcPersistentPropertyUnitTests {
 		});
 	}
 
-	private PersistentPropertyPathExtension getPersistentPropertyPath(Class<?> type, String propertyName) {
+	private AggregatePath getPersistentPropertyPath(Class<?> type, String propertyName) {
+
 		PersistentPropertyPath<RelationalPersistentProperty> path = context
 				.findPersistentPropertyPaths(type, p -> p.getName().equals(propertyName)).getFirst()
 				.orElseThrow(() -> new AssertionFailedError(String.format("Couldn't find path for '%s'", propertyName)));
 
-		return new PersistentPropertyPathExtension(context, path);
+		return context.getAggregatePath( path);
 	}
 
 	@SuppressWarnings("unused")

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/mybatis/MyBatisDataAccessStrategyUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/mybatis/MyBatisDataAccessStrategyUnitTests.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.jdbc.core.PropertyPathTestingUtils;
+import org.springframework.data.jdbc.core.PersistentPropertyPathTestUtils;
 import org.springframework.data.jdbc.core.convert.Identifier;
 import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
 import org.springframework.data.mapping.PersistentPropertyPath;
@@ -54,7 +54,7 @@ public class MyBatisDataAccessStrategyUnitTests {
 
 	MyBatisDataAccessStrategy accessStrategy = new MyBatisDataAccessStrategy(session, IdentifierProcessing.ANSI);
 
-	PersistentPropertyPath<RelationalPersistentProperty> path = PropertyPathTestingUtils.toPath("one.two",
+	PersistentPropertyPath<RelationalPersistentProperty> path = PersistentPropertyPathTestUtils.getPath("one.two",
 			DummyEntity.class, context);
 
 	@BeforeEach

--- a/spring-data-r2dbc/pom.xml
+++ b/spring-data-r2dbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-r2dbc</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-refactor-path-extension-SNAPSHOT</version>
 
 	<name>Spring Data R2DBC</name>
 	<description>Spring Data module for R2DBC</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-refactor-path-extension-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/convert/MappingR2dbcConverter.java
+++ b/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/convert/MappingR2dbcConverter.java
@@ -50,6 +50,7 @@ import org.springframework.data.r2dbc.support.ArrayUtils;
 import org.springframework.data.relational.core.conversion.BasicRelationalConverter;
 import org.springframework.data.relational.core.conversion.RelationalConverter;
 import org.springframework.data.relational.core.dialect.ArrayColumns;
+import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
 import org.springframework.data.util.TypeInformation;
@@ -74,7 +75,7 @@ public class MappingR2dbcConverter extends BasicRelationalConverter implements R
 	 */
 	public MappingR2dbcConverter(
 			MappingContext<? extends RelationalPersistentEntity<?>, ? extends RelationalPersistentProperty> context) {
-		super(context, new R2dbcCustomConversions(R2dbcCustomConversions.STORE_CONVERSIONS, Collections.emptyList()));
+		super((RelationalMappingContext) context, new R2dbcCustomConversions(R2dbcCustomConversions.STORE_CONVERSIONS, Collections.emptyList()));
 	}
 
 	/**
@@ -85,7 +86,7 @@ public class MappingR2dbcConverter extends BasicRelationalConverter implements R
 	public MappingR2dbcConverter(
 			MappingContext<? extends RelationalPersistentEntity<?>, ? extends RelationalPersistentProperty> context,
 			CustomConversions conversions) {
-		super(context, conversions);
+		super((RelationalMappingContext) context, conversions);
 	}
 
 	// ----------------------------------

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-relational</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-refactor-path-extension-SNAPSHOT</version>
 
 	<name>Spring Data Relational</name>
 	<description>Spring Data Relational support</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-refactor-path-extension-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/BasicRelationalConverter.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/BasicRelationalConverter.java
@@ -38,6 +38,7 @@ import org.springframework.data.mapping.model.ConvertingPropertyAccessor;
 import org.springframework.data.mapping.model.EntityInstantiators;
 import org.springframework.data.mapping.model.ParameterValueProvider;
 import org.springframework.data.mapping.model.SimpleTypeHolder;
+import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
 import org.springframework.data.util.TypeInformation;
@@ -60,7 +61,7 @@ import org.springframework.util.ClassUtils;
  */
 public class BasicRelationalConverter implements RelationalConverter {
 
-	private final MappingContext<? extends RelationalPersistentEntity<?>, RelationalPersistentProperty> context;
+	private final RelationalMappingContext context;
 	private final ConfigurableConversionService conversionService;
 	private final EntityInstantiators entityInstantiators;
 	private final CustomConversions conversions;
@@ -70,8 +71,7 @@ public class BasicRelationalConverter implements RelationalConverter {
 	 *
 	 * @param context must not be {@literal null}.
 	 */
-	public BasicRelationalConverter(
-			MappingContext<? extends RelationalPersistentEntity<?>, ? extends RelationalPersistentProperty> context) {
+	public BasicRelationalConverter(RelationalMappingContext context) {
 		this(context, new CustomConversions(StoreConversions.NONE, Collections.emptyList()), new DefaultConversionService(),
 				new EntityInstantiators());
 	}
@@ -82,22 +82,18 @@ public class BasicRelationalConverter implements RelationalConverter {
 	 * @param context must not be {@literal null}.
 	 * @param conversions must not be {@literal null}.
 	 */
-	public BasicRelationalConverter(
-			MappingContext<? extends RelationalPersistentEntity<?>, ? extends RelationalPersistentProperty> context,
-			CustomConversions conversions) {
+	public BasicRelationalConverter(RelationalMappingContext context, CustomConversions conversions) {
 		this(context, conversions, new DefaultConversionService(), new EntityInstantiators());
 	}
 
 	@SuppressWarnings("unchecked")
-	private BasicRelationalConverter(
-			MappingContext<? extends RelationalPersistentEntity<?>, ? extends RelationalPersistentProperty> context,
-			CustomConversions conversions, ConfigurableConversionService conversionService,
-			EntityInstantiators entityInstantiators) {
+	private BasicRelationalConverter(RelationalMappingContext context, CustomConversions conversions,
+			ConfigurableConversionService conversionService, EntityInstantiators entityInstantiators) {
 
 		Assert.notNull(context, "MappingContext must not be null");
 		Assert.notNull(conversions, "CustomConversions must not be null");
 
-		this.context = (MappingContext) context;
+		this.context = context;
 		this.conversionService = conversionService;
 		this.entityInstantiators = entityInstantiators;
 		this.conversions = conversions;
@@ -115,7 +111,7 @@ public class BasicRelationalConverter implements RelationalConverter {
 	}
 
 	@Override
-	public MappingContext<? extends RelationalPersistentEntity<?>, ? extends RelationalPersistentProperty> getMappingContext() {
+	public RelationalMappingContext getMappingContext() {
 		return context;
 	}
 

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/RelationalEntityDeleteWriter.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/RelationalEntityDeleteWriter.java
@@ -22,6 +22,7 @@ import java.util.function.Consumer;
 
 import org.springframework.data.convert.EntityWriter;
 import org.springframework.data.mapping.PersistentPropertyPath;
+import org.springframework.data.relational.core.mapping.AggregatePath;
 import org.springframework.data.relational.core.mapping.PersistentPropertyPathExtension;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
@@ -126,7 +127,7 @@ public class RelationalEntityDeleteWriter implements EntityWriter<Object, Mutabl
 			Consumer<PersistentPropertyPath<RelationalPersistentProperty>> pathConsumer) {
 
 		context.findPersistentPropertyPaths(entityType, property -> property.isEntity() && !property.isEmbedded()) //
-				.filter(PersistentPropertyPathExtension::isWritable) //
+				.filter(AggregatePath::isWritable) //
 				.forEach(pathConsumer);
 	}
 }

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/RelationalEntityDeleteWriter.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/RelationalEntityDeleteWriter.java
@@ -22,8 +22,7 @@ import java.util.function.Consumer;
 
 import org.springframework.data.convert.EntityWriter;
 import org.springframework.data.mapping.PersistentPropertyPath;
-import org.springframework.data.relational.core.mapping.AggregatePath;
-import org.springframework.data.relational.core.mapping.PersistentPropertyPathExtension;
+import org.springframework.data.relational.core.mapping.AggregatePathUtil;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
 import org.springframework.lang.Nullable;
@@ -127,7 +126,7 @@ public class RelationalEntityDeleteWriter implements EntityWriter<Object, Mutabl
 			Consumer<PersistentPropertyPath<RelationalPersistentProperty>> pathConsumer) {
 
 		context.findPersistentPropertyPaths(entityType, property -> property.isEntity() && !property.isEmbedded()) //
-				.filter(AggregatePath::isWritable) //
+				.filter(AggregatePathUtil::isWritable) //
 				.forEach(pathConsumer);
 	}
 }

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/WritingContext.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/WritingContext.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.data.mapping.PersistentPropertyPath;
+import org.springframework.data.relational.core.mapping.AggregatePath;
 import org.springframework.data.relational.core.mapping.PersistentPropertyPathExtension;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
@@ -63,7 +64,7 @@ class WritingContext<T> {
 		this.rootIdValueSource = IdValueSource.forInstance(root,
 				context.getRequiredPersistentEntity(aggregateChange.getEntityType()));
 		this.paths = context.findPersistentPropertyPaths(entityType, (p) -> p.isEntity() && !p.isEmbedded()) //
-				.filter(PersistentPropertyPathExtension::isWritable).toList();
+				.filter(AggregatePath::isWritable).toList();
 	}
 
 	/**

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/WritingContext.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/WritingContext.java
@@ -24,8 +24,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.data.mapping.PersistentPropertyPath;
-import org.springframework.data.relational.core.mapping.AggregatePath;
-import org.springframework.data.relational.core.mapping.PersistentPropertyPathExtension;
+import org.springframework.data.relational.core.mapping.AggregatePathUtil;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
@@ -64,7 +63,7 @@ class WritingContext<T> {
 		this.rootIdValueSource = IdValueSource.forInstance(root,
 				context.getRequiredPersistentEntity(aggregateChange.getEntityType()));
 		this.paths = context.findPersistentPropertyPaths(entityType, (p) -> p.isEntity() && !p.isEmbedded()) //
-				.filter(AggregatePath::isWritable).toList();
+				.filter(AggregatePathUtil::isWritable).toList();
 	}
 
 	/**

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/AggregatePath.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/AggregatePath.java
@@ -1,0 +1,467 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.relational.core.mapping;
+
+import org.springframework.data.mapping.PersistentPropertyPath;
+import org.springframework.data.relational.core.sql.SqlIdentifier;
+import org.springframework.data.util.Lazy;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * Represents a path within an aggregate starting from the aggregate root.
+ *
+ * @since 3.2
+ * @author Jens Schauder
+ */
+public class AggregatePath {
+
+	private final RelationalMappingContext context;
+
+	@Nullable private final RelationalPersistentEntity<?> rootType;
+
+	@Nullable private final PersistentPropertyPath<? extends RelationalPersistentProperty> path;
+	private final Lazy<SqlIdentifier> columnAlias = Lazy.of(() -> prefixWithTableAlias(getColumnName()));
+
+	public AggregatePath(RelationalMappingContext context,
+			PersistentPropertyPath<? extends RelationalPersistentProperty> path) {
+
+		Assert.notNull(context, "context must not be null");
+		Assert.notNull(path, "path must not be null");
+
+		this.context = context;
+		this.path = path;
+
+		this.rootType = null;
+	}
+
+	public AggregatePath(RelationalMappingContext context, RelationalPersistentEntity<?> rootType) {
+
+		Assert.notNull(context, "context must not be null");
+		Assert.notNull(rootType, "rootType must not be null");
+
+		this.context = context;
+		this.rootType = rootType;
+
+		this.path = null;
+	}
+
+	public static boolean isWritable(@Nullable PersistentPropertyPath<? extends RelationalPersistentProperty> path) {
+		return path == null || path.getLeafProperty().isWritable() && isWritable(path.getParentPath());
+	}
+
+	public boolean isRoot() {
+		return path == null;
+	}
+
+	/**
+	 * Tests if {@code this} and the argument represent the same path.
+	 *
+	 * @param path to which this path gets compared. May be {@literal null}.
+	 * @return Whence the argument matches the path represented by this instance.
+	 */
+	public boolean matches(@Nullable PersistentPropertyPath<RelationalPersistentProperty> path) {
+		return this.path == null ? path == null || path.isEmpty() : this.path.equals(path);
+	}
+
+	/**
+	 * The name of the column used to reference the id in the parent table.
+	 *
+	 * @throws IllegalStateException when called on an empty path.
+	 */
+	public SqlIdentifier getReverseColumnName() {
+
+		Assert.state(path != null, "Empty paths don't have a reverse column name");
+
+		return path.getLeafProperty().getReverseColumnName(this);
+	}
+
+	/**
+	 * Returns the path that has the same beginning but is one segment shorter than this path.
+	 *
+	 * @return the parent path. Guaranteed to be not {@literal null}.
+	 * @throws IllegalStateException when called on an empty path.
+	 */
+	public AggregatePath getParentPath() {
+
+		if (path == null) {
+			throw new IllegalStateException("The parent path of a root path is not defined.");
+		}
+
+		if (path.getLength() == 1) {
+			return context.getAggregatePath(path.getLeafProperty().getOwner());
+		}
+
+		return context.getAggregatePath(path.getParentPath());
+	}
+
+	/**
+	 * The {@link RelationalPersistentEntity} associated with the leaf of this path.
+	 *
+	 * @return Might return {@literal null} when called on a path that does not represent an entity.
+	 */
+	@Nullable
+	public RelationalPersistentEntity<?> getLeafEntity() {
+		return path == null ? rootType : context.getPersistentEntity(path.getLeafProperty().getActualType());
+	}
+
+	/**
+	 * @return {@literal true} if this path represents an entity which has an Id attribute.
+	 */
+	public boolean hasIdProperty() {
+
+		RelationalPersistentEntity<?> leafEntity = getLeafEntity();
+		return leafEntity != null && leafEntity.hasIdProperty();
+	}
+
+	/**
+	 * Returns the longest ancestor path that has an {@link org.springframework.data.annotation.Id} property.
+	 *
+	 * @return A path that starts just as this path but is shorter. Guaranteed to be not {@literal null}.
+	 */
+	public AggregatePath getIdDefiningParentPath() {
+
+		AggregatePath parent = getParentPath();
+
+		if (parent.path == null) {
+			return parent;
+		}
+
+		if (!parent.hasIdProperty()) {
+			return parent.getIdDefiningParentPath();
+		}
+
+		return parent;
+	}
+
+	/**
+	 * The {@link RelationalPersistentEntity} associated with the leaf of this path or throw {@link IllegalStateException}
+	 * if the leaf cannot be resolved.
+	 *
+	 * @return the required {@link RelationalPersistentEntity} associated with the leaf of this path.
+	 * @throws IllegalStateException if the persistent entity cannot be resolved.
+	 */
+	public RelationalPersistentEntity<?> getRequiredLeafEntity() {
+
+		RelationalPersistentEntity<?> entity = getLeafEntity();
+
+		if (entity == null) {
+
+			throw new IllegalStateException(
+					String.format("Couldn't resolve leaf PersistentEntity for type %s", path.getLeafProperty().getActualType()));
+		}
+
+		return entity;
+	}
+
+	public RelationalPersistentProperty getRequiredIdProperty() {
+		return this.path == null ? rootType.getRequiredIdProperty() : getRequiredLeafEntity().getRequiredIdProperty();
+
+	}
+
+	public int getLength() {
+		return path == null ? 0 : path.getLength();
+	}
+
+	/**
+	 * The column name used for the list index or map key of the leaf property of this path.
+	 *
+	 * @return May be {@literal null}.
+	 */
+	@Nullable
+	public SqlIdentifier getQualifierColumn() {
+		return path == null ? null : path.getLeafProperty().getKeyColumn();
+	}
+
+	/**
+	 * The type of the qualifier column of the leaf property of this path or {@literal null} if this is not applicable.
+	 *
+	 * @return may be {@literal null}.
+	 */
+	@Nullable
+	public Class<?> getQualifierColumnType() {
+
+		if (path == null) {
+			return null;
+		}
+		if (!path.getLeafProperty().isQualified()) {
+			return null;
+		}
+		return path.getLeafProperty().getQualifierColumnType();
+	}
+
+	/**
+	 * Returns {@literal true} exactly when the path is non empty and the leaf property an embedded one.
+	 *
+	 * @return if the leaf property is embedded.
+	 */
+	public boolean isEmbedded() {
+		return path != null && path.getLeafProperty().isEmbedded();
+	}
+
+	/**
+	 * @return {@literal true} when this is an empty path or the path references an entity.
+	 */
+	public boolean isEntity() {
+		return path == null || path.getLeafProperty().isEntity();
+	}
+
+	/**
+	 * Finds and returns the longest path with ich identical or an ancestor to the current path and maps directly to a
+	 * table.
+	 *
+	 * @return a path. Guaranteed to be not {@literal null}.
+	 */
+	private AggregatePath getTableOwningAncestor() {
+
+		return isEntity() && !isEmbedded() ? this : getParentPath().getTableOwningAncestor();
+	}
+
+	@Nullable
+	private SqlIdentifier assembleTableAlias() {
+
+		Assert.state(path != null, "Path is null");
+
+		RelationalPersistentProperty leafProperty = path.getLeafProperty();
+		String prefix;
+		if (isEmbedded()) {
+			prefix = leafProperty.getEmbeddedPrefix();
+
+		} else {
+			prefix = leafProperty.getName();
+		}
+
+		if (path.getLength() == 1) {
+			Assert.notNull(prefix, "Prefix mus not be null");
+			return StringUtils.hasText(prefix) ? SqlIdentifier.quoted(prefix) : null;
+		}
+
+		AggregatePath parentPath = getParentPath();
+		SqlIdentifier sqlIdentifier = parentPath.assembleTableAlias();
+
+		if (sqlIdentifier != null) {
+
+			return parentPath.isEmbedded() ? sqlIdentifier.transform(name -> name.concat(prefix))
+					: sqlIdentifier.transform(name -> name + "_" + prefix);
+		}
+		return SqlIdentifier.quoted(prefix);
+
+	}
+
+	/**
+	 * The alias used for the table on which this path is based.
+	 *
+	 * @return a table alias, {@literal null} if the table owning path is the empty path.
+	 */
+	@Nullable
+	public SqlIdentifier getTableAlias() {
+
+		AggregatePath tableOwner = getTableOwningAncestor();
+
+		return tableOwner.path == null ? null : tableOwner.assembleTableAlias();
+
+	}
+
+	/**
+	 * The fully qualified name of the table this path is tied to or of the longest ancestor path that is actually tied to
+	 * a table.
+	 *
+	 * @return the name of the table. Guaranteed to be not {@literal null}.
+	 * @since 3.0
+	 */
+	public SqlIdentifier getQualifiedTableName() {
+		return getTableOwningAncestor().getRequiredLeafEntity().getQualifiedTableName();
+	}
+
+	/**
+	 * The name of the column used to represent this property in the database.
+	 *
+	 * @throws IllegalStateException when called on an empty path.
+	 */
+	public SqlIdentifier getColumnName() {
+
+		Assert.state(path != null, "Path is null");
+
+		return assembleColumnName(path.getLeafProperty().getColumnName());
+	}
+
+	/**
+	 * The alias for the column used to represent this property in the database.
+	 *
+	 * @throws IllegalStateException when called on an empty path.
+	 */
+	public SqlIdentifier getColumnAlias() {
+		return columnAlias.get();
+	}
+
+	/**
+	 * The alias used in select for the column used to reference the id in the parent table.
+	 *
+	 * @throws IllegalStateException when called on an empty path.
+	 */
+	public SqlIdentifier getReverseColumnNameAlias() {
+
+		return prefixWithTableAlias(getReverseColumnName());
+	}
+
+	@Override
+	public String toString() {
+		return "AggregatePath["
+				+ (rootType == null ? path.getBaseProperty().getOwner().getType().getName() : rootType.getName()) + "]"
+				+ ((path == null) ? "/" : path.toDotPath());
+	}
+
+	private SqlIdentifier assembleColumnName(SqlIdentifier suffix) {
+
+		Assert.state(path != null, "Path is null");
+
+		if (path.getLength() <= 1) {
+			return suffix;
+		}
+
+		PersistentPropertyPath<? extends RelationalPersistentProperty> parentPath = path.getParentPath();
+		RelationalPersistentProperty parentLeaf = parentPath.getLeafProperty();
+
+		if (!parentLeaf.isEmbedded()) {
+			return suffix;
+		}
+
+		String embeddedPrefix = parentLeaf.getEmbeddedPrefix();
+
+		return getParentPath().assembleColumnName(suffix.transform(embeddedPrefix::concat));
+	}
+
+	private SqlIdentifier prefixWithTableAlias(SqlIdentifier columnName) {
+
+		SqlIdentifier tableAlias = getTableAlias();
+		return tableAlias == null ? columnName : columnName.transform(name -> tableAlias.getReference() + "_" + name);
+	}
+
+	public String toDotPath() {
+		return path == null ? "" : path.toDotPath();
+	}
+
+	/**
+	 * Returns {@literal true} if there are multiple values for this path, i.e. if the path contains at least one element
+	 * that is a collection and array or a map.
+	 *
+	 * @return {@literal true} if the path contains a multivalued element.
+	 */
+	public boolean isMultiValued() {
+
+		return path != null && //
+				(path.getLeafProperty().isCollectionLike() //
+						|| path.getLeafProperty().isQualified() //
+						|| getParentPath().isMultiValued() //
+				);
+	}
+
+	/**
+	 * @return {@literal true} if the leaf property of this path is a {@link java.util.Map}.
+	 * @see RelationalPersistentProperty#isMap()
+	 */
+	public boolean isMap() {
+		return path != null && path.getLeafProperty().isMap();
+	}
+
+	/**
+	 * @return {@literal true} when this is references a {@link java.util.List} or {@link java.util.Map}.
+	 */
+	public boolean isQualified() {
+		return path != null && path.getLeafProperty().isQualified();
+	}
+
+	public RelationalPersistentProperty getRequiredLeafProperty() {
+
+		if (path == null) {
+			throw new IllegalStateException("root path does not have a leaf property");
+		}
+		return path.getLeafProperty();
+	}
+
+	public RelationalPersistentProperty getBaseProperty() {
+
+		if (path == null) {
+			throw new IllegalStateException("root path does not have a base property");
+		}
+		return path.getBaseProperty();
+	}
+
+	/**
+	 * The column name of the id column of the ancestor path that represents an actual table.
+	 */
+	public SqlIdentifier getIdColumnName() {
+		return getTableOwningAncestor().getRequiredLeafEntity().getIdColumn();
+	}
+
+	/**
+	 * @return {@literal true} when this is references a {@link java.util.Collection} or an array.
+	 */
+	public boolean isCollectionLike() {
+		return path != null && path.getLeafProperty().isCollectionLike();
+	}
+
+	/**
+	 * @return whether the leaf end of the path is ordered, i.e. the data to populate must be ordered.
+	 * @see RelationalPersistentProperty#isOrdered()
+	 */
+	public boolean isOrdered() {
+		return path != null && path.getLeafProperty().isOrdered();
+	}
+
+	/**
+	 * Creates a new path by extending the current path by the property passed as an argument.
+	 *
+	 * @param property must not be {@literal null}.
+	 * @return Guaranteed to be not {@literal null}.
+	 */
+	public AggregatePath extendBy(RelationalPersistentProperty property) {
+
+		PersistentPropertyPath<? extends RelationalPersistentProperty> newPath = path == null //
+				? context.getPersistentPropertyPath(property.getName(), rootType.getType()) //
+				: context.getPersistentPropertyPath(path.toDotPath() + "." + property.getName(),
+						path.getBaseProperty().getOwner().getType());
+
+		return context.getAggregatePath(newPath);
+	}
+
+	public PersistentPropertyPath<? extends RelationalPersistentProperty> getRequiredPersistentPropertyPath() {
+
+		Assert.state(path != null, "path must not be null");
+		return path;
+	}
+
+	/**
+	 * If the table owning ancestor has an id the column name of that id property is returned. Otherwise the reverse
+	 * column is returned.
+	 */
+	public SqlIdentifier getEffectiveIdColumnName() {
+
+		AggregatePath owner = getTableOwningAncestor();
+		return owner.path == null ? owner.getRequiredLeafEntity().getIdColumn() : owner.getReverseColumnName();
+	}
+
+	@Nullable
+	public PersistentPropertyPathExtension getPathExtension() {
+
+		if (path == null) {
+			return new PersistentPropertyPathExtension(context, rootType);
+		}
+		return new PersistentPropertyPathExtension(context, path);
+	}
+}

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/AggregatePath.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/AggregatePath.java
@@ -36,13 +36,6 @@ public interface AggregatePath {
 	boolean isRoot();
 
 	/**
-	 * The name of the column used to reference the id in the parent table.
-	 *
-	 * @throws IllegalStateException when called on an empty path.
-	 */
-	SqlIdentifier getReverseColumnName();
-
-	/**
 	 * Returns the path that has the same beginning but is one segment shorter than this path.
 	 *
 	 * @return the parent path. Guaranteed to be not {@literal null}.
@@ -67,37 +60,9 @@ public interface AggregatePath {
 	 */
 	RelationalPersistentEntity<?> getRequiredLeafEntity();
 
-	/**
-	 * @return {@literal true} if this path represents an entity which has an Id attribute.
-	 */
-	boolean hasIdProperty();
-
-	/**
-	 * Returns the longest ancestor path that has an {@link org.springframework.data.annotation.Id} property.
-	 *
-	 * @return A path that starts just as this path but is shorter. Guaranteed to be not {@literal null}.
-	 */
-	AggregatePath getIdDefiningParentPath();
-
 	RelationalPersistentProperty getRequiredIdProperty();
 
 	int getLength();
-
-	/**
-	 * The column name used for the list index or map key of the leaf property of this path.
-	 *
-	 * @return May be {@literal null}.
-	 */
-	@Nullable
-	SqlIdentifier getQualifierColumn();
-
-	/**
-	 * The type of the qualifier column of the leaf property of this path or {@literal null} if this is not applicable.
-	 *
-	 * @return may be {@literal null}.
-	 */
-	@Nullable
-	Class<?> getQualifierColumnType();
 
 	/**
 	 * Returns {@literal true} exactly when the path is non empty and the leaf property an embedded one.
@@ -110,44 +75,6 @@ public interface AggregatePath {
 	 * @return {@literal true} when this is an empty path or the path references an entity.
 	 */
 	boolean isEntity();
-
-	/**
-	 * The alias used for the table on which this path is based.
-	 *
-	 * @return a table alias, {@literal null} if the table owning path is the empty path.
-	 */
-	@Nullable
-	SqlIdentifier getTableAlias();
-
-	/**
-	 * The fully qualified name of the table this path is tied to or of the longest ancestor path that is actually tied to
-	 * a table.
-	 *
-	 * @return the name of the table. Guaranteed to be not {@literal null}.
-	 * @since 3.0
-	 */
-	SqlIdentifier getQualifiedTableName();
-
-	/**
-	 * The name of the column used to represent this property in the database.
-	 *
-	 * @throws IllegalStateException when called on an empty path.
-	 */
-	SqlIdentifier getColumnName();
-
-	/**
-	 * The alias for the column used to represent this property in the database.
-	 *
-	 * @throws IllegalStateException when called on an empty path.
-	 */
-	SqlIdentifier getColumnAlias();
-
-	/**
-	 * The alias used in select for the column used to reference the id in the parent table.
-	 *
-	 * @throws IllegalStateException when called on an empty path.
-	 */
-	SqlIdentifier getReverseColumnNameAlias();
 
 	String toDotPath();
 
@@ -175,11 +102,6 @@ public interface AggregatePath {
 	RelationalPersistentProperty getBaseProperty();
 
 	/**
-	 * The column name of the id column of the ancestor path that represents an actual table.
-	 */
-	SqlIdentifier getIdColumnName();
-
-	/**
 	 * @return {@literal true} when this is references a {@link java.util.Collection} or an array.
 	 */
 	boolean isCollectionLike();
@@ -200,25 +122,6 @@ public interface AggregatePath {
 
 	PersistentPropertyPath<? extends RelationalPersistentProperty> getRequiredPersistentPropertyPath();
 
-	/**
-	 * If the table owning ancestor has an id the column name of that id property is returned. Otherwise the reverse
-	 * column is returned.
-	 */
-	SqlIdentifier getEffectiveIdColumnName();
-
 	@Nullable
 	PersistentPropertyPathExtension getPathExtension();
-
-	/**
-	 * Finds and returns the longest path with ich identical or an ancestor to the current path and maps directly to a
-	 * table.
-	 *
-	 * @return a path. Guaranteed to be not {@literal null}.
-	 */
-	AggregatePath getTableOwningAncestor();
-
-	@Nullable
-	SqlIdentifier assembleTableAlias();
-
-	SqlIdentifier assembleColumnName(SqlIdentifier suffix);
 }

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/AggregatePathUtil.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/AggregatePathUtil.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.relational.core.mapping;
+
+import org.springframework.data.mapping.PersistentPropertyPath;
+import org.springframework.data.relational.core.sql.SqlIdentifier;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+public final class AggregatePathUtil {
+
+	private AggregatePathUtil(){
+		throw new IllegalStateException("This class should never get instantiated");
+	}
+
+	public static boolean hasIdProperty(AggregatePath path) {
+
+		RelationalPersistentEntity<?> leafEntity = path.getLeafEntity();
+		return leafEntity != null && leafEntity.hasIdProperty();
+	}
+
+
+	/**
+	 * Returns the longest ancestor path that has an {@link org.springframework.data.annotation.Id} property.
+	 *
+	 * @return A path that starts just as this path but is shorter. Guaranteed to be not {@literal null}.
+	 */
+	public static AggregatePath getIdDefiningParentPath(AggregatePath path) {
+
+		AggregatePath parent = path.getParentPath();
+
+		if (path.isRoot()) {
+			return parent;
+		}
+
+		if (!AggregatePathUtil.hasIdProperty(parent)) {
+
+			return getIdDefiningParentPath(parent);
+		}
+
+		return parent;
+	}
+
+
+	/**
+	 * The fully qualified name of the table this path is tied to or of the longest ancestor path that is actually tied to
+	 * a table.
+	 *
+	 * @return the name of the table. Guaranteed to be not {@literal null}.
+	 * @since 3.0
+	 */
+	public static SqlIdentifier getQualifiedTableName(AggregatePath path) {
+		return getTableOwningAncestor(path).getRequiredLeafEntity().getQualifiedTableName();
+	}
+
+
+
+	/**
+	 * The column name of the id column of the ancestor path that represents an actual table.
+	 */
+	public static SqlIdentifier getIdColumnName(AggregatePath path) {
+		return getTableOwningAncestor(path).getRequiredLeafEntity().getIdColumn();
+	}
+
+
+	/**
+	 * If the table owning ancestor has an id the column name of that id property is returned. Otherwise the reverse
+	 * column is returned.
+	 */
+	public static SqlIdentifier getEffectiveIdColumnName(AggregatePath path) {
+
+		AggregatePath owner = getTableOwningAncestor(path);
+		return owner.isRoot() ? owner.getRequiredLeafEntity().getIdColumn() : getReverseColumnName(owner);
+	}
+
+
+
+	/**
+	 * The name of the column used to represent this property in the database.
+	 *
+	 * @throws IllegalStateException when called on an empty path.
+	 */
+	public static SqlIdentifier getColumnName(AggregatePath path) {
+
+		Assert.state(!path.isRoot(), "Path is null");
+
+		return assembleColumnName(path, path.getRequiredLeafProperty().getColumnName());
+	}
+
+
+	/**
+	 * The column name used for the list index or map key of the leaf property of this path.
+	 *
+	 * @return May be {@literal null}.
+	 */
+	@Nullable
+	public static SqlIdentifier getQualifierColumn(AggregatePath path) {
+		return path.isRoot() ? null : path.getRequiredLeafProperty().getKeyColumn();
+	}
+
+	/**
+	 * The type of the qualifier column of the leaf property of this path or {@literal null} if this is not applicable.
+	 *
+	 * @return may be {@literal null}.
+	 */
+	@Nullable
+	public static Class<?> getQualifierColumnType(AggregatePath path) {
+
+		if (path.isRoot()) {
+			return null;
+		}
+		if (!path.getRequiredLeafProperty().isQualified()) {
+			return null;
+		}
+		return path.getRequiredLeafProperty().getQualifierColumnType();
+	}
+
+
+	/**
+	 * The alias for the column used to represent this property in the database.
+	 *
+	 * @throws IllegalStateException when called on an empty path.
+	 */
+	public static SqlIdentifier getColumnAlias(AggregatePath path) {
+		return prefixWithTableAlias(path, getColumnName(path));
+	}
+
+	/**
+	 * The alias used in select for the column used to reference the id in the parent table.
+	 *
+	 * @throws IllegalStateException when called on an empty path.
+	 */
+	public static SqlIdentifier getReverseColumnNameAlias(AggregatePath path) {
+
+		return prefixWithTableAlias(path, getReverseColumnName(path));
+	}
+
+
+	/**
+	 * The name of the column used to reference the id in the parent table.
+	 *
+	 * @throws IllegalStateException when called on an empty path.
+	 */
+	public static SqlIdentifier getReverseColumnName(AggregatePath path) {
+
+		Assert.state(!path.isRoot(), "Empty paths don't have a reverse column name");
+
+		return path.getRequiredLeafProperty().getReverseColumnName(path);
+	}
+
+	/**
+	 * Finds and returns the longest path with ich identical or an ancestor to the current path and maps directly to a
+	 * table.
+	 *
+	 * @return a path. Guaranteed to be not {@literal null}.
+	 */
+	private static AggregatePath getTableOwningAncestor(AggregatePath path) {
+
+		return path.isEntity() && !path.isEmbedded() ? path : getTableOwningAncestor(path.getParentPath());
+	}
+
+	@Nullable
+	private static SqlIdentifier assembleTableAlias(AggregatePath path) {
+
+		Assert.state(!path.isRoot(), "Path is null");
+
+		RelationalPersistentProperty leafProperty = path.getRequiredLeafProperty();
+		String prefix;
+		if (path.isEmbedded()) {
+			prefix = leafProperty.getEmbeddedPrefix();
+
+		} else {
+			prefix = leafProperty.getName();
+		}
+
+		if (path.getLength() == 1) {
+			Assert.notNull(prefix, "Prefix mus not be null");
+			return StringUtils.hasText(prefix) ? SqlIdentifier.quoted(prefix) : null;
+		}
+
+		AggregatePath parentPath = path.getParentPath();
+		SqlIdentifier sqlIdentifier = assembleTableAlias(parentPath);
+
+		if (sqlIdentifier != null) {
+
+			return parentPath.isEmbedded() ? sqlIdentifier.transform(name -> name.concat(prefix))
+					: sqlIdentifier.transform(name -> name + "_" + prefix);
+		}
+		return SqlIdentifier.quoted(prefix);
+
+	}
+
+	/**
+	 * The alias used for the table on which this path is based.
+	 *
+	 * @return a table alias, {@literal null} if the table owning path is the empty path.
+	 */
+	@Nullable
+	public static SqlIdentifier getTableAlias(AggregatePath path) {
+
+		AggregatePath tableOwner = getTableOwningAncestor(path);
+
+		return tableOwner.isRoot() ? null : assembleTableAlias(tableOwner);
+
+	}
+
+
+	public static SqlIdentifier assembleColumnName(AggregatePath path, SqlIdentifier suffix) {
+
+		Assert.state(!path.isRoot(), "Path is null");
+
+		if (path.getLength() <= 1) {
+			return suffix;
+		}
+
+		PersistentPropertyPath<? extends RelationalPersistentProperty> parentPath = path.getParentPath().getRequiredPersistentPropertyPath();
+		RelationalPersistentProperty parentLeaf = parentPath.getLeafProperty();
+
+		if (!parentLeaf.isEmbedded()) {
+			return suffix;
+		}
+
+		String embeddedPrefix = parentLeaf.getEmbeddedPrefix();
+
+		return assembleColumnName(path.getParentPath(),suffix.transform(embeddedPrefix::concat));
+	}
+
+	private static SqlIdentifier prefixWithTableAlias(AggregatePath path, SqlIdentifier columnName) {
+
+		SqlIdentifier tableAlias = getTableAlias(path);
+		return tableAlias == null ? columnName : columnName.transform(name -> tableAlias.getReference() + "_" + name);
+	}
+}

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/BasicRelationalPersistentProperty.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/BasicRelationalPersistentProperty.java
@@ -226,6 +226,12 @@ public class BasicRelationalPersistentProperty extends AnnotationBasedPersistent
 	}
 
 	@Override
+	public SqlIdentifier getReverseColumnName(AggregatePath path) {
+		return collectionIdColumnName.get()
+				.orElseGet(() -> createDerivedSqlIdentifier(this.namingStrategy.getReverseColumnName(path)));
+	}
+
+	@Override
 	public SqlIdentifier getKeyColumn() {
 
 		if (!isQualified()) {

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/CachingNamingStrategy.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/CachingNamingStrategy.java
@@ -63,6 +63,10 @@ class CachingNamingStrategy implements NamingStrategy {
 	}
 
 	@Override
+	public String getReverseColumnName(AggregatePath path) {
+		return delegate.getReverseColumnName(path);
+	}
+	@Override
 	public String getReverseColumnName(PersistentPropertyPathExtension path) {
 		return delegate.getReverseColumnName(path);
 	}

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/ColumnDetector.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/ColumnDetector.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.relational.core.mapping;
+
+import org.springframework.data.mapping.PersistentPropertyPath;
+import org.springframework.data.relational.core.sql.SqlIdentifier;
+import org.springframework.util.Assert;
+
+/**
+ * @author Mark Paluch
+ */
+public class ColumnDetector extends TableAccessor {
+
+	private final AggregatePath path;
+
+	private ColumnDetector(AggregatePath path) {
+		super(path);
+		this.path = path;
+	}
+
+	public static ColumnDetector of(AggregatePath path) {
+		return new ColumnDetector(path);
+	}
+
+	public static ColumnDetector of(TableAccessor tableOwner) {
+		if (tableOwner instanceof ColumnDetector) {
+			return (ColumnDetector) tableOwner;
+		}
+
+		return new ColumnDetector(tableOwner.getPath());
+	}
+
+	@Override
+	ColumnDetector createTableAccessor(AggregatePath path) {
+		return of(path);
+	}
+
+	@Override
+	public ColumnDetector getTableOwner() {
+		return (ColumnDetector) super.getTableOwner();
+	}
+
+	/**
+	 * The column name of the id column of the ancestor path that represents an actual table.
+	 */
+	public SqlIdentifier getIdColumnName() {
+		return getTableOwner().getPath().getRequiredLeafEntity().getIdColumn();
+	}
+
+	/**
+	 * If the table owning ancestor has an id the column name of that id property is returned. Otherwise the reverse
+	 * column is returned.
+	 */
+	public SqlIdentifier getEffectiveIdColumnName() {
+
+		AggregatePath owner = getTableOwner().getPath();
+		return owner.isRoot() ? owner.getRequiredLeafEntity().getIdColumn()
+				: SingleColumnAggregatePath.of(owner).getReverseColumnName();
+	}
+
+	/**
+	 * The name of the column used to represent this property in the database.
+	 *
+	 * @throws IllegalStateException when called on an empty path.
+	 */
+	public SqlIdentifier getColumnName() {
+
+		Assert.state(!path.isRoot(), "Path is null");
+
+		return assembleColumnName(path, path.getRequiredLeafProperty().getColumnName());
+	}
+
+	/**
+	 * The alias for the column used to represent this property in the database.
+	 */
+	public SqlIdentifier getColumnAlias() {
+		return prefixWithTableAlias(getColumnName());
+	}
+
+	private static SqlIdentifier assembleColumnName(AggregatePath path, SqlIdentifier suffix) {
+
+		if (path.getLength() <= 1) {
+			return suffix;
+		}
+
+		PersistentPropertyPath<? extends RelationalPersistentProperty> parentPath = path.getParentPath()
+				.getRequiredPersistentPropertyPath();
+		RelationalPersistentProperty parentLeaf = parentPath.getLeafProperty();
+
+		if (!parentLeaf.isEmbedded()) {
+			return suffix;
+		}
+
+		String embeddedPrefix = parentLeaf.getEmbeddedPrefix();
+
+		return assembleColumnName(path.getParentPath(), suffix.transform(embeddedPrefix::concat));
+	}
+
+}

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/DefaultAggregatePath.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/DefaultAggregatePath.java
@@ -1,0 +1,474 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.relational.core.mapping;
+
+import java.util.Objects;
+
+import org.springframework.data.mapping.PersistentPropertyPath;
+import org.springframework.data.relational.core.sql.SqlIdentifier;
+import org.springframework.data.util.Lazy;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * Represents a path within an aggregate starting from the aggregate root.
+ *
+ * @since 3.2
+ * @author Jens Schauder
+ */
+class DefaultAggregatePath  implements AggregatePath{
+
+	private final RelationalMappingContext context;
+
+	@Nullable private final RelationalPersistentEntity<?> rootType;
+
+	@Nullable private final PersistentPropertyPath<? extends RelationalPersistentProperty> path;
+	private final Lazy<SqlIdentifier> columnAlias = Lazy.of(() -> prefixWithTableAlias(getColumnName()));
+
+	DefaultAggregatePath(RelationalMappingContext context,
+								PersistentPropertyPath<? extends RelationalPersistentProperty> path) {
+
+		Assert.notNull(context, "context must not be null");
+		Assert.notNull(path, "path must not be null");
+
+		this.context = context;
+		this.path = path;
+
+		this.rootType = null;
+	}
+
+	DefaultAggregatePath(RelationalMappingContext context, RelationalPersistentEntity<?> rootType) {
+
+		Assert.notNull(context, "context must not be null");
+		Assert.notNull(rootType, "rootType must not be null");
+
+		this.context = context;
+		this.rootType = rootType;
+
+		this.path = null;
+	}
+
+	public static boolean isWritable(@Nullable PersistentPropertyPath<? extends RelationalPersistentProperty> path) {
+		return path == null || path.getLeafProperty().isWritable() && isWritable(path.getParentPath());
+	}
+
+	public boolean isRoot() {
+		return path == null;
+	}
+
+	/**
+	 * The name of the column used to reference the id in the parent table.
+	 *
+	 * @throws IllegalStateException when called on an empty path.
+	 */
+	public SqlIdentifier getReverseColumnName() {
+
+		Assert.state(!isRoot(), "Empty paths don't have a reverse column name");
+
+		return path.getLeafProperty().getReverseColumnName(this);
+	}
+
+	/**
+	 * Returns the path that has the same beginning but is one segment shorter than this path.
+	 *
+	 * @return the parent path. Guaranteed to be not {@literal null}.
+	 * @throws IllegalStateException when called on an empty path.
+	 */
+	public AggregatePath getParentPath() {
+
+		if (isRoot()) {
+			throw new IllegalStateException("The parent path of a root path is not defined.");
+		}
+
+		if (path.getLength() == 1) {
+			return context.getAggregatePath(path.getLeafProperty().getOwner());
+		}
+
+		return context.getAggregatePath(path.getParentPath());
+	}
+
+	/**
+	 * The {@link RelationalPersistentEntity} associated with the leaf of this path.
+	 *
+	 * @return Might return {@literal null} when called on a path that does not represent an entity.
+	 */
+	@Nullable
+	public RelationalPersistentEntity<?> getLeafEntity() {
+		return isRoot() ? rootType : context.getPersistentEntity(path.getLeafProperty().getActualType());
+	}
+
+	/**
+	 * The {@link RelationalPersistentEntity} associated with the leaf of this path or throw {@link IllegalStateException}
+	 * if the leaf cannot be resolved.
+	 *
+	 * @return the required {@link RelationalPersistentEntity} associated with the leaf of this path.
+	 * @throws IllegalStateException if the persistent entity cannot be resolved.
+	 */
+	public RelationalPersistentEntity<?> getRequiredLeafEntity() {
+
+		RelationalPersistentEntity<?> entity = getLeafEntity();
+
+		if (entity == null) {
+
+			throw new IllegalStateException(
+					String.format("Couldn't resolve leaf PersistentEntity for type %s", path.getLeafProperty().getActualType()));
+		}
+
+		return entity;
+	}
+
+	/**
+	 * @return {@literal true} if this path represents an entity which has an Id attribute.
+	 */
+	public boolean hasIdProperty() {
+
+		RelationalPersistentEntity<?> leafEntity = getLeafEntity();
+		return leafEntity != null && leafEntity.hasIdProperty();
+	}
+
+	/**
+	 * Returns the longest ancestor path that has an {@link org.springframework.data.annotation.Id} property.
+	 *
+	 * @return A path that starts just as this path but is shorter. Guaranteed to be not {@literal null}.
+	 */
+	public AggregatePath getIdDefiningParentPath() {
+
+		AggregatePath parent = getParentPath();
+
+		if (isRoot()) {
+			return parent;
+		}
+
+		if (!parent.hasIdProperty()) {
+			return parent.getIdDefiningParentPath();
+		}
+
+		return parent;
+	}
+
+	public RelationalPersistentProperty getRequiredIdProperty() {
+		return isRoot() ? rootType.getRequiredIdProperty() : getRequiredLeafEntity().getRequiredIdProperty();
+
+	}
+
+	public int getLength() {
+		return isRoot() ? 0 : path.getLength();
+	}
+
+	/**
+	 * The column name used for the list index or map key of the leaf property of this path.
+	 *
+	 * @return May be {@literal null}.
+	 */
+	@Nullable
+	public SqlIdentifier getQualifierColumn() {
+		return isRoot() ? null : path.getLeafProperty().getKeyColumn();
+	}
+
+	/**
+	 * The type of the qualifier column of the leaf property of this path or {@literal null} if this is not applicable.
+	 *
+	 * @return may be {@literal null}.
+	 */
+	@Nullable
+	public Class<?> getQualifierColumnType() {
+
+		if (isRoot()) {
+			return null;
+		}
+		if (!path.getLeafProperty().isQualified()) {
+			return null;
+		}
+		return path.getLeafProperty().getQualifierColumnType();
+	}
+
+	/**
+	 * Returns {@literal true} exactly when the path is non empty and the leaf property an embedded one.
+	 *
+	 * @return if the leaf property is embedded.
+	 */
+	public boolean isEmbedded() {
+		return !isRoot() && path.getLeafProperty().isEmbedded();
+	}
+
+	/**
+	 * @return {@literal true} when this is an empty path or the path references an entity.
+	 */
+	public boolean isEntity() {
+		return isRoot() || path.getLeafProperty().isEntity();
+	}
+
+	/**
+	 * Finds and returns the longest path with ich identical or an ancestor to the current path and maps directly to a
+	 * table.
+	 *
+	 * @return a path. Guaranteed to be not {@literal null}.
+	 */
+	public AggregatePath getTableOwningAncestor() {
+
+		return isEntity() && !isEmbedded() ? this : getParentPath().getTableOwningAncestor();
+	}
+
+	@Nullable
+	public SqlIdentifier assembleTableAlias() {
+
+		Assert.state(!isRoot(), "Path is null");
+
+		RelationalPersistentProperty leafProperty = path.getLeafProperty();
+		String prefix;
+		if (isEmbedded()) {
+			prefix = leafProperty.getEmbeddedPrefix();
+
+		} else {
+			prefix = leafProperty.getName();
+		}
+
+		if (path.getLength() == 1) {
+			Assert.notNull(prefix, "Prefix mus not be null");
+			return StringUtils.hasText(prefix) ? SqlIdentifier.quoted(prefix) : null;
+		}
+
+		AggregatePath parentPath = getParentPath();
+		SqlIdentifier sqlIdentifier = parentPath.assembleTableAlias();
+
+		if (sqlIdentifier != null) {
+
+			return parentPath.isEmbedded() ? sqlIdentifier.transform(name -> name.concat(prefix))
+					: sqlIdentifier.transform(name -> name + "_" + prefix);
+		}
+		return SqlIdentifier.quoted(prefix);
+
+	}
+
+	/**
+	 * The alias used for the table on which this path is based.
+	 *
+	 * @return a table alias, {@literal null} if the table owning path is the empty path.
+	 */
+	@Nullable
+	public SqlIdentifier getTableAlias() {
+
+		AggregatePath tableOwner = getTableOwningAncestor();
+
+		return tableOwner.isRoot() ? null : tableOwner.assembleTableAlias();
+
+	}
+
+	/**
+	 * The fully qualified name of the table this path is tied to or of the longest ancestor path that is actually tied to
+	 * a table.
+	 *
+	 * @return the name of the table. Guaranteed to be not {@literal null}.
+	 * @since 3.0
+	 */
+	public SqlIdentifier getQualifiedTableName() {
+		return getTableOwningAncestor().getRequiredLeafEntity().getQualifiedTableName();
+	}
+
+	/**
+	 * The name of the column used to represent this property in the database.
+	 *
+	 * @throws IllegalStateException when called on an empty path.
+	 */
+	public SqlIdentifier getColumnName() {
+
+		Assert.state(!isRoot(), "Path is null");
+
+		return assembleColumnName(path.getLeafProperty().getColumnName());
+	}
+
+	/**
+	 * The alias for the column used to represent this property in the database.
+	 *
+	 * @throws IllegalStateException when called on an empty path.
+	 */
+	public SqlIdentifier getColumnAlias() {
+		return columnAlias.get();
+	}
+
+	/**
+	 * The alias used in select for the column used to reference the id in the parent table.
+	 *
+	 * @throws IllegalStateException when called on an empty path.
+	 */
+	public SqlIdentifier getReverseColumnNameAlias() {
+
+		return prefixWithTableAlias(getReverseColumnName());
+	}
+
+	@Override
+	public String toString() {
+		return "AggregatePath["
+				+ (rootType == null ? path.getBaseProperty().getOwner().getType().getName() : rootType.getName()) + "]"
+				+ ((isRoot()) ? "/" : path.toDotPath());
+	}
+
+	public SqlIdentifier assembleColumnName(SqlIdentifier suffix) {
+
+		Assert.state(!isRoot(), "Path is null");
+
+		if (path.getLength() <= 1) {
+			return suffix;
+		}
+
+		PersistentPropertyPath<? extends RelationalPersistentProperty> parentPath = path.getParentPath();
+		RelationalPersistentProperty parentLeaf = parentPath.getLeafProperty();
+
+		if (!parentLeaf.isEmbedded()) {
+			return suffix;
+		}
+
+		String embeddedPrefix = parentLeaf.getEmbeddedPrefix();
+
+		return getParentPath().assembleColumnName(suffix.transform(embeddedPrefix::concat));
+	}
+
+	private SqlIdentifier prefixWithTableAlias(SqlIdentifier columnName) {
+
+		SqlIdentifier tableAlias = getTableAlias();
+		return tableAlias == null ? columnName : columnName.transform(name -> tableAlias.getReference() + "_" + name);
+	}
+
+	public String toDotPath() {
+		return isRoot() ? "" : path.toDotPath();
+	}
+
+	/**
+	 * Returns {@literal true} if there are multiple values for this path, i.e. if the path contains at least one element
+	 * that is a collection and array or a map.
+	 *
+	 * @return {@literal true} if the path contains a multivalued element.
+	 */
+	public boolean isMultiValued() {
+
+		return !isRoot() && //
+				(path.getLeafProperty().isCollectionLike() //
+						|| path.getLeafProperty().isQualified() //
+						|| getParentPath().isMultiValued() //
+				);
+	}
+
+	/**
+	 * @return {@literal true} if the leaf property of this path is a {@link java.util.Map}.
+	 * @see RelationalPersistentProperty#isMap()
+	 */
+	public boolean isMap() {
+		return !isRoot() && path.getLeafProperty().isMap();
+	}
+
+	/**
+	 * @return {@literal true} when this is references a {@link java.util.List} or {@link java.util.Map}.
+	 */
+	public boolean isQualified() {
+		return !isRoot() && path.getLeafProperty().isQualified();
+	}
+
+	public RelationalPersistentProperty getRequiredLeafProperty() {
+
+		if (isRoot()) {
+			throw new IllegalStateException("root path does not have a leaf property");
+		}
+		return path.getLeafProperty();
+	}
+
+	public RelationalPersistentProperty getBaseProperty() {
+
+		if (isRoot()) {
+			throw new IllegalStateException("root path does not have a base property");
+		}
+		return path.getBaseProperty();
+	}
+
+	/**
+	 * The column name of the id column of the ancestor path that represents an actual table.
+	 */
+	public SqlIdentifier getIdColumnName() {
+		return getTableOwningAncestor().getRequiredLeafEntity().getIdColumn();
+	}
+
+	/**
+	 * @return {@literal true} when this is references a {@link java.util.Collection} or an array.
+	 */
+	public boolean isCollectionLike() {
+		return !isRoot() && path.getLeafProperty().isCollectionLike();
+	}
+
+	/**
+	 * @return whether the leaf end of the path is ordered, i.e. the data to populate must be ordered.
+	 * @see RelationalPersistentProperty#isOrdered()
+	 */
+	public boolean isOrdered() {
+		return !isRoot() && path.getLeafProperty().isOrdered();
+	}
+
+	/**
+	 * Creates a new path by extending the current path by the property passed as an argument.
+	 *
+	 * @param property must not be {@literal null}.
+	 * @return Guaranteed to be not {@literal null}.
+	 */
+	public AggregatePath append(RelationalPersistentProperty property) {
+
+		PersistentPropertyPath<? extends RelationalPersistentProperty> newPath = isRoot() //
+				? context.getPersistentPropertyPath(property.getName(), rootType.getType()) //
+				: context.getPersistentPropertyPath(path.toDotPath() + "." + property.getName(),
+						path.getBaseProperty().getOwner().getType());
+
+		return context.getAggregatePath(newPath);
+	}
+
+	public PersistentPropertyPath<? extends RelationalPersistentProperty> getRequiredPersistentPropertyPath() {
+
+		Assert.state(!isRoot(), "path must not be null");
+		return path;
+	}
+
+	/**
+	 * If the table owning ancestor has an id the column name of that id property is returned. Otherwise the reverse
+	 * column is returned.
+	 */
+	public SqlIdentifier getEffectiveIdColumnName() {
+
+		AggregatePath owner = getTableOwningAncestor();
+		return owner.isRoot() ? owner.getRequiredLeafEntity().getIdColumn() : owner.getReverseColumnName();
+	}
+
+	@Nullable
+	public PersistentPropertyPathExtension getPathExtension() {
+
+		if (isRoot()) {
+			return new PersistentPropertyPathExtension(context, rootType);
+		}
+		return new PersistentPropertyPathExtension(context, path);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		DefaultAggregatePath that = (DefaultAggregatePath) o;
+		return Objects.equals(context, that.context) && Objects.equals(rootType, that.rootType) && Objects.equals(path, that.path);
+	}
+
+	@Override
+	public int hashCode() {
+
+		return Objects.hash(context, rootType, path);
+	}
+}

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/DefaultNamingStrategy.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/DefaultNamingStrategy.java
@@ -61,6 +61,14 @@ public class DefaultNamingStrategy implements NamingStrategy {
 		return getColumnNameReferencing(leafEntity);
 	}
 
+	@Override
+	public String getReverseColumnName(AggregatePath path) {
+
+		RelationalPersistentEntity<?> leafEntity = path.getIdDefiningParentPath().getRequiredLeafEntity();
+
+		return getColumnNameReferencing(leafEntity);
+	}
+
 	private String getColumnNameReferencing(RelationalPersistentEntity<?> leafEntity) {
 
 		if (foreignKeyNaming == ForeignKeyNaming.IGNORE_RENAMING) {

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/DefaultNamingStrategy.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/DefaultNamingStrategy.java
@@ -64,7 +64,7 @@ public class DefaultNamingStrategy implements NamingStrategy {
 	@Override
 	public String getReverseColumnName(AggregatePath path) {
 
-		RelationalPersistentEntity<?> leafEntity = path.getIdDefiningParentPath().getRequiredLeafEntity();
+		RelationalPersistentEntity<?> leafEntity = AggregatePathUtil.getIdDefiningParentPath(path).getRequiredLeafEntity();
 
 		return getColumnNameReferencing(leafEntity);
 	}

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/ForeignTableDetector.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/ForeignTableDetector.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.relational.core.mapping;
+
+import org.springframework.data.relational.core.sql.SqlIdentifier;
+import org.springframework.util.Assert;
+
+/**
+ * @author Mark Paluch
+ */
+public class ForeignTableDetector extends TableAccessor{
+
+	private final AggregatePath path;
+
+	ForeignTableDetector(AggregatePath path) {
+		super(path);
+		this.path = path;
+	}
+
+	public static ForeignTableDetector of(AggregatePath path) {
+
+		Assert.notNull(path, "AggregatePath must not be null");
+
+		if (path.isRoot()) {
+			throw new IllegalStateException("Root path does not map to a single column");
+		}
+
+		if (path.isEmbedded()) {
+			throw new IllegalStateException(String.format("Embedded property %s does not map to a foreign table", path));
+		}
+
+		if (!path.isQualified()) {
+			throw new IllegalStateException(String.format("Property %s does not map to a foreign table", path));
+		}
+
+		return new ForeignTableDetector(path);
+	}
+
+	/**
+	 * The column name used for the list index or map key of the leaf property of this path.
+	 *
+	 * @throws IllegalStateException if the key column cannot be determined for the current path.
+	 */
+	public SqlIdentifier getQualifierColumn() {
+
+		SqlIdentifier keyColumn = path.getRequiredLeafProperty().getKeyColumn();
+
+		if (keyColumn == null) {
+			throw new IllegalStateException("Cannot determine key column for %s".formatted(path));
+		}
+		return keyColumn;
+	}
+
+	/**
+	 * The type of the qualifier column of the leaf property of this path or {@literal null} if this is not applicable.
+	 *
+	 * @return may be {@literal null}.
+	 */
+	public Class<?> getQualifierColumnType() {
+
+		RelationalPersistentProperty property = path.getRequiredLeafProperty();
+
+		return property.getQualifierColumnType();
+	}
+
+	/**
+	 * The name of the column used to reference the id in the parent table.
+	 *
+	 * @throws IllegalStateException when called on an empty path.
+	 */
+	public SqlIdentifier getReverseColumnName() {
+		return path.getRequiredLeafProperty().getReverseColumnName(path);
+	}
+
+}

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/NamingStrategy.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/NamingStrategy.java
@@ -88,8 +88,27 @@ public interface NamingStrategy {
 		return property.getOwner().getTableName().getReference();
 	}
 
+	/**
+	 *
+	 * @deprecated use {@link #getReverseColumnName(AggregatePath)} instead.
+	 */
+	@Deprecated(since = "3.2", forRemoval = true)
 	default String getReverseColumnName(PersistentPropertyPathExtension path) {
-		return getTableName(path.getIdDefiningParentPath().getRequiredLeafEntity().getType());
+		return getReverseColumnName(path.getAggregatePath());
+	}
+
+	/**
+	 * provides the name of the column referencing the parent entity.
+	 *
+	 * @param path the path for which the reverse column name should get determined. Must not be null.
+	 * @return a column name.
+	 *
+	 * @since 3.2
+	 */
+	default String getReverseColumnName(AggregatePath path){
+
+		AggregatePath idDefiningParentPath = path.getIdDefiningParentPath();
+		return getTableName(idDefiningParentPath.getRequiredLeafEntity().getType());
 	}
 
 	/**
@@ -104,4 +123,5 @@ public interface NamingStrategy {
 
 		return getReverseColumnName(property) + "_key";
 	}
+
 }

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/NamingStrategy.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/NamingStrategy.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.data.relational.core.mapping;
 
-import org.springframework.data.relational.core.sql.IdentifierProcessing;
 import org.springframework.data.util.ParsingUtils;
 import org.springframework.util.Assert;
 
@@ -89,7 +88,6 @@ public interface NamingStrategy {
 	}
 
 	/**
-	 *
 	 * @deprecated use {@link #getReverseColumnName(AggregatePath)} instead.
 	 */
 	@Deprecated(since = "3.2", forRemoval = true)
@@ -102,12 +100,11 @@ public interface NamingStrategy {
 	 *
 	 * @param path the path for which the reverse column name should get determined. Must not be null.
 	 * @return a column name.
-	 *
 	 * @since 3.2
 	 */
-	default String getReverseColumnName(AggregatePath path){
+	default String getReverseColumnName(AggregatePath path) {
 
-		AggregatePath idDefiningParentPath = path.getIdDefiningParentPath();
+		AggregatePath idDefiningParentPath = AggregatePathUtil.getIdDefiningParentPath(path);
 		return getTableName(idDefiningParentPath.getRequiredLeafEntity().getType());
 	}
 

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/PersistentPropertyPathExtension.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/PersistentPropertyPathExtension.java
@@ -20,7 +20,6 @@ import java.util.Objects;
 import org.springframework.data.mapping.PersistentProperty;
 import org.springframework.data.mapping.PersistentPropertyPath;
 import org.springframework.data.mapping.context.MappingContext;
-import org.springframework.data.relational.core.sql.IdentifierProcessing;
 import org.springframework.data.relational.core.sql.SqlIdentifier;
 import org.springframework.data.util.Lazy;
 import org.springframework.lang.Nullable;
@@ -35,7 +34,9 @@ import org.springframework.util.StringUtils;
  * @author Daniil Razorenov
  * @author Kurt Niemi
  * @since 1.1
+ * @deprecated use {@link AggregatePath} instead
  */
+@Deprecated(since = "3.2", forRemoval = true)
 public class PersistentPropertyPathExtension {
 
 	private final RelationalPersistentEntity<?> entity;
@@ -155,8 +156,8 @@ public class PersistentPropertyPathExtension {
 			if (this.path == null) {
 				throw new IllegalStateException("Couldn't resolve leaf PersistentEntity absent path");
 			}
-			throw new IllegalStateException(String.format("Couldn't resolve leaf PersistentEntity for type %s",
-					path.getLeafProperty().getActualType()));
+			throw new IllegalStateException(
+					String.format("Couldn't resolve leaf PersistentEntity for type %s", path.getLeafProperty().getActualType()));
 		}
 
 		return entity;
@@ -388,14 +389,6 @@ public class PersistentPropertyPathExtension {
 	}
 
 	/**
-	 * @return whether the leaf end of the path is ordered, i.e. the data to populate must be ordered.
-	 * @see RelationalPersistentProperty#isOrdered()
-	 */
-	public boolean isOrdered() {
-		return path != null && path.getLeafProperty().isOrdered();
-	}
-
-	/**
 	 * @return {@literal true} if the leaf property of this path is a {@link java.util.Map}.
 	 * @see RelationalPersistentProperty#isMap()
 	 */
@@ -481,8 +474,7 @@ public class PersistentPropertyPathExtension {
 	private SqlIdentifier prefixWithTableAlias(SqlIdentifier columnName) {
 
 		SqlIdentifier tableAlias = getTableAlias();
-		return tableAlias == null ? columnName
-				: columnName.transform(name -> tableAlias.getReference() + "_" + name);
+		return tableAlias == null ? columnName : columnName.transform(name -> tableAlias.getReference() + "_" + name);
 	}
 
 	@Override
@@ -499,5 +491,14 @@ public class PersistentPropertyPathExtension {
 	@Override
 	public int hashCode() {
 		return Objects.hash(entity, path);
+	}
+
+	public AggregatePath getAggregatePath() {
+		if (path != null) {
+
+			return ((RelationalMappingContext) context).getAggregatePath(path);
+		} else {
+			return ((RelationalMappingContext) context).getAggregatePath(entity);
+		}
 	}
 }

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/RelationalMappingContext.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/RelationalMappingContext.java
@@ -15,8 +15,12 @@
  */
 package org.springframework.data.relational.core.mapping;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
+import org.springframework.data.mapping.PersistentPropertyPath;
 import org.springframework.data.mapping.context.AbstractMappingContext;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mapping.model.Property;
@@ -39,6 +43,8 @@ public class RelationalMappingContext
 		extends AbstractMappingContext<RelationalPersistentEntity<?>, RelationalPersistentProperty> {
 
 	private final NamingStrategy namingStrategy;
+	private final Map<Object, AggregatePath> aggregatePathCache = new ConcurrentHashMap<>();
+
 	private boolean forceQuote = true;
 
 	private final ExpressionEvaluator expressionEvaluator = new ExpressionEvaluator(EvaluationContextProvider.DEFAULT);
@@ -129,4 +135,18 @@ public class RelationalMappingContext
 		persistentProperty.setExpressionEvaluator(this.expressionEvaluator);
 	}
 
+	/**
+	 * Provides an {@link AggregatePath} for the provided {@link PersistentPropertyPath}.
+	 *
+	 * @param path the path to provide an {@link AggregatePath} for. Must not be null.
+	 * @return an {@link AggregatePath} on the provided path.
+	 * @since 3.2
+	 */
+	public AggregatePath getAggregatePath(PersistentPropertyPath<? extends RelationalPersistentProperty> path) {
+		return aggregatePathCache.computeIfAbsent(path, key -> new AggregatePath(this, path));
+	}
+
+	public AggregatePath getAggregatePath(RelationalPersistentEntity<?> type) {
+		return aggregatePathCache.computeIfAbsent(type, key -> new AggregatePath(this, type));
+	}
 }

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/RelationalMappingContext.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/RelationalMappingContext.java
@@ -143,10 +143,10 @@ public class RelationalMappingContext
 	 * @since 3.2
 	 */
 	public AggregatePath getAggregatePath(PersistentPropertyPath<? extends RelationalPersistentProperty> path) {
-		return aggregatePathCache.computeIfAbsent(path, key -> new AggregatePath(this, path));
+		return aggregatePathCache.computeIfAbsent(path, key -> new DefaultAggregatePath(this, path));
 	}
 
 	public AggregatePath getAggregatePath(RelationalPersistentEntity<?> type) {
-		return aggregatePathCache.computeIfAbsent(type, key -> new AggregatePath(this, type));
+		return aggregatePathCache.computeIfAbsent(type, key -> new DefaultAggregatePath(this, type));
 	}
 }

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/RelationalPersistentProperty.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/RelationalPersistentProperty.java
@@ -38,7 +38,15 @@ public interface RelationalPersistentProperty extends PersistentProperty<Relatio
 	@Override
 	RelationalPersistentEntity<?> getOwner();
 
+	/**
+	 * @deprecated use {@link #getReverseColumnName(AggregatePath)} instead
+	 */
+	@Deprecated(since = "3.2", forRemoval = true)
 	SqlIdentifier getReverseColumnName(PersistentPropertyPathExtension path);
+
+	default SqlIdentifier getReverseColumnName(AggregatePath path) {
+		return getReverseColumnName(path.getPathExtension());
+	}
 
 	@Nullable
 	SqlIdentifier getKeyColumn();

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/RelationalPersistentProperty.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/RelationalPersistentProperty.java
@@ -44,9 +44,14 @@ public interface RelationalPersistentProperty extends PersistentProperty<Relatio
 	@Deprecated(since = "3.2", forRemoval = true)
 	SqlIdentifier getReverseColumnName(PersistentPropertyPathExtension path);
 
-	default SqlIdentifier getReverseColumnName(AggregatePath path) {
-		return getReverseColumnName(path.getPathExtension());
-	}
+
+	// TODO: Remove this method as we have a cycle between path and property
+	/**
+	 * @param path
+	 * @return
+	 * @since 3.2
+	 */
+	SqlIdentifier getReverseColumnName(AggregatePath path);
 
 	@Nullable
 	SqlIdentifier getKeyColumn();
@@ -86,7 +91,7 @@ public interface RelationalPersistentProperty extends PersistentProperty<Relatio
 
 	/**
 	 * Returns whether this property is only to be used during inserts and read.
-	 * 
+	 *
 	 * @since 3.0
 	 */
 	boolean isInsertOnly();

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/SingleColumnAggregatePath.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/SingleColumnAggregatePath.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.relational.core.mapping;
+
+import org.springframework.data.relational.core.sql.SqlIdentifier;
+import org.springframework.util.Assert;
+
+/**
+ * @author Mark Paluch
+ */
+public class SingleColumnAggregatePath {
+
+	private final AggregatePath path;
+
+	private SingleColumnAggregatePath(AggregatePath path) {
+		this.path = path;
+	}
+
+	public static SingleColumnAggregatePath of(AggregatePath path) {
+
+		Assert.notNull(path, "AggregatePath must not be null");
+
+		if (path.isRoot()) {
+			throw new IllegalStateException("Root path does not map to a single column");
+		}
+
+		if (path.isEmbedded()) {
+			throw new IllegalStateException(String.format("Embedded property %s does not map to a single column", path));
+		}
+
+		return new SingleColumnAggregatePath(path);
+	}
+
+	/**
+	 * The name of the column used to reference the id in the parent table.
+	 *
+	 * @throws IllegalStateException when called on an empty path.
+	 */
+	public SqlIdentifier getReverseColumnName() {
+		return path.getRequiredLeafProperty().getReverseColumnName(path);
+	}
+
+}

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/TableAccessor.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/TableAccessor.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.relational.core.mapping;
+
+import org.springframework.data.relational.core.sql.SqlIdentifier;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author Mark Paluch
+ */
+public class TableAccessor {
+
+	private final AggregatePath path;
+
+	TableAccessor(AggregatePath path) {
+		this.path = path;
+	}
+
+	public static TableAccessor of(AggregatePath path) {
+		return new TableAccessor(path);
+	}
+
+	/**
+	 * The alias used for the table on which this path is based.
+	 *
+	 * @return a table alias, {@literal null} if the table owning path is the empty path.
+	 */
+	public boolean hasTableAlias() {
+
+		TableAccessor tableOwner = getTableOwner();
+		AggregatePath path = tableOwner.getPath();
+
+		if (path.isRoot()) {
+			return false;
+		}
+
+		// TODO: Do this better
+		return assembleTableAlias(path) != null;
+	}
+
+	/**
+	 * The fully qualified name of the table this path is tied to or of the longest ancestor path that is actually tied to
+	 * a table.
+	 *
+	 * @return the name of the table. Guaranteed to be not {@literal null}.
+	 * @since 3.0
+	 */
+	public SqlIdentifier getQualifiedTableName() {
+		return getTableOwner().getPath().getRequiredLeafEntity().getQualifiedTableName();
+	}
+
+	/**
+	 * The alias used for the table on which this path is based.
+	 *
+	 * @return a table alias, {@literal null} if the table owning path is the empty path.
+	 */
+	@Nullable
+	public SqlIdentifier findTableAlias() {
+
+		// TODO: Make non-nullable
+		TableAccessor tableOwner = getTableOwner();
+		AggregatePath path = tableOwner.getPath();
+
+		return path.isRoot() ? null : assembleTableAlias(path);
+	}
+
+	public TableAccessor getTableOwner() {
+
+		AggregatePath result = path.filter(it -> it.isEntity() && !it.isEmbedded());
+
+		if (result == null) {
+			throw new IllegalArgumentException("Cannot find table-owning AggregatePath for %s".formatted(path));
+		}
+
+		if (result == path) {
+			return this;
+		}
+
+		return createTableAccessor(result);
+	}
+
+	TableAccessor createTableAccessor(AggregatePath path) {
+		return new TableAccessor(path);
+	}
+
+	public AggregatePath getPath() {
+		return path;
+	}
+
+	SqlIdentifier prefixWithTableAlias(SqlIdentifier columnName) {
+
+		SqlIdentifier tableAlias = findTableAlias();
+		return tableAlias == null ? columnName : columnName.transform(name -> tableAlias.getReference() + "_" + name);
+	}
+
+	@Nullable
+	private static SqlIdentifier assembleTableAlias(AggregatePath path) {
+
+		RelationalPersistentProperty leafProperty = path.getRequiredLeafProperty();
+		String prefix;
+		if (path.isEmbedded()) {
+			prefix = leafProperty.getEmbeddedPrefix();
+
+		} else {
+			prefix = leafProperty.getName();
+		}
+
+		if (path.getLength() == 1) {
+			Assert.notNull(prefix, "Prefix mus not be null");
+			return StringUtils.hasText(prefix) ? SqlIdentifier.quoted(prefix) : null;
+		}
+
+		AggregatePath parentPath = path.getParentPath();
+		SqlIdentifier sqlIdentifier = assembleTableAlias(parentPath);
+
+		if (sqlIdentifier != null) {
+
+			return parentPath.isEmbedded() ? sqlIdentifier.transform(name -> name.concat(prefix))
+					: sqlIdentifier.transform(name -> name + "_" + prefix);
+		}
+
+		return SqlIdentifier.quoted(prefix);
+	}
+
+}

--- a/spring-data-relational/src/test/java/org/springframework/data/relational/core/mapping/AggregatePathUnitTests.java
+++ b/spring-data-relational/src/test/java/org/springframework/data/relational/core/mapping/AggregatePathUnitTests.java
@@ -162,8 +162,8 @@ class AggregatePathUnitTests {
 
 		assertSoftly(softly -> {
 
-			softly.assertThat(path().extendBy(entity.getRequiredPersistentProperty("withId"))).isEqualTo(path("withId"));
-			softly.assertThat(path("withId").extendBy(path("withId").getRequiredIdProperty()))
+			softly.assertThat(path().append(entity.getRequiredPersistentProperty("withId"))).isEqualTo(path("withId"));
+			softly.assertThat(path("withId").append(path("withId").getRequiredIdProperty()))
 					.isEqualTo(path("withId.withIdId"));
 		});
 	}
@@ -438,18 +438,6 @@ class AggregatePathUnitTests {
 			softly.assertThat(path("second.third2").getLength()).isEqualTo(2);
 			softly.assertThat(path("withId.second.third").getLength()).isEqualTo(3);
 			softly.assertThat(path("withId.second.third2.value").getLength()).isEqualTo(4);
-		});
-	}
-
-	@Test // GH-1525
-	void matches() {
-
-		assertSoftly(softly -> {
-
-			softly.assertThat(path().matches(createSimplePath("second").getParentPath())).isTrue();
-			softly.assertThat(path().matches(createSimplePath("second"))).isFalse();
-			softly.assertThat(path("withId.second.third").matches(createSimplePath("withId.second.third"))).isTrue();
-			softly.assertThat(path("withId.second.third").matches(createSimplePath("withId.second.third2.value"))).isFalse();
 		});
 	}
 

--- a/spring-data-relational/src/test/java/org/springframework/data/relational/core/mapping/AggregatePathUnitTests.java
+++ b/spring-data-relational/src/test/java/org/springframework/data/relational/core/mapping/AggregatePathUnitTests.java
@@ -1,0 +1,497 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.relational.core.mapping;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.SoftAssertions.*;
+import static org.springframework.data.relational.core.sql.SqlIdentifier.*;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.ReadOnlyProperty;
+import org.springframework.data.mapping.PersistentPropertyPath;
+import org.springframework.data.relational.core.sql.SqlIdentifier;
+
+/**
+ * Tests for {@link AggregatePath}.
+ *
+ * @author Jens Schauder
+ */
+class AggregatePathUnitTests {
+	RelationalMappingContext context = new RelationalMappingContext();
+
+	private RelationalPersistentEntity<?> entity = context.getRequiredPersistentEntity(DummyEntity.class);
+
+	@Test // GH-1525
+	void isNotRootForNonRootPath() {
+
+		AggregatePath path = context.getAggregatePath(context.getPersistentPropertyPath("entityId", DummyEntity.class));
+
+		assertThat(path.isRoot()).isFalse();
+	}
+
+	@Test // GH-1525
+	void isRootForRootPath() {
+
+		AggregatePath path = context.getAggregatePath(entity);
+
+		assertThat(path.isRoot()).isTrue();
+	}
+
+	@Test // GH-1525
+	void getParentPath() {
+
+		assertSoftly(softly -> {
+
+			softly.assertThat(path("second.third2.value").getParentPath()).isEqualTo(path("second.third2"));
+			softly.assertThat(path("second.third2").getParentPath()).isEqualTo(path("second"));
+			softly.assertThat(path("second").getParentPath()).isEqualTo(path());
+
+			softly.assertThatThrownBy(() -> path().getParentPath()).isInstanceOf(IllegalStateException.class);
+		});
+	}
+
+	@Test // GH-1525
+	void getRequiredLeafEntity() {
+
+		assertSoftly(softly -> {
+
+			softly.assertThat(path().getRequiredLeafEntity()).isEqualTo(entity);
+			softly.assertThat(path("second").getRequiredLeafEntity())
+					.isEqualTo(context.getRequiredPersistentEntity(Second.class));
+			softly.assertThat(path("second.third").getRequiredLeafEntity())
+					.isEqualTo(context.getRequiredPersistentEntity(Third.class));
+			softly.assertThat(path("secondList").getRequiredLeafEntity())
+					.isEqualTo(context.getRequiredPersistentEntity(Second.class));
+
+			softly.assertThatThrownBy(() -> path("secondList.third.value").getRequiredLeafEntity())
+					.isInstanceOf(IllegalStateException.class);
+
+		});
+	}
+
+	@Test // GH-1525
+	void idDefiningPath() {
+
+		assertSoftly(softly -> {
+
+			softly.assertThat(path("second.third2.value").getIdDefiningParentPath()).isEqualTo(path());
+			softly.assertThat(path("second.third.value").getIdDefiningParentPath()).isEqualTo(path());
+			softly.assertThat(path("secondList.third2.value").getIdDefiningParentPath()).isEqualTo(path());
+			softly.assertThat(path("secondList.third.value").getIdDefiningParentPath()).isEqualTo(path());
+			softly.assertThat(path("second2.third2.value").getIdDefiningParentPath()).isEqualTo(path());
+			softly.assertThat(path("second2.third.value").getIdDefiningParentPath()).isEqualTo(path());
+			softly.assertThat(path("withId.second.third2.value").getIdDefiningParentPath()).isEqualTo(path("withId"));
+			softly.assertThat(path("withId.second.third.value").getIdDefiningParentPath()).isEqualTo(path("withId"));
+		});
+	}
+
+	@Test // GH-1525
+	void getRequiredIdProperty() {
+
+		assertSoftly(softly -> {
+
+			softly.assertThat(path().getRequiredIdProperty().getName()).isEqualTo("entityId");
+			softly.assertThat(path("withId").getRequiredIdProperty().getName()).isEqualTo("withIdId");
+			softly.assertThatThrownBy(() -> path("second").getRequiredIdProperty()).isInstanceOf(IllegalStateException.class);
+		});
+	}
+
+	@Test // GH-1525
+	void reverseColumnName() {
+
+		assertSoftly(softly -> {
+
+			softly.assertThat(path("second.third2").getReverseColumnName()).isEqualTo(quoted("DUMMY_ENTITY"));
+			softly.assertThat(path("second.third").getReverseColumnName()).isEqualTo(quoted("DUMMY_ENTITY"));
+			softly.assertThat(path("secondList.third2").getReverseColumnName()).isEqualTo(quoted("DUMMY_ENTITY"));
+			softly.assertThat(path("secondList.third").getReverseColumnName()).isEqualTo(quoted("DUMMY_ENTITY"));
+			softly.assertThat(path("second2.third2").getReverseColumnName()).isEqualTo(quoted("DUMMY_ENTITY"));
+			softly.assertThat(path("second2.third").getReverseColumnName()).isEqualTo(quoted("DUMMY_ENTITY"));
+			softly.assertThat(path("withId.second.third2.value").getReverseColumnName()).isEqualTo(quoted("WITH_ID"));
+			softly.assertThat(path("withId.second.third").getReverseColumnName()).isEqualTo(quoted("WITH_ID"));
+			softly.assertThat(path("withId.second2.third").getReverseColumnName()).isEqualTo(quoted("WITH_ID"));
+		});
+	}
+
+	@Test // GH-1525
+	void getQualifierColumn() {
+
+		assertSoftly(softly -> {
+
+			softly.assertThat(path().getQualifierColumn()).isEqualTo(null);
+			softly.assertThat(path("second.third").getQualifierColumn()).isEqualTo(null);
+			softly.assertThat(path("secondList.third2").getQualifierColumn()).isEqualTo(null);
+			softly.assertThat(path("secondList").getQualifierColumn()).isEqualTo(SqlIdentifier.quoted("DUMMY_ENTITY_KEY"));
+
+		});
+	}
+
+	@Test // GH-1525
+	void getQualifierColumnType() {
+
+		assertSoftly(softly -> {
+
+			softly.assertThat(path().getQualifierColumnType()).isEqualTo(null);
+			softly.assertThat(path("second.third").getQualifierColumnType()).isEqualTo(null);
+			softly.assertThat(path("secondList.third2").getQualifierColumnType()).isEqualTo(null);
+			softly.assertThat(path("secondList").getQualifierColumnType()).isEqualTo(Integer.class);
+
+		});
+	}
+
+	@Test // GH-1525
+	void extendBy() {
+
+		assertSoftly(softly -> {
+
+			softly.assertThat(path().extendBy(entity.getRequiredPersistentProperty("withId"))).isEqualTo(path("withId"));
+			softly.assertThat(path("withId").extendBy(path("withId").getRequiredIdProperty()))
+					.isEqualTo(path("withId.withIdId"));
+		});
+	}
+
+	@Test // GH-1525
+	void isWritable() {
+
+		assertSoftly(softly -> {
+			softly.assertThat(AggregatePath.isWritable(createSimplePath("withId"))).describedAs("simple path is writable")
+					.isTrue();
+			softly.assertThat(AggregatePath.isWritable(createSimplePath("secondList.third2")))
+					.describedAs("long path is writable").isTrue();
+			softly.assertThat(AggregatePath.isWritable(createSimplePath("second")))
+					.describedAs("simple read only path is not writable").isFalse();
+			softly.assertThat(AggregatePath.isWritable(createSimplePath("second.third")))
+					.describedAs("long path containing read only element is not writable").isFalse();
+		});
+	}
+
+	@Test // GH-1525
+	void isEmbedded() {
+
+		assertSoftly(softly -> {
+			softly.assertThat(path().isEmbedded()).isFalse();
+			softly.assertThat(path("withId").isEmbedded()).isFalse();
+			softly.assertThat(path("second2.third").isEmbedded()).isFalse();
+			softly.assertThat(path("second2").isEmbedded()).isTrue();
+
+		});
+	}
+
+
+	@Test // GH-1525
+	void isEntity() {
+
+		assertSoftly(softly -> {
+
+			softly.assertThat(path().isEntity()).isTrue();
+			softly.assertThat(path("second").isEntity()).isTrue();
+			softly.assertThat(path("second.third2").isEntity()).isTrue();
+			softly.assertThat(path("secondList.third2").isEntity()).isTrue();
+			softly.assertThat(path("secondList").isEntity()).isTrue();
+			softly.assertThat(path("second.third2.value").isEntity()).isFalse();
+			softly.assertThat(path("secondList.third2.value").isEntity()).isFalse();
+		});
+	}
+
+	@Test // GH-1525
+	void isMultiValued() {
+
+		assertSoftly(softly -> {
+
+			softly.assertThat(path().isMultiValued()).isFalse();
+			softly.assertThat(path("second").isMultiValued()).isFalse();
+			softly.assertThat(path("second.third2").isMultiValued()).isFalse();
+			softly.assertThat(path("secondList.third2").isMultiValued()).isTrue();
+			softly.assertThat(path("secondList").isMultiValued()).isTrue();
+		});
+	}
+
+	@Test // GH-1525
+	void isQualified() {
+
+		assertSoftly(softly -> {
+
+			softly.assertThat(path().isQualified()).isFalse();
+			softly.assertThat(path("second").isQualified()).isFalse();
+			softly.assertThat(path("second.third2").isQualified()).isFalse();
+			softly.assertThat(path("secondList.third2").isQualified()).isFalse();
+			softly.assertThat(path("secondList").isQualified()).isTrue();
+		});
+	}
+
+	@Test // GH-1525
+	void isMap() {
+
+		assertSoftly(softly -> {
+
+			softly.assertThat(path().isMap()).isFalse();
+			softly.assertThat(path("second").isMap()).isFalse();
+			softly.assertThat(path("second.third2").isMap()).isFalse();
+			softly.assertThat(path("secondList.third2").isMap()).isFalse();
+			softly.assertThat(path("secondList").isMap()).isFalse();
+			softly.assertThat(path("secondMap.third2").isMap()).isFalse();
+			softly.assertThat(path("secondMap").isMap()).isTrue();
+		});
+	}
+
+	@Test // GH-1525
+	void isCollectionLike() {
+
+		assertSoftly(softly -> {
+
+			softly.assertThat(path().isCollectionLike()).isFalse();
+			softly.assertThat(path("second").isCollectionLike()).isFalse();
+			softly.assertThat(path("second.third2").isCollectionLike()).isFalse();
+			softly.assertThat(path("secondList.third2").isCollectionLike()).isFalse();
+			softly.assertThat(path("secondMap.third2").isCollectionLike()).isFalse();
+			softly.assertThat(path("secondMap").isCollectionLike()).isFalse();
+			softly.assertThat(path("secondList").isCollectionLike()).isTrue();
+		});
+	}
+
+	@Test // GH-1525
+	void isOrdered() {
+
+		assertSoftly(softly -> {
+
+			softly.assertThat(path().isOrdered()).isFalse();
+			softly.assertThat(path("second").isOrdered()).isFalse();
+			softly.assertThat(path("second.third2").isOrdered()).isFalse();
+			softly.assertThat(path("secondList.third2").isOrdered()).isFalse();
+			softly.assertThat(path("secondMap.third2").isOrdered()).isFalse();
+			softly.assertThat(path("secondMap").isOrdered()).isFalse();
+			softly.assertThat(path("secondList").isOrdered()).isTrue();
+		});
+	}
+
+	@Test // GH-1525
+	void getTableAlias() {
+
+		assertSoftly(softly -> {
+
+			softly.assertThat(path().getTableAlias()).isEqualTo(null);
+			softly.assertThat(path("second").getTableAlias()).isEqualTo(quoted("second"));
+			softly.assertThat(path("second.third2").getTableAlias()).isEqualTo(quoted("second"));
+			softly.assertThat(path("second.third2.value").getTableAlias()).isEqualTo(quoted("second"));
+			softly.assertThat(path("second.third").getTableAlias()).isEqualTo(quoted("second_third"));
+			softly.assertThat(path("second.third.value").getTableAlias()).isEqualTo(quoted("second_third"));
+			softly.assertThat(path("secondList.third2").getTableAlias()).isEqualTo(quoted("secondList"));
+			softly.assertThat(path("secondList.third2.value").getTableAlias()).isEqualTo(quoted("secondList"));
+			softly.assertThat(path("secondList.third").getTableAlias()).isEqualTo(quoted("secondList_third"));
+			softly.assertThat(path("secondList.third.value").getTableAlias()).isEqualTo(quoted("secondList_third"));
+			softly.assertThat(path("secondList").getTableAlias()).isEqualTo(quoted("secondList"));
+			softly.assertThat(path("second2.third").getTableAlias()).isEqualTo(quoted("secthird"));
+			softly.assertThat(path("second3.third").getTableAlias()).isEqualTo(quoted("third"));
+		});
+	}
+	@Test // GH-1525
+	void getTableName() {
+
+		assertSoftly(softly -> {
+
+			softly.assertThat(path().getQualifiedTableName()).isEqualTo(quoted("DUMMY_ENTITY"));
+			softly.assertThat(path("second").getQualifiedTableName()).isEqualTo(quoted("SECOND"));
+			softly.assertThat(path("second.third2").getQualifiedTableName()).isEqualTo(quoted("SECOND"));
+			softly.assertThat(path("second.third2.value").getQualifiedTableName()).isEqualTo(quoted("SECOND"));
+			softly.assertThat(path("secondList.third2").getQualifiedTableName()).isEqualTo(quoted("SECOND"));
+			softly.assertThat(path("secondList.third2.value").getQualifiedTableName()).isEqualTo(quoted("SECOND"));
+			softly.assertThat(path("secondList").getQualifiedTableName()).isEqualTo(quoted("SECOND"));
+		});
+	}
+	@Test // GH-1525
+	void getColumnName() {
+
+		assertSoftly(softly -> {
+
+			softly.assertThat(path("second.third2.value").getColumnName()).isEqualTo(quoted("THRDVALUE"));
+			softly.assertThat(path("second.third.value").getColumnName()).isEqualTo(quoted("VALUE"));
+			softly.assertThat(path("secondList.third2.value").getColumnName()).isEqualTo(quoted("THRDVALUE"));
+			softly.assertThat(path("secondList.third.value").getColumnName()).isEqualTo(quoted("VALUE"));
+			softly.assertThat(path("second2.third2.value").getColumnName()).isEqualTo(quoted("SECTHRDVALUE"));
+			softly.assertThat(path("second2.third.value").getColumnName()).isEqualTo(quoted("VALUE"));
+		});
+	}
+
+	@Test // GH-1525
+	void getColumnAlias() {
+
+		assertSoftly(softly -> {
+
+			softly.assertThat(path("second.third2.value").getColumnAlias()).isEqualTo(quoted("SECOND_THRDVALUE"));
+			softly.assertThat(path("second.third.value").getColumnAlias()).isEqualTo(quoted("SECOND_THIRD_VALUE"));
+			softly.assertThat(path("secondList.third2.value").getColumnAlias()).isEqualTo(quoted("SECONDLIST_THRDVALUE"));
+			softly.assertThat(path("secondList.third.value").getColumnAlias()).isEqualTo(quoted("SECONDLIST_THIRD_VALUE"));
+			softly.assertThat(path("second2.third2.value").getColumnAlias()).isEqualTo(quoted("SECTHRDVALUE"));
+			softly.assertThat(path("second2.third.value").getColumnAlias()).isEqualTo(quoted("SECTHIRD_VALUE"));
+		});
+	}
+
+	@Test // GH-1525
+	void getReverseColumnAlias() {
+
+		assertSoftly(softly -> {
+
+			softly.assertThat(path("second.third2.value").getReverseColumnNameAlias()).isEqualTo(quoted("SECOND_DUMMY_ENTITY"));
+			softly.assertThat(path("second.third.value").getReverseColumnNameAlias()).isEqualTo(quoted("SECOND_THIRD_DUMMY_ENTITY"));
+			softly.assertThat(path("secondList.third2.value").getReverseColumnNameAlias()).isEqualTo(quoted("SECONDLIST_DUMMY_ENTITY"));
+			softly.assertThat(path("secondList.third.value").getReverseColumnNameAlias()).isEqualTo(quoted("SECONDLIST_THIRD_DUMMY_ENTITY"));
+			softly.assertThat(path("second2.third2.value").getReverseColumnNameAlias()).isEqualTo(quoted("DUMMY_ENTITY"));
+			softly.assertThat(path("second2.third.value").getReverseColumnNameAlias()).isEqualTo(quoted("SECTHIRD_DUMMY_ENTITY"));
+		});
+	}
+
+	@Test // GH-1525
+	void getRequiredLeafProperty() {
+
+		assertSoftly(softly -> {
+
+			softly.assertThat(path("second.third2.value").getRequiredLeafProperty()).isEqualTo(context.getRequiredPersistentEntity(Third.class).getPersistentProperty("value"));
+			softly.assertThat(path("second.third").getRequiredLeafProperty()).isEqualTo(context.getRequiredPersistentEntity(Second.class).getPersistentProperty("third"));
+			softly.assertThat(path("secondList").getRequiredLeafProperty()).isEqualTo(entity.getPersistentProperty("secondList"));
+			softly.assertThatThrownBy(() -> path().getRequiredLeafProperty()).isInstanceOf(IllegalStateException.class);
+		});
+	}
+
+	@Test // GH-1525
+	void getBaseProperty() {
+
+		assertSoftly(softly -> {
+
+			softly.assertThat(path("second.third2.value").getBaseProperty()).isEqualTo(entity.getPersistentProperty("second"));
+			softly.assertThat(path("second.third.value").getBaseProperty()).isEqualTo(entity.getPersistentProperty("second"));
+			softly.assertThat(path("secondList.third2.value").getBaseProperty()).isEqualTo(entity.getPersistentProperty("secondList"));
+			softly.assertThatThrownBy(() -> path().getBaseProperty()).isInstanceOf(IllegalStateException.class);
+		});
+	}
+
+
+	@Test // GH-1525
+	void getIdColumnName() {
+
+		assertSoftly(softly -> {
+
+			softly.assertThat(path().getIdColumnName()).isEqualTo(quoted("ENTITY_ID"));
+			softly.assertThat(path("withId").getIdColumnName()).isEqualTo(quoted("WITH_ID_ID"));
+
+			softly.assertThatThrownBy(() -> path("second").getIdColumnName()).isInstanceOf(IllegalStateException.class);
+			softly.assertThatThrownBy(() ->path("second.third2").getIdColumnName()).isInstanceOf(IllegalStateException.class);
+			softly.assertThatThrownBy(() ->path("withId.second").getIdColumnName()).isInstanceOf(IllegalStateException.class);
+		});
+	}
+
+	@Test // GH-1525
+	void toDotPath() {
+
+		assertSoftly(softly -> {
+
+			softly.assertThat(path().toDotPath()).isEqualTo("");
+			softly.assertThat(path("second.third.value").toDotPath()).isEqualTo("second.third.value");
+		});
+	}
+
+	@Test // GH-1525
+	void getRequiredPersistentPropertyPath() {
+
+		assertSoftly(softly -> {
+
+			softly.assertThat(path("second.third.value").getRequiredPersistentPropertyPath()).isEqualTo(createSimplePath("second.third.value"));
+			softly.assertThatThrownBy(() -> path().getRequiredPersistentPropertyPath()).isInstanceOf(IllegalStateException.class);
+		});
+	}
+
+	@Test // GH-1525
+	void getEffectiveIdColumnName() {
+
+		assertSoftly(softly -> {
+
+			softly.assertThat(path().getEffectiveIdColumnName()).isEqualTo(quoted("ENTITY_ID"));
+			softly.assertThat(path("second.third2").getEffectiveIdColumnName()).isEqualTo(quoted("DUMMY_ENTITY"));
+			softly.assertThat(path("withId.second.third").getEffectiveIdColumnName()).isEqualTo(quoted("WITH_ID"));
+			softly.assertThat(path("withId.second.third2.value").getEffectiveIdColumnName()).isEqualTo(quoted("WITH_ID"));
+		});
+	}
+
+	@Test // GH-1525
+	void getLength() {
+
+		assertSoftly(softly -> {
+
+			softly.assertThat(path().getLength()).isEqualTo(0);
+			softly.assertThat(path("second.third2").getLength()).isEqualTo(2);
+			softly.assertThat(path("withId.second.third").getLength()).isEqualTo(3);
+			softly.assertThat(path("withId.second.third2.value").getLength()).isEqualTo(4);
+		});
+	}
+
+	@Test // GH-1525
+	void matches() {
+
+		assertSoftly(softly -> {
+
+			softly.assertThat(path().matches(createSimplePath("second").getParentPath())).isTrue();
+			softly.assertThat(path().matches(createSimplePath("second"))).isFalse();
+			softly.assertThat(path("withId.second.third").matches(createSimplePath("withId.second.third"))).isTrue();
+			softly.assertThat(path("withId.second.third").matches(createSimplePath("withId.second.third2.value"))).isFalse();
+		});
+	}
+
+	private AggregatePath path() {
+		return context.getAggregatePath(entity);
+	}
+
+	private AggregatePath path(String path) {
+		return context.getAggregatePath(createSimplePath(path));
+	}
+
+	PersistentPropertyPath<RelationalPersistentProperty> createSimplePath(String path) {
+		return PersistentPropertyPathTestUtils.getPath(context, path, DummyEntity.class);
+	}
+
+	@SuppressWarnings("unused")
+	static class DummyEntity {
+		@Id Long entityId;
+		@ReadOnlyProperty Second second;
+		@Embedded(onEmpty = Embedded.OnEmpty.USE_NULL, prefix = "sec") Second second2;
+		@Embedded(onEmpty = Embedded.OnEmpty.USE_NULL) Second second3;
+		List<Second> secondList;
+		Map<String, Second> secondMap;
+		WithId withId;
+	}
+
+	@SuppressWarnings("unused")
+	static class Second {
+		Third third;
+		@Embedded(onEmpty = Embedded.OnEmpty.USE_NULL, prefix = "thrd") Third third2;
+	}
+
+	@SuppressWarnings("unused")
+	static class Third {
+		String value;
+	}
+
+	@SuppressWarnings("unused")
+	static class WithId {
+		@Id Long withIdId;
+		Second second;
+		@Embedded(onEmpty = Embedded.OnEmpty.USE_NULL, prefix = "sec") Second second2;
+	}
+
+}

--- a/spring-data-relational/src/test/java/org/springframework/data/relational/core/mapping/AggregatePathUnitTests.java
+++ b/spring-data-relational/src/test/java/org/springframework/data/relational/core/mapping/AggregatePathUnitTests.java
@@ -92,14 +92,14 @@ class AggregatePathUnitTests {
 
 		assertSoftly(softly -> {
 
-			softly.assertThat(path("second.third2.value").getIdDefiningParentPath()).isEqualTo(path());
-			softly.assertThat(path("second.third.value").getIdDefiningParentPath()).isEqualTo(path());
-			softly.assertThat(path("secondList.third2.value").getIdDefiningParentPath()).isEqualTo(path());
-			softly.assertThat(path("secondList.third.value").getIdDefiningParentPath()).isEqualTo(path());
-			softly.assertThat(path("second2.third2.value").getIdDefiningParentPath()).isEqualTo(path());
-			softly.assertThat(path("second2.third.value").getIdDefiningParentPath()).isEqualTo(path());
-			softly.assertThat(path("withId.second.third2.value").getIdDefiningParentPath()).isEqualTo(path("withId"));
-			softly.assertThat(path("withId.second.third.value").getIdDefiningParentPath()).isEqualTo(path("withId"));
+			softly.assertThat(AggregatePathUtil.getIdDefiningParentPath(path("second.third2.value"))).isEqualTo(path());
+			softly.assertThat(AggregatePathUtil.getIdDefiningParentPath(path("second.third.value"))).isEqualTo(path());
+			softly.assertThat(AggregatePathUtil.getIdDefiningParentPath(path("secondList.third2.value"))).isEqualTo(path());
+			softly.assertThat(AggregatePathUtil.getIdDefiningParentPath(path("secondList.third.value"))).isEqualTo(path());
+			softly.assertThat(AggregatePathUtil.getIdDefiningParentPath(path("second2.third2.value"))).isEqualTo(path());
+			softly.assertThat(AggregatePathUtil.getIdDefiningParentPath(path("second2.third.value"))).isEqualTo(path());
+			softly.assertThat(AggregatePathUtil.getIdDefiningParentPath(path("withId.second.third2.value"))).isEqualTo(path("withId"));
+			softly.assertThat(AggregatePathUtil.getIdDefiningParentPath(path("withId.second.third.value"))).isEqualTo(path("withId"));
 		});
 	}
 
@@ -119,15 +119,15 @@ class AggregatePathUnitTests {
 
 		assertSoftly(softly -> {
 
-			softly.assertThat(path("second.third2").getReverseColumnName()).isEqualTo(quoted("DUMMY_ENTITY"));
-			softly.assertThat(path("second.third").getReverseColumnName()).isEqualTo(quoted("DUMMY_ENTITY"));
-			softly.assertThat(path("secondList.third2").getReverseColumnName()).isEqualTo(quoted("DUMMY_ENTITY"));
-			softly.assertThat(path("secondList.third").getReverseColumnName()).isEqualTo(quoted("DUMMY_ENTITY"));
-			softly.assertThat(path("second2.third2").getReverseColumnName()).isEqualTo(quoted("DUMMY_ENTITY"));
-			softly.assertThat(path("second2.third").getReverseColumnName()).isEqualTo(quoted("DUMMY_ENTITY"));
-			softly.assertThat(path("withId.second.third2.value").getReverseColumnName()).isEqualTo(quoted("WITH_ID"));
-			softly.assertThat(path("withId.second.third").getReverseColumnName()).isEqualTo(quoted("WITH_ID"));
-			softly.assertThat(path("withId.second2.third").getReverseColumnName()).isEqualTo(quoted("WITH_ID"));
+			softly.assertThat(AggregatePathUtil.getReverseColumnName(path("second.third2"))).isEqualTo(quoted("DUMMY_ENTITY"));
+			softly.assertThat(AggregatePathUtil.getReverseColumnName(path("second.third"))).isEqualTo(quoted("DUMMY_ENTITY"));
+			softly.assertThat(AggregatePathUtil.getReverseColumnName(path("secondList.third2"))).isEqualTo(quoted("DUMMY_ENTITY"));
+			softly.assertThat(AggregatePathUtil.getReverseColumnName(path("secondList.third"))).isEqualTo(quoted("DUMMY_ENTITY"));
+			softly.assertThat(AggregatePathUtil.getReverseColumnName(path("second2.third2"))).isEqualTo(quoted("DUMMY_ENTITY"));
+			softly.assertThat(AggregatePathUtil.getReverseColumnName(path("second2.third"))).isEqualTo(quoted("DUMMY_ENTITY"));
+			softly.assertThat(AggregatePathUtil.getReverseColumnName(path("withId.second.third2.value"))).isEqualTo(quoted("WITH_ID"));
+			softly.assertThat(AggregatePathUtil.getReverseColumnName(path("withId.second.third"))).isEqualTo(quoted("WITH_ID"));
+			softly.assertThat(AggregatePathUtil.getReverseColumnName(path("withId.second2.third"))).isEqualTo(quoted("WITH_ID"));
 		});
 	}
 
@@ -136,10 +136,10 @@ class AggregatePathUnitTests {
 
 		assertSoftly(softly -> {
 
-			softly.assertThat(path().getQualifierColumn()).isEqualTo(null);
-			softly.assertThat(path("second.third").getQualifierColumn()).isEqualTo(null);
-			softly.assertThat(path("secondList.third2").getQualifierColumn()).isEqualTo(null);
-			softly.assertThat(path("secondList").getQualifierColumn()).isEqualTo(SqlIdentifier.quoted("DUMMY_ENTITY_KEY"));
+			softly.assertThat(AggregatePathUtil.getQualifierColumn(path())).isEqualTo(null);
+			softly.assertThat(AggregatePathUtil.getQualifierColumn(path("second.third"))).isEqualTo(null);
+			softly.assertThat(AggregatePathUtil.getQualifierColumn(path("secondList.third2"))).isEqualTo(null);
+			softly.assertThat(AggregatePathUtil.getQualifierColumn(path("secondList"))).isEqualTo(SqlIdentifier.quoted("DUMMY_ENTITY_KEY"));
 
 		});
 	}
@@ -149,10 +149,10 @@ class AggregatePathUnitTests {
 
 		assertSoftly(softly -> {
 
-			softly.assertThat(path().getQualifierColumnType()).isEqualTo(null);
-			softly.assertThat(path("second.third").getQualifierColumnType()).isEqualTo(null);
-			softly.assertThat(path("secondList.third2").getQualifierColumnType()).isEqualTo(null);
-			softly.assertThat(path("secondList").getQualifierColumnType()).isEqualTo(Integer.class);
+			softly.assertThat(AggregatePathUtil.getQualifierColumnType(path())).isEqualTo(null);
+			softly.assertThat(AggregatePathUtil.getQualifierColumnType(path("second.third"))).isEqualTo(null);
+			softly.assertThat(AggregatePathUtil.getQualifierColumnType(path("secondList.third2"))).isEqualTo(null);
+			softly.assertThat(AggregatePathUtil.getQualifierColumnType(path("secondList"))).isEqualTo(Integer.class);
 
 		});
 	}
@@ -287,19 +287,19 @@ class AggregatePathUnitTests {
 
 		assertSoftly(softly -> {
 
-			softly.assertThat(path().getTableAlias()).isEqualTo(null);
-			softly.assertThat(path("second").getTableAlias()).isEqualTo(quoted("second"));
-			softly.assertThat(path("second.third2").getTableAlias()).isEqualTo(quoted("second"));
-			softly.assertThat(path("second.third2.value").getTableAlias()).isEqualTo(quoted("second"));
-			softly.assertThat(path("second.third").getTableAlias()).isEqualTo(quoted("second_third"));
-			softly.assertThat(path("second.third.value").getTableAlias()).isEqualTo(quoted("second_third"));
-			softly.assertThat(path("secondList.third2").getTableAlias()).isEqualTo(quoted("secondList"));
-			softly.assertThat(path("secondList.third2.value").getTableAlias()).isEqualTo(quoted("secondList"));
-			softly.assertThat(path("secondList.third").getTableAlias()).isEqualTo(quoted("secondList_third"));
-			softly.assertThat(path("secondList.third.value").getTableAlias()).isEqualTo(quoted("secondList_third"));
-			softly.assertThat(path("secondList").getTableAlias()).isEqualTo(quoted("secondList"));
-			softly.assertThat(path("second2.third").getTableAlias()).isEqualTo(quoted("secthird"));
-			softly.assertThat(path("second3.third").getTableAlias()).isEqualTo(quoted("third"));
+			softly.assertThat(AggregatePathUtil.getTableAlias(path())).isEqualTo(null);
+			softly.assertThat(AggregatePathUtil.getTableAlias(path("second"))).isEqualTo(quoted("second"));
+			softly.assertThat(AggregatePathUtil.getTableAlias(path("second.third2"))).isEqualTo(quoted("second"));
+			softly.assertThat(AggregatePathUtil.getTableAlias(path("second.third2.value"))).isEqualTo(quoted("second"));
+			softly.assertThat(AggregatePathUtil.getTableAlias(path("second.third"))).isEqualTo(quoted("second_third"));
+			softly.assertThat(AggregatePathUtil.getTableAlias(path("second.third.value"))).isEqualTo(quoted("second_third"));
+			softly.assertThat(AggregatePathUtil.getTableAlias(path("secondList.third2"))).isEqualTo(quoted("secondList"));
+			softly.assertThat(AggregatePathUtil.getTableAlias(path("secondList.third2.value"))).isEqualTo(quoted("secondList"));
+			softly.assertThat(AggregatePathUtil.getTableAlias(path("secondList.third"))).isEqualTo(quoted("secondList_third"));
+			softly.assertThat(AggregatePathUtil.getTableAlias(path("secondList.third.value"))).isEqualTo(quoted("secondList_third"));
+			softly.assertThat(AggregatePathUtil.getTableAlias(path("secondList"))).isEqualTo(quoted("secondList"));
+			softly.assertThat(AggregatePathUtil.getTableAlias(path("second2.third"))).isEqualTo(quoted("secthird"));
+			softly.assertThat(AggregatePathUtil.getTableAlias(path("second3.third"))).isEqualTo(quoted("third"));
 		});
 	}
 	@Test // GH-1525
@@ -307,13 +307,13 @@ class AggregatePathUnitTests {
 
 		assertSoftly(softly -> {
 
-			softly.assertThat(path().getQualifiedTableName()).isEqualTo(quoted("DUMMY_ENTITY"));
-			softly.assertThat(path("second").getQualifiedTableName()).isEqualTo(quoted("SECOND"));
-			softly.assertThat(path("second.third2").getQualifiedTableName()).isEqualTo(quoted("SECOND"));
-			softly.assertThat(path("second.third2.value").getQualifiedTableName()).isEqualTo(quoted("SECOND"));
-			softly.assertThat(path("secondList.third2").getQualifiedTableName()).isEqualTo(quoted("SECOND"));
-			softly.assertThat(path("secondList.third2.value").getQualifiedTableName()).isEqualTo(quoted("SECOND"));
-			softly.assertThat(path("secondList").getQualifiedTableName()).isEqualTo(quoted("SECOND"));
+			softly.assertThat(AggregatePathUtil.getQualifiedTableName(path())).isEqualTo(quoted("DUMMY_ENTITY"));
+			softly.assertThat(AggregatePathUtil.getQualifiedTableName(path("second"))).isEqualTo(quoted("SECOND"));
+			softly.assertThat(AggregatePathUtil.getQualifiedTableName(path("second.third2"))).isEqualTo(quoted("SECOND"));
+			softly.assertThat(AggregatePathUtil.getQualifiedTableName(path("second.third2.value"))).isEqualTo(quoted("SECOND"));
+			softly.assertThat(AggregatePathUtil.getQualifiedTableName(path("secondList.third2"))).isEqualTo(quoted("SECOND"));
+			softly.assertThat(AggregatePathUtil.getQualifiedTableName(path("secondList.third2.value"))).isEqualTo(quoted("SECOND"));
+			softly.assertThat(AggregatePathUtil.getQualifiedTableName(path("secondList"))).isEqualTo(quoted("SECOND"));
 		});
 	}
 	@Test // GH-1525
@@ -321,12 +321,12 @@ class AggregatePathUnitTests {
 
 		assertSoftly(softly -> {
 
-			softly.assertThat(path("second.third2.value").getColumnName()).isEqualTo(quoted("THRDVALUE"));
-			softly.assertThat(path("second.third.value").getColumnName()).isEqualTo(quoted("VALUE"));
-			softly.assertThat(path("secondList.third2.value").getColumnName()).isEqualTo(quoted("THRDVALUE"));
-			softly.assertThat(path("secondList.third.value").getColumnName()).isEqualTo(quoted("VALUE"));
-			softly.assertThat(path("second2.third2.value").getColumnName()).isEqualTo(quoted("SECTHRDVALUE"));
-			softly.assertThat(path("second2.third.value").getColumnName()).isEqualTo(quoted("VALUE"));
+			softly.assertThat(AggregatePathUtil.getColumnName(path("second.third2.value"))).isEqualTo(quoted("THRDVALUE"));
+			softly.assertThat(AggregatePathUtil.getColumnName(path("second.third.value"))).isEqualTo(quoted("VALUE"));
+			softly.assertThat(AggregatePathUtil.getColumnName(path("secondList.third2.value"))).isEqualTo(quoted("THRDVALUE"));
+			softly.assertThat(AggregatePathUtil.getColumnName(path("secondList.third.value"))).isEqualTo(quoted("VALUE"));
+			softly.assertThat(AggregatePathUtil.getColumnName(path("second2.third2.value"))).isEqualTo(quoted("SECTHRDVALUE"));
+			softly.assertThat(AggregatePathUtil.getColumnName(path("second2.third.value"))).isEqualTo(quoted("VALUE"));
 		});
 	}
 
@@ -335,12 +335,12 @@ class AggregatePathUnitTests {
 
 		assertSoftly(softly -> {
 
-			softly.assertThat(path("second.third2.value").getColumnAlias()).isEqualTo(quoted("SECOND_THRDVALUE"));
-			softly.assertThat(path("second.third.value").getColumnAlias()).isEqualTo(quoted("SECOND_THIRD_VALUE"));
-			softly.assertThat(path("secondList.third2.value").getColumnAlias()).isEqualTo(quoted("SECONDLIST_THRDVALUE"));
-			softly.assertThat(path("secondList.third.value").getColumnAlias()).isEqualTo(quoted("SECONDLIST_THIRD_VALUE"));
-			softly.assertThat(path("second2.third2.value").getColumnAlias()).isEqualTo(quoted("SECTHRDVALUE"));
-			softly.assertThat(path("second2.third.value").getColumnAlias()).isEqualTo(quoted("SECTHIRD_VALUE"));
+			softly.assertThat(AggregatePathUtil.getColumnAlias(path("second.third2.value"))).isEqualTo(quoted("SECOND_THRDVALUE"));
+			softly.assertThat(AggregatePathUtil.getColumnAlias(path("second.third.value"))).isEqualTo(quoted("SECOND_THIRD_VALUE"));
+			softly.assertThat(AggregatePathUtil.getColumnAlias(path("secondList.third2.value"))).isEqualTo(quoted("SECONDLIST_THRDVALUE"));
+			softly.assertThat(AggregatePathUtil.getColumnAlias(path("secondList.third.value"))).isEqualTo(quoted("SECONDLIST_THIRD_VALUE"));
+			softly.assertThat(AggregatePathUtil.getColumnAlias(path("second2.third2.value"))).isEqualTo(quoted("SECTHRDVALUE"));
+			softly.assertThat(AggregatePathUtil.getColumnAlias(path("second2.third.value"))).isEqualTo(quoted("SECTHIRD_VALUE"));
 		});
 	}
 
@@ -349,12 +349,12 @@ class AggregatePathUnitTests {
 
 		assertSoftly(softly -> {
 
-			softly.assertThat(path("second.third2.value").getReverseColumnNameAlias()).isEqualTo(quoted("SECOND_DUMMY_ENTITY"));
-			softly.assertThat(path("second.third.value").getReverseColumnNameAlias()).isEqualTo(quoted("SECOND_THIRD_DUMMY_ENTITY"));
-			softly.assertThat(path("secondList.third2.value").getReverseColumnNameAlias()).isEqualTo(quoted("SECONDLIST_DUMMY_ENTITY"));
-			softly.assertThat(path("secondList.third.value").getReverseColumnNameAlias()).isEqualTo(quoted("SECONDLIST_THIRD_DUMMY_ENTITY"));
-			softly.assertThat(path("second2.third2.value").getReverseColumnNameAlias()).isEqualTo(quoted("DUMMY_ENTITY"));
-			softly.assertThat(path("second2.third.value").getReverseColumnNameAlias()).isEqualTo(quoted("SECTHIRD_DUMMY_ENTITY"));
+			softly.assertThat(AggregatePathUtil.getReverseColumnNameAlias(path("second.third2.value"))).isEqualTo(quoted("SECOND_DUMMY_ENTITY"));
+			softly.assertThat(AggregatePathUtil.getReverseColumnNameAlias(path("second.third.value"))).isEqualTo(quoted("SECOND_THIRD_DUMMY_ENTITY"));
+			softly.assertThat(AggregatePathUtil.getReverseColumnNameAlias(path("secondList.third2.value"))).isEqualTo(quoted("SECONDLIST_DUMMY_ENTITY"));
+			softly.assertThat(AggregatePathUtil.getReverseColumnNameAlias(path("secondList.third.value"))).isEqualTo(quoted("SECONDLIST_THIRD_DUMMY_ENTITY"));
+			softly.assertThat(AggregatePathUtil.getReverseColumnNameAlias(path("second2.third2.value"))).isEqualTo(quoted("DUMMY_ENTITY"));
+			softly.assertThat(AggregatePathUtil.getReverseColumnNameAlias(path("second2.third.value"))).isEqualTo(quoted("SECTHIRD_DUMMY_ENTITY"));
 		});
 	}
 
@@ -388,12 +388,12 @@ class AggregatePathUnitTests {
 
 		assertSoftly(softly -> {
 
-			softly.assertThat(path().getIdColumnName()).isEqualTo(quoted("ENTITY_ID"));
-			softly.assertThat(path("withId").getIdColumnName()).isEqualTo(quoted("WITH_ID_ID"));
+			softly.assertThat(AggregatePathUtil.getIdColumnName(path())).isEqualTo(quoted("ENTITY_ID"));
+			softly.assertThat(AggregatePathUtil.getIdColumnName(path("withId"))).isEqualTo(quoted("WITH_ID_ID"));
 
-			softly.assertThatThrownBy(() -> path("second").getIdColumnName()).isInstanceOf(IllegalStateException.class);
-			softly.assertThatThrownBy(() ->path("second.third2").getIdColumnName()).isInstanceOf(IllegalStateException.class);
-			softly.assertThatThrownBy(() ->path("withId.second").getIdColumnName()).isInstanceOf(IllegalStateException.class);
+			softly.assertThatThrownBy(() -> AggregatePathUtil.getIdColumnName(path("second"))).isInstanceOf(IllegalStateException.class);
+			softly.assertThatThrownBy(() ->AggregatePathUtil.getIdColumnName(path("second.third2"))).isInstanceOf(IllegalStateException.class);
+			softly.assertThatThrownBy(() ->AggregatePathUtil.getIdColumnName(path("withId.second"))).isInstanceOf(IllegalStateException.class);
 		});
 	}
 
@@ -422,10 +422,10 @@ class AggregatePathUnitTests {
 
 		assertSoftly(softly -> {
 
-			softly.assertThat(path().getEffectiveIdColumnName()).isEqualTo(quoted("ENTITY_ID"));
-			softly.assertThat(path("second.third2").getEffectiveIdColumnName()).isEqualTo(quoted("DUMMY_ENTITY"));
-			softly.assertThat(path("withId.second.third").getEffectiveIdColumnName()).isEqualTo(quoted("WITH_ID"));
-			softly.assertThat(path("withId.second.third2.value").getEffectiveIdColumnName()).isEqualTo(quoted("WITH_ID"));
+			softly.assertThat(AggregatePathUtil.getEffectiveIdColumnName(path())).isEqualTo(quoted("ENTITY_ID"));
+			softly.assertThat(AggregatePathUtil.getEffectiveIdColumnName(path("second.third2"))).isEqualTo(quoted("DUMMY_ENTITY"));
+			softly.assertThat(AggregatePathUtil.getEffectiveIdColumnName(path("withId.second.third"))).isEqualTo(quoted("WITH_ID"));
+			softly.assertThat(AggregatePathUtil.getEffectiveIdColumnName(path("withId.second.third2.value"))).isEqualTo(quoted("WITH_ID"));
 		});
 	}
 

--- a/spring-data-relational/src/test/java/org/springframework/data/relational/core/mapping/BasicRelationalPersistentPropertyUnitTests.java
+++ b/spring-data-relational/src/test/java/org/springframework/data/relational/core/mapping/BasicRelationalPersistentPropertyUnitTests.java
@@ -64,7 +64,7 @@ public class BasicRelationalPersistentPropertyUnitTests {
 				.findPersistentPropertyPaths(DummyEntity.class, p -> p.getName().equals("someList")).getFirst()
 				.orElseThrow(() -> new AssertionFailedError("Couldn't find path for 'someList'"));
 
-		assertThat(listProperty.getReverseColumnName(new PersistentPropertyPathExtension(context, path)))
+		assertThat(listProperty.getReverseColumnName(context.getAggregatePath(path)))
 				.isEqualTo(quoted("dummy_column_name"));
 		assertThat(listProperty.getKeyColumn()).isEqualTo(quoted("dummy_key_column_name"));
 	}
@@ -89,7 +89,6 @@ public class BasicRelationalPersistentPropertyUnitTests {
 		RelationalPersistentProperty property = entity.getRequiredPersistentProperty("someList");
 
 		assertThat(property.getKeyColumn()).isEqualTo(quoted("key_col"));
-		assertThat(property.getReverseColumnName(null)).isEqualTo(quoted("id_col"));
 	}
 
 	@Test // DATAJDBC-111

--- a/spring-data-relational/src/test/java/org/springframework/data/relational/core/mapping/PersistentPropertyPathTestUtils.java
+++ b/spring-data-relational/src/test/java/org/springframework/data/relational/core/mapping/PersistentPropertyPathTestUtils.java
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.jdbc.core.mapping;
+package org.springframework.data.relational.core.mapping;
 
 import lombok.experimental.UtilityClass;
 
 import org.springframework.data.mapping.PersistentPropertyPath;
+import org.springframework.data.mapping.PersistentPropertyPaths;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
 
@@ -30,10 +31,14 @@ public class PersistentPropertyPathTestUtils {
 	public static PersistentPropertyPath<RelationalPersistentProperty> getPath(RelationalMappingContext context,
 			String path, Class<?> baseType) {
 
-		return context.findPersistentPropertyPaths(baseType, p -> p.isEntity()) //
-				.filter(p -> p.toDotPath().equals(path)) //
-				.stream() //
-				.findFirst() //
-				.orElseThrow(() -> new IllegalArgumentException(String.format("No path for %s based on %s", path, baseType)));
+		PersistentPropertyPaths<?, RelationalPersistentProperty> persistentPropertyPaths = context
+				.findPersistentPropertyPaths(baseType, p -> true);
+
+		return persistentPropertyPaths
+				.filter(p -> p.toDotPath().equals(path))
+				.stream()
+				.findFirst()
+				.orElse(null);
+
 	}
 }


### PR DESCRIPTION
`AggregatePath` replaces `PersistentPropertyPathExtension`.
It gets created and cached by the `RelationalMappingContext`, which should be more efficient and certainly looks nicer.

Closes https://github.com/spring-projects/spring-data-relational/issues/1525