### PR TITLE
Fix links to spring.io docs

### DIFF
--- a/spring-data-r2dbc/src/main/asciidoc/preface.adoc
+++ b/spring-data-r2dbc/src/main/asciidoc/preface.adoc
@@ -28,7 +28,7 @@ To use all the features of Spring Data R2DBC, such as the repository support, yo
 
 To learn more about Spring, refer to the comprehensive documentation that explains the Spring Framework in detail.
 There are a lot of articles, blog entries, and books on the subject.
-See the Spring framework https://spring.io/docs[home page] for more information.
+See the Spring framework https://spring.io[home page] for more information.
 
 [[get-started:first-steps:what]]
 == What is R2DBC?
@@ -82,7 +82,7 @@ Whenever feasible, Spring Data adapts transparently to the use of RxJava or anot
 The Spring Data R2DBC 3.x binaries require:
 
 * JDK level 17 and above
-* https://spring.io/docs[Spring Framework] {springVersion} and above
+* {spring-framework-ref}[Spring Framework] {springVersion} and above
 * https://r2dbc.io[R2DBC] {r2dbcVersion} and above
 
 [[get-started:help]]

--- a/src/main/asciidoc/preface.adoc
+++ b/src/main/asciidoc/preface.adoc
@@ -30,12 +30,12 @@ To leverage all the features of Spring Data JDBC, such as the repository support
 
 To learn more about Spring, you can refer to the comprehensive documentation that explains the Spring Framework in detail.
 There are a lot of articles, blog entries, and books on the subject.
-See the Spring framework https://spring.io/docs[home page] for more information.
+See the Spring framework https://spring.io[home page] for more information.
 
 [[requirements]]
 == Requirements
 
-The Spring Data JDBC binaries require JDK level 8.0 and above and https://spring.io/docs[Spring Framework] {springVersion} and above.
+The Spring Data JDBC binaries require JDK level 8.0 and above and {spring-framework-docs}[Spring Framework] {springVersion} and above.
 
 In terms of databases, Spring Data JDBC requires a <<jdbc.dialects,dialect>> to abstract common SQL functionality over vendor-specific flavours.
 Spring Data JDBC includes direct support for the following databases:


### PR DESCRIPTION
The documentation contained broken links. All the links to _spring.io/docs_ led to a 404 page.
When replacing the links, a question arose: should I simply change them to _docs.spring.io_ or is it better to use more meaningful ones, considering that _docs.spring.io_ simply redirects to _spring.io_, so tried to replace it with more relevant ones