### PR TITLE
Remove an extra level in the class hierarchy

### DIFF
--- a/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/convert/R2dbcConverters.java
+++ b/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/convert/R2dbcConverters.java
@@ -30,10 +30,6 @@ import java.util.UUID;
 
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.convert.converter.ConverterFactory;
-import org.springframework.data.r2dbc.convert.R2dbcConverters.RowToNumberConverterFactory.RowToOffsetDateTimeConverter;
-import org.springframework.data.r2dbc.convert.R2dbcConverters.RowToNumberConverterFactory.RowToStringConverter;
-import org.springframework.data.r2dbc.convert.R2dbcConverters.RowToNumberConverterFactory.RowToUuidConverter;
-import org.springframework.data.r2dbc.convert.R2dbcConverters.RowToNumberConverterFactory.RowToZonedDateTimeConverter;
 import org.springframework.util.Assert;
 import org.springframework.util.NumberUtils;
 
@@ -42,6 +38,7 @@ import org.springframework.util.NumberUtils;
  *
  * @author Hebert Coelho
  * @author Mark Paluch
+ * @author Valeriy Vyrva
  */
 abstract class R2dbcConverters {
 
@@ -169,66 +166,66 @@ abstract class R2dbcConverters {
 				return (object != null ? NumberUtils.convertNumberToTargetClass((Number) object, this.targetType) : null);
 			}
 		}
-
-		/**
-		 * Simple singleton to convert {@link Row}s to their {@link OffsetDateTime} representation.
-		 *
-		 * @author Hebert Coelho
-		 */
-		public enum RowToOffsetDateTimeConverter implements Converter<Row, OffsetDateTime> {
-
-			INSTANCE;
-
-			@Override
-			public OffsetDateTime convert(Row row) {
-				return row.get(0, OffsetDateTime.class);
-			}
-		}
-
-		/**
-		 * Simple singleton to convert {@link Row}s to their {@link String} representation.
-		 *
-		 * @author Hebert Coelho
-		 */
-		public enum RowToStringConverter implements Converter<Row, String> {
-
-			INSTANCE;
-
-			@Override
-			public String convert(Row row) {
-				return row.get(0, String.class);
-			}
-		}
-
-		/**
-		 * Simple singleton to convert {@link Row}s to their {@link UUID} representation.
-		 *
-		 * @author Hebert Coelho
-		 */
-		public enum RowToUuidConverter implements Converter<Row, UUID> {
-
-			INSTANCE;
-
-			@Override
-			public UUID convert(Row row) {
-				return row.get(0, UUID.class);
-			}
-		}
-
-		/**
-		 * Simple singleton to convert {@link Row}s to their {@link ZonedDateTime} representation.
-		 *
-		 * @author Hebert Coelho
-		 */
-		public enum RowToZonedDateTimeConverter implements Converter<Row, ZonedDateTime> {
-
-			INSTANCE;
-
-			@Override
-			public ZonedDateTime convert(Row row) {
-				return row.get(0, ZonedDateTime.class);
-			}
-		}
-
 	}
+
+	/**
+	 * Simple singleton to convert {@link Row}s to their {@link OffsetDateTime} representation.
+	 *
+	 * @author Hebert Coelho
+	 */
+	public enum RowToOffsetDateTimeConverter implements Converter<Row, OffsetDateTime> {
+
+		INSTANCE;
+
+		@Override
+		public OffsetDateTime convert(Row row) {
+			return row.get(0, OffsetDateTime.class);
+		}
+	}
+
+	/**
+	 * Simple singleton to convert {@link Row}s to their {@link String} representation.
+	 *
+	 * @author Hebert Coelho
+	 */
+	public enum RowToStringConverter implements Converter<Row, String> {
+
+		INSTANCE;
+
+		@Override
+		public String convert(Row row) {
+			return row.get(0, String.class);
+		}
+	}
+
+	/**
+	 * Simple singleton to convert {@link Row}s to their {@link UUID} representation.
+	 *
+	 * @author Hebert Coelho
+	 */
+	public enum RowToUuidConverter implements Converter<Row, UUID> {
+
+		INSTANCE;
+
+		@Override
+		public UUID convert(Row row) {
+			return row.get(0, UUID.class);
+		}
+	}
+
+	/**
+	 * Simple singleton to convert {@link Row}s to their {@link ZonedDateTime} representation.
+	 *
+	 * @author Hebert Coelho
+	 */
+	public enum RowToZonedDateTimeConverter implements Converter<Row, ZonedDateTime> {
+
+		INSTANCE;
+
+		@Override
+		public ZonedDateTime convert(Row row) {
+			return row.get(0, ZonedDateTime.class);
+		}
+	}
+
 }

--- a/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/convert/R2dbcConvertersUnitTests.java
+++ b/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/convert/R2dbcConvertersUnitTests.java
@@ -35,16 +35,17 @@ import org.springframework.data.r2dbc.convert.R2dbcConverters.RowToLocalDateConv
 import org.springframework.data.r2dbc.convert.R2dbcConverters.RowToLocalDateTimeConverter;
 import org.springframework.data.r2dbc.convert.R2dbcConverters.RowToLocalTimeConverter;
 import org.springframework.data.r2dbc.convert.R2dbcConverters.RowToNumberConverterFactory;
-import org.springframework.data.r2dbc.convert.R2dbcConverters.RowToNumberConverterFactory.RowToOffsetDateTimeConverter;
-import org.springframework.data.r2dbc.convert.R2dbcConverters.RowToNumberConverterFactory.RowToStringConverter;
-import org.springframework.data.r2dbc.convert.R2dbcConverters.RowToNumberConverterFactory.RowToUuidConverter;
-import org.springframework.data.r2dbc.convert.R2dbcConverters.RowToNumberConverterFactory.RowToZonedDateTimeConverter;
+import org.springframework.data.r2dbc.convert.R2dbcConverters.RowToOffsetDateTimeConverter;
+import org.springframework.data.r2dbc.convert.R2dbcConverters.RowToStringConverter;
+import org.springframework.data.r2dbc.convert.R2dbcConverters.RowToUuidConverter;
+import org.springframework.data.r2dbc.convert.R2dbcConverters.RowToZonedDateTimeConverter;
 
 /**
  * Unit tests for {@link R2dbcConverters}.
  *
  * @author Hebert Coelho
  * @author Mark Paluch
+ * @author Valeriy Vyrva
  */
 public class R2dbcConvertersUnitTests {
 


### PR DESCRIPTION
Simplify class hierarchy by moving `RowToOffsetDateTimeConverter`, `RowToStringConverter`, `RowToUuidConverter` and `RowToZonedDateTimeConverter` out of `RowToNumberConverterFactory` class.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
