### PR TITLE
Allow query methods get multiple parameters from Map or JavaBean and add them to the SqlParameterSource.

### DIFF
--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/Multiparameter.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/Multiparameter.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jdbc.repository.query;
+
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates a method parameter, which may be a Map or JavaBean,
+ * should be regarded as multiple parameters and added to the {@link SqlParameterSource}.
+ *
+ * @author Zhou Xingyi
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Multiparameter {
+}


### PR DESCRIPTION
Hi, I submitted this PR to allow query methods get multiple parameters from Map or JavaBean and add them to the SqlParameterSource.

Since the Parameter does not provide a method to determine whether the parameter is declared with the given annotation type, I have to do it using reflection. I think it would be better if the Parameter provided more methods, such as "hasParameterAnnotation", etc.