### PR TITLE
Replace BatchJdbcOperations with standard NamedParameterJdbcOperations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-relational-parent</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-deprecate-batch-jdbc-operations-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Relational Parent</name>
@@ -47,6 +47,8 @@
 		<!-- test utilities-->
 		<awaitility.version>4.2.0</awaitility.version>
 		<archunit.version>1.0.1</archunit.version>
+
+		<spring>6.1.0-SNAPSHOT</spring>
 	</properties>
 
 	<inceptionYear>2017</inceptionYear>

--- a/spring-data-jdbc-distribution/pom.xml
+++ b/spring-data-jdbc-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-deprecate-batch-jdbc-operations-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-jdbc</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-deprecate-batch-jdbc-operations-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-deprecate-batch-jdbc-operations-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/BatchJdbcOperations.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/BatchJdbcOperations.java
@@ -44,7 +44,9 @@ import org.springframework.util.Assert;
  *
  * @author Chirag Tailor
  * @since 2.4
+ * @deprecated Use the standard {@link org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations} instead.
  */
+@Deprecated(since = "3.2")
 public class BatchJdbcOperations {
 
 	private final JdbcOperations jdbcOperations;

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/IdGeneratingBatchInsertStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/IdGeneratingBatchInsertStrategy.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import org.springframework.data.relational.core.dialect.Dialect;
 import org.springframework.data.relational.core.dialect.IdGeneration;
 import org.springframework.data.relational.core.sql.SqlIdentifier;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.lang.Nullable;
@@ -33,21 +34,23 @@ import org.springframework.lang.Nullable;
  *
  * @author Chirag Tailor
  * @author Kurt Niemi
+ * @author Jens Schauder
  * @since 2.4
  */
 class IdGeneratingBatchInsertStrategy implements BatchInsertStrategy {
 
 	private final InsertStrategy insertStrategy;
 	private final Dialect dialect;
-	private final BatchJdbcOperations batchJdbcOperations;
+	private final NamedParameterJdbcOperations jdbcOperations;
 	private final SqlIdentifier idColumn;
 
 	IdGeneratingBatchInsertStrategy(InsertStrategy insertStrategy, Dialect dialect,
-			BatchJdbcOperations batchJdbcOperations, @Nullable SqlIdentifier idColumn) {
+			NamedParameterJdbcOperations jdbcOperations, @Nullable SqlIdentifier idColumn) {
 
 		this.insertStrategy = insertStrategy;
 		this.dialect = dialect;
-		this.batchJdbcOperations = batchJdbcOperations;
+		this.jdbcOperations = jdbcOperations;
+
 		this.idColumn = idColumn;
 	}
 
@@ -66,12 +69,12 @@ class IdGeneratingBatchInsertStrategy implements BatchInsertStrategy {
 
 			String[] keyColumnNames = getKeyColumnNames();
 			if (keyColumnNames.length == 0) {
-				batchJdbcOperations.batchUpdate(sql, sqlParameterSources, holder);
+				jdbcOperations.batchUpdate(sql, sqlParameterSources, holder);
 			} else {
-				batchJdbcOperations.batchUpdate(sql, sqlParameterSources, holder, keyColumnNames);
+				jdbcOperations.batchUpdate(sql, sqlParameterSources, holder, keyColumnNames);
 			}
 		} else {
-			batchJdbcOperations.batchUpdate(sql, sqlParameterSources, holder);
+			jdbcOperations.batchUpdate(sql, sqlParameterSources, holder);
 		}
 		Object[] ids = new Object[sqlParameterSources.length];
 		List<Map<String, Object>> keyList = holder.getKeyList();

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/mybatis/MyBatisDataAccessStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/mybatis/MyBatisDataAccessStrategy.java
@@ -89,8 +89,7 @@ public class MyBatisDataAccessStrategy implements DataAccessStrategy {
 
 		SqlGeneratorSource sqlGeneratorSource = new SqlGeneratorSource(context, converter, dialect);
 		SqlParametersFactory sqlParametersFactory = new SqlParametersFactory(context, converter);
-		InsertStrategyFactory insertStrategyFactory = new InsertStrategyFactory(operations,
-				new BatchJdbcOperations(operations.getJdbcOperations()), dialect);
+		InsertStrategyFactory insertStrategyFactory = new InsertStrategyFactory(operations, dialect);
 
 		DataAccessStrategy defaultDataAccessStrategy = new DataAccessStrategyFactory( //
 				sqlGeneratorSource, //

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/config/AbstractJdbcConfiguration.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/config/AbstractJdbcConfiguration.java
@@ -209,7 +209,7 @@ public class AbstractJdbcConfiguration implements ApplicationContextAware {
 		SqlGeneratorSource sqlGeneratorSource = new SqlGeneratorSource(context, jdbcConverter, dialect);
 		DataAccessStrategyFactory factory = new DataAccessStrategyFactory(sqlGeneratorSource, jdbcConverter, operations,
 				new SqlParametersFactory(context, jdbcConverter),
-				new InsertStrategyFactory(operations, new BatchJdbcOperations(operations.getJdbcOperations()), dialect));
+				new InsertStrategyFactory(operations, dialect));
 
 		return factory.create();
 	}

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/support/JdbcRepositoryFactoryBean.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/support/JdbcRepositoryFactoryBean.java
@@ -21,7 +21,6 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
-import org.springframework.data.jdbc.core.convert.BatchJdbcOperations;
 import org.springframework.data.jdbc.core.convert.DataAccessStrategy;
 import org.springframework.data.jdbc.core.convert.DataAccessStrategyFactory;
 import org.springframework.data.jdbc.core.convert.InsertStrategyFactory;
@@ -179,8 +178,7 @@ public class JdbcRepositoryFactoryBean<T extends Repository<S, ID>, S, ID extend
 						SqlGeneratorSource sqlGeneratorSource = new SqlGeneratorSource(this.mappingContext, this.converter,
 								this.dialect);
 						SqlParametersFactory sqlParametersFactory = new SqlParametersFactory(this.mappingContext, this.converter);
-						InsertStrategyFactory insertStrategyFactory = new InsertStrategyFactory(this.operations,
-								new BatchJdbcOperations(this.operations.getJdbcOperations()), this.dialect);
+						InsertStrategyFactory insertStrategyFactory = new InsertStrategyFactory(this.operations, this.dialect);
 
 						DataAccessStrategyFactory factory = new DataAccessStrategyFactory(sqlGeneratorSource, this.converter,
 								this.operations, sqlParametersFactory, insertStrategyFactory);

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/InsertStrategyFactoryTest.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/InsertStrategyFactoryTest.java
@@ -32,9 +32,8 @@ import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 class InsertStrategyFactoryTest {
 
 	NamedParameterJdbcOperations namedParameterJdbcOperations = mock(NamedParameterJdbcOperations.class);
-	BatchJdbcOperations batchJdbcOperations = mock(BatchJdbcOperations.class);
 	InsertStrategyFactory insertStrategyFactory = new InsertStrategyFactory(namedParameterJdbcOperations,
-			batchJdbcOperations, AnsiDialect.INSTANCE);
+			AnsiDialect.INSTANCE);
 
 	String sql = "some sql";
 	SqlParameterSource sqlParameterSource = new SqlIdentifierParameterSource();

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/SimpleJdbcRepositoryEventsUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/SimpleJdbcRepositoryEventsUnitTests.java
@@ -15,6 +15,16 @@
  */
 package org.springframework.data.jdbc.repository;
 
+import static java.util.Arrays.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.groups.Tuple.tuple;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
@@ -23,7 +33,15 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.jdbc.core.convert.*;
+import org.springframework.data.jdbc.core.convert.BasicJdbcConverter;
+import org.springframework.data.jdbc.core.convert.DefaultDataAccessStrategy;
+import org.springframework.data.jdbc.core.convert.DefaultJdbcTypeFactory;
+import org.springframework.data.jdbc.core.convert.DelegatingDataAccessStrategy;
+import org.springframework.data.jdbc.core.convert.InsertStrategyFactory;
+import org.springframework.data.jdbc.core.convert.JdbcConverter;
+import org.springframework.data.jdbc.core.convert.JdbcCustomConversions;
+import org.springframework.data.jdbc.core.convert.SqlGeneratorSource;
+import org.springframework.data.jdbc.core.convert.SqlParametersFactory;
 import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
 import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
 import org.springframework.data.jdbc.repository.support.SimpleJdbcRepository;
@@ -47,16 +65,6 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.lang.Nullable;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-
-import static java.util.Arrays.*;
-import static org.assertj.core.api.Assertions.*;
-import static org.assertj.core.groups.Tuple.tuple;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
 
 /**
  * Unit tests for application events via {@link SimpleJdbcRepository}.
@@ -90,8 +98,7 @@ class SimpleJdbcRepositoryEventsUnitTests {
 				new DefaultJdbcTypeFactory(operations.getJdbcOperations()), dialect.getIdentifierProcessing());
 		SqlGeneratorSource generatorSource = new SqlGeneratorSource(context, converter, dialect);
 		SqlParametersFactory sqlParametersFactory = new SqlParametersFactory(context, converter);
-		InsertStrategyFactory insertStrategyFactory = new InsertStrategyFactory(operations,
-				new BatchJdbcOperations(operations.getJdbcOperations()), dialect);
+		InsertStrategyFactory insertStrategyFactory = new InsertStrategyFactory(operations, dialect);
 
 		this.dataAccessStrategy = spy(new DefaultDataAccessStrategy(generatorSource, context, converter, operations,
 				sqlParametersFactory, insertStrategyFactory));
@@ -299,8 +306,7 @@ class SimpleJdbcRepositoryEventsUnitTests {
 			extends CrudRepository<DummyEntity, Long>, PagingAndSortingRepository<DummyEntity, Long> {}
 
 	static final class DummyEntity {
-		@Id
-		private final Long id;
+		@Id private final Long id;
 
 		public DummyEntity(Long id) {
 			this.id = id;
@@ -311,12 +317,15 @@ class SimpleJdbcRepositoryEventsUnitTests {
 		}
 
 		public boolean equals(final Object o) {
-			if (o == this) return true;
-			if (!(o instanceof DummyEntity)) return false;
+			if (o == this)
+				return true;
+			if (!(o instanceof DummyEntity))
+				return false;
 			final DummyEntity other = (DummyEntity) o;
 			final Object this$id = this.getId();
 			final Object other$id = other.getId();
-			if (this$id == null ? other$id != null : !this$id.equals(other$id)) return false;
+			if (this$id == null ? other$id != null : !this$id.equals(other$id))
+				return false;
 			return true;
 		}
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/config/EnableJdbcRepositoriesIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/config/EnableJdbcRepositoriesIntegrationTests.java
@@ -33,7 +33,6 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.jdbc.core.JdbcAggregateTemplate;
-import org.springframework.data.jdbc.core.convert.BatchJdbcOperations;
 import org.springframework.data.jdbc.core.convert.DataAccessStrategy;
 import org.springframework.data.jdbc.core.convert.DataAccessStrategyFactory;
 import org.springframework.data.jdbc.core.convert.InsertStrategyFactory;
@@ -174,7 +173,7 @@ public class EnableJdbcRepositoriesIntegrationTests {
 				RelationalMappingContext context, JdbcConverter converter, Dialect dialect) {
 			return new DataAccessStrategyFactory(new SqlGeneratorSource(context, converter, dialect), converter,
 					template, new SqlParametersFactory(context, converter),
-					new InsertStrategyFactory(template, new BatchJdbcOperations(template.getJdbcOperations()), dialect)).create();
+					new InsertStrategyFactory(template, dialect)).create();
 		}
 
 		@Bean

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/TestConfiguration.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/TestConfiguration.java
@@ -108,7 +108,7 @@ public class TestConfiguration {
 
 		return new DataAccessStrategyFactory(new SqlGeneratorSource(context, converter, dialect), converter,
 				template, new SqlParametersFactory(context, converter),
-				new InsertStrategyFactory(template, new BatchJdbcOperations(template.getJdbcOperations()), dialect)).create();
+				new InsertStrategyFactory(template, dialect)).create();
 	}
 
 	@Bean("jdbcMappingContext")

--- a/spring-data-r2dbc/pom.xml
+++ b/spring-data-r2dbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-r2dbc</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-deprecate-batch-jdbc-operations-SNAPSHOT</version>
 
 	<name>Spring Data R2DBC</name>
 	<description>Spring Data module for R2DBC</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-deprecate-batch-jdbc-operations-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-relational</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-deprecate-batch-jdbc-operations-SNAPSHOT</version>
 
 	<name>Spring Data Relational</name>
 	<description>Spring Data Relational support</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-deprecate-batch-jdbc-operations-SNAPSHOT</version>
 	</parent>
 
 	<properties>


### PR DESCRIPTION
BatchJdbcOperations is still there, but deprecated, and not used except for deprecated places kept for backward compatibility.

This is possible since Spring Framework made the features offered by `BatchJdbcOperations` part of `NamedParameterJdbcOperations`.

See https://github.com/spring-projects/spring-framework/pull/28132
See https://github.com/spring-projects/spring-data-relational/pull/1191


_Note: the prepare branch commit switches to snapshot versions of Spring Framework in order to access the results of https://github.com/spring-projects/spring-framework/pull/28132. Merge only after that is released in a Milestone/RC_