### PR TITLE
Refine JDBC integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-relational-parent</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-GH-1620-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Relational Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,28 @@
 							<includes>
 								<include>**/*Tests.java</include>
 							</includes>
+							<excludes>
+								<exclude>**/*IntegrationTests.java</exclude>
+							</excludes>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>default-test</id>
+						<phase>integration-test</phase>
+						<goals>
+							<goal>integration-test</goal>
+						</goals>
+						<configuration>
+							<includes>
+								<include>**/*IntegrationTests.java</include>
+							</includes>
 						</configuration>
 					</execution>
 				</executions>

--- a/spring-data-jdbc-distribution/pom.xml
+++ b/spring-data-jdbc-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-GH-1620-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-jdbc</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-GH-1620-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-GH-1620-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -235,6 +235,28 @@
 
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>default-test</id>
+						<phase>integration-test</phase>
+						<goals>
+							<goal>integration-test</goal>
+						</goals>
+						<configuration>
+							<systemPropertyVariables>
+								<spring.profiles.active>hsql</spring.profiles.active>
+							</systemPropertyVariables>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 
 	<profiles>
 		<profile>

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -243,21 +243,18 @@
 				<plugins>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-surefire-plugin</artifactId>
+						<artifactId>maven-failsafe-plugin</artifactId>
 						<executions>
 							<execution>
 								<id>postgres-test</id>
-								<phase>test</phase>
+								<phase>integration-test</phase>
 								<goals>
-									<goal>test</goal>
+									<goal>integration-test</goal>
 								</goals>
 								<configuration>
 									<includes>
 										<include>**/*IntegrationTests.java</include>
 									</includes>
-									<excludes>
-										<exclude>**/*HsqlIntegrationTests.java</exclude>
-									</excludes>
 									<systemPropertyVariables>
 										<spring.profiles.active>postgres</spring.profiles.active>
 									</systemPropertyVariables>
@@ -274,21 +271,18 @@
 				<plugins>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-surefire-plugin</artifactId>
+						<artifactId>maven-failsafe-plugin</artifactId>
 						<executions>
 							<execution>
 								<id>h2-test</id>
-								<phase>test</phase>
+								<phase>integration-test</phase>
 								<goals>
-									<goal>test</goal>
+									<goal>integration-test</goal>
 								</goals>
 								<configuration>
 									<includes>
 										<include>**/*IntegrationTests.java</include>
 									</includes>
-									<excludes>
-										<exclude>**/*HsqlIntegrationTests.java</exclude>
-									</excludes>
 									<systemPropertyVariables>
 										<spring.profiles.active>h2</spring.profiles.active>
 									</systemPropertyVariables>
@@ -296,17 +290,14 @@
 							</execution>
 							<execution>
 								<id>mysql-test</id>
-								<phase>test</phase>
+								<phase>integration-test</phase>
 								<goals>
-									<goal>test</goal>
+									<goal>integration-test</goal>
 								</goals>
 								<configuration>
 									<includes>
 										<include>**/*IntegrationTests.java</include>
 									</includes>
-									<excludes>
-										<exclude>**/*HsqlIntegrationTests.java</exclude>
-									</excludes>
 									<systemPropertyVariables>
 										<spring.profiles.active>mysql</spring.profiles.active>
 									</systemPropertyVariables>
@@ -314,17 +305,14 @@
 							</execution>
 							<execution>
 								<id>postgres-test</id>
-								<phase>test</phase>
+								<phase>integration-test</phase>
 								<goals>
-									<goal>test</goal>
+									<goal>integration-test</goal>
 								</goals>
 								<configuration>
 									<includes>
 										<include>**/*IntegrationTests.java</include>
 									</includes>
-									<excludes>
-										<exclude>**/*HsqlIntegrationTests.java</exclude>
-									</excludes>
 									<systemPropertyVariables>
 										<spring.profiles.active>postgres</spring.profiles.active>
 									</systemPropertyVariables>
@@ -332,17 +320,14 @@
 							</execution>
 							<execution>
 								<id>mariadb-test</id>
-								<phase>test</phase>
+								<phase>integration-test</phase>
 								<goals>
-									<goal>test</goal>
+									<goal>integration-test</goal>
 								</goals>
 								<configuration>
 									<includes>
 										<include>**/*IntegrationTests.java</include>
 									</includes>
-									<excludes>
-										<exclude>**/*HsqlIntegrationTests.java</exclude>
-									</excludes>
 									<systemPropertyVariables>
 										<spring.profiles.active>mariadb</spring.profiles.active>
 									</systemPropertyVariables>
@@ -350,17 +335,14 @@
 							</execution>
 							<execution>
 								<id>db2-test</id>
-								<phase>test</phase>
+								<phase>integration-test</phase>
 								<goals>
-									<goal>test</goal>
+									<goal>integration-test</goal>
 								</goals>
 								<configuration>
 									<includes>
 										<include>**/*IntegrationTests.java</include>
 									</includes>
-									<excludes>
-										<exclude>**/*HsqlIntegrationTests.java</exclude>
-									</excludes>
 									<systemPropertyVariables>
 										<spring.profiles.active>db2</spring.profiles.active>
 									</systemPropertyVariables>
@@ -368,17 +350,14 @@
 							</execution>
 							<execution>
 								<id>oracle-test</id>
-								<phase>test</phase>
+								<phase>integration-test</phase>
 								<goals>
-									<goal>test</goal>
+									<goal>integration-test</goal>
 								</goals>
 								<configuration>
 									<includes>
 										<include>**/*IntegrationTests.java</include>
 									</includes>
-									<excludes>
-										<exclude>**/*HsqlIntegrationTests.java</exclude>
-									</excludes>
 									<systemPropertyVariables>
 										<spring.profiles.active>oracle</spring.profiles.active>
 									</systemPropertyVariables>
@@ -386,17 +365,14 @@
 							</execution>
 							<execution>
 								<id>mssql-test</id>
-								<phase>test</phase>
+								<phase>integration-test</phase>
 								<goals>
-									<goal>test</goal>
+									<goal>integration-test</goal>
 								</goals>
 								<configuration>
 									<includes>
 										<include>**/*IntegrationTests.java</include>
 									</includes>
-									<excludes>
-										<exclude>**/*HsqlIntegrationTests.java</exclude>
-									</excludes>
 									<systemPropertyVariables>
 										<spring.profiles.active>mssql</spring.profiles.active>
 									</systemPropertyVariables>

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/AbstractJdbcAggregateTemplateIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/AbstractJdbcAggregateTemplateIntegrationTests.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.SoftAssertions.*;
 import static org.springframework.data.jdbc.testing.TestConfiguration.*;
 import static org.springframework.data.jdbc.testing.TestDatabaseFeatures.Feature.*;
-import static org.springframework.test.context.TestExecutionListeners.MergeMode.*;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -38,7 +37,6 @@ import java.util.stream.IntStream;
 
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
@@ -55,9 +53,8 @@ import org.springframework.data.domain.Persistable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jdbc.core.convert.DataAccessStrategy;
 import org.springframework.data.jdbc.core.convert.JdbcConverter;
-import org.springframework.data.jdbc.testing.AssumeFeatureTestExecutionListener;
-import org.springframework.data.jdbc.testing.CombiningActiveProfileResolver;
 import org.springframework.data.jdbc.testing.EnabledOnFeature;
+import org.springframework.data.jdbc.testing.IntegrationTest;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.jdbc.testing.TestDatabaseFeatures;
 import org.springframework.data.mapping.context.InvalidPersistentPropertyPath;
@@ -69,10 +66,6 @@ import org.springframework.data.relational.core.mapping.RelationalMappingContext
 import org.springframework.data.relational.core.mapping.Table;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestExecutionListeners;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Integration tests for {@link JdbcAggregateTemplate}.
@@ -89,10 +82,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Chirag Tailor
  * @author Vincent Galloy
  */
-@ContextConfiguration
-@Transactional
-@TestExecutionListeners(value = AssumeFeatureTestExecutionListener.class, mergeMode = MERGE_WITH_DEFAULTS)
-@ExtendWith(SpringExtension.class)
+@IntegrationTest
 abstract class AbstractJdbcAggregateTemplateIntegrationTests {
 
 	@Autowired JdbcAggregateOperations template;
@@ -1611,6 +1601,7 @@ abstract class AbstractJdbcAggregateTemplateIntegrationTests {
 			return getId() == null;
 		}
 
+		@Override
 		public Long getId() {
 			return this.id;
 		}
@@ -1658,18 +1649,15 @@ abstract class AbstractJdbcAggregateTemplateIntegrationTests {
 		public boolean equals(final Object o) {
 			if (o == this)
 				return true;
-			if (!(o instanceof AggregateWithImmutableVersion))
+			if (!(o instanceof final AggregateWithImmutableVersion other))
 				return false;
-			final AggregateWithImmutableVersion other = (AggregateWithImmutableVersion) o;
 			final Object this$id = this.id;
 			final Object other$id = other.id;
-			if (this$id == null ? other$id != null : !this$id.equals(other$id))
+			if (!Objects.equals(this$id, other$id))
 				return false;
 			final Object this$version = this.getVersion();
 			final Object other$version = other.getVersion();
-			if (this$version == null ? other$version != null : !this$version.equals(other$version))
-				return false;
-			return true;
+			return Objects.equals(this$version, other$version);
 		}
 
 		public int hashCode() {
@@ -1722,18 +1710,15 @@ abstract class AbstractJdbcAggregateTemplateIntegrationTests {
 		public boolean equals(final Object o) {
 			if (o == this)
 				return true;
-			if (!(o instanceof ConstructorInvocation))
+			if (!(o instanceof final ConstructorInvocation other))
 				return false;
-			final ConstructorInvocation other = (ConstructorInvocation) o;
 			final Object this$id = this.id;
 			final Object other$id = other.id;
-			if (this$id == null ? other$id != null : !this$id.equals(other$id))
+			if (!Objects.equals(this$id, other$id))
 				return false;
 			final Object this$version = this.getVersion();
 			final Object other$version = other.getVersion();
-			if (this$version == null ? other$version != null : !this$version.equals(other$version))
-				return false;
-			return true;
+			return Objects.equals(this$version, other$version);
 		}
 
 		public int hashCode() {
@@ -1757,6 +1742,7 @@ abstract class AbstractJdbcAggregateTemplateIntegrationTests {
 			this.version = (Long) newVersion;
 		}
 
+		@Override
 		public Long getVersion() {
 			return this.version;
 		}
@@ -1788,6 +1774,7 @@ abstract class AbstractJdbcAggregateTemplateIntegrationTests {
 			this.version = (Integer) newVersion;
 		}
 
+		@Override
 		public Integer getVersion() {
 			return this.version;
 		}
@@ -1819,6 +1806,7 @@ abstract class AbstractJdbcAggregateTemplateIntegrationTests {
 			this.version = (Short) newVersion;
 		}
 
+		@Override
 		public Short getVersion() {
 			return this.version;
 		}
@@ -1876,7 +1864,7 @@ abstract class AbstractJdbcAggregateTemplateIntegrationTests {
 
 	static class JdbcAggregateTemplateIntegrationTests extends AbstractJdbcAggregateTemplateIntegrationTests {}
 
-	@ActiveProfiles(value = PROFILE_SINGLE_QUERY_LOADING, resolver = CombiningActiveProfileResolver.class)
+	@ActiveProfiles(value = PROFILE_SINGLE_QUERY_LOADING)
 	static class JdbcAggregateTemplateSingleQueryLoadingIntegrationTests
 			extends AbstractJdbcAggregateTemplateIntegrationTests {
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/ImmutableAggregateTemplateHsqlIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/ImmutableAggregateTemplateHsqlIntegrationTests.java
@@ -18,9 +18,10 @@ package org.springframework.data.jdbc.core;
 import static java.util.Collections.*;
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.Objects;
+
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
@@ -29,12 +30,11 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.jdbc.core.convert.DataAccessStrategy;
 import org.springframework.data.jdbc.core.convert.JdbcConverter;
+import org.springframework.data.jdbc.testing.DatabaseType;
+import org.springframework.data.jdbc.testing.EnabledOnDatabase;
+import org.springframework.data.jdbc.testing.IntegrationTest;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Integration tests for {@link JdbcAggregateTemplate} and it's handling of immutable entities.
@@ -43,10 +43,8 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Salim Achouche
  * @author Chirag Tailor
  */
-@ContextConfiguration
-@Transactional
-@ActiveProfiles("hsql")
-@ExtendWith(SpringExtension.class)
+@IntegrationTest
+@EnabledOnDatabase(DatabaseType.HSQL)
 public class ImmutableAggregateTemplateHsqlIntegrationTests {
 
 	@Autowired JdbcAggregateOperations template;
@@ -328,26 +326,23 @@ public class ImmutableAggregateTemplateHsqlIntegrationTests {
 		public boolean equals(final Object o) {
 			if (o == this)
 				return true;
-			if (!(o instanceof LegoSet))
+			if (!(o instanceof final LegoSet other))
 				return false;
-			final LegoSet other = (LegoSet) o;
 			final Object this$id = this.getId();
 			final Object other$id = other.getId();
-			if (this$id == null ? other$id != null : !this$id.equals(other$id))
+			if (!Objects.equals(this$id, other$id))
 				return false;
 			final Object this$name = this.getName();
 			final Object other$name = other.getName();
-			if (this$name == null ? other$name != null : !this$name.equals(other$name))
+			if (!Objects.equals(this$name, other$name))
 				return false;
 			final Object this$manual = this.getManual();
 			final Object other$manual = other.getManual();
-			if (this$manual == null ? other$manual != null : !this$manual.equals(other$manual))
+			if (!Objects.equals(this$manual, other$manual))
 				return false;
 			final Object this$author = this.getAuthor();
 			final Object other$author = other.getAuthor();
-			if (this$author == null ? other$author != null : !this$author.equals(other$author))
-				return false;
-			return true;
+			return Objects.equals(this$author, other$author);
 		}
 
 		public int hashCode() {
@@ -407,18 +402,15 @@ public class ImmutableAggregateTemplateHsqlIntegrationTests {
 		public boolean equals(final Object o) {
 			if (o == this)
 				return true;
-			if (!(o instanceof Manual))
+			if (!(o instanceof final Manual other))
 				return false;
-			final Manual other = (Manual) o;
 			final Object this$id = this.getId();
 			final Object other$id = other.getId();
-			if (this$id == null ? other$id != null : !this$id.equals(other$id))
+			if (!Objects.equals(this$id, other$id))
 				return false;
 			final Object this$content = this.getContent();
 			final Object other$content = other.getContent();
-			if (this$content == null ? other$content != null : !this$content.equals(other$content))
-				return false;
-			return true;
+			return Objects.equals(this$content, other$content);
 		}
 
 		public int hashCode() {
@@ -466,18 +458,15 @@ public class ImmutableAggregateTemplateHsqlIntegrationTests {
 		public boolean equals(final Object o) {
 			if (o == this)
 				return true;
-			if (!(o instanceof Author))
+			if (!(o instanceof final Author other))
 				return false;
-			final Author other = (Author) o;
 			final Object this$id = this.getId();
 			final Object other$id = other.getId();
-			if (this$id == null ? other$id != null : !this$id.equals(other$id))
+			if (!Objects.equals(this$id, other$id))
 				return false;
 			final Object this$name = this.getName();
 			final Object other$name = other.getName();
-			if (this$name == null ? other$name != null : !this$name.equals(other$name))
-				return false;
-			return true;
+			return Objects.equals(this$name, other$name);
 		}
 
 		public int hashCode() {
@@ -560,18 +549,15 @@ public class ImmutableAggregateTemplateHsqlIntegrationTests {
 		public boolean equals(final Object o) {
 			if (o == this)
 				return true;
-			if (!(o instanceof NonRoot))
+			if (!(o instanceof final NonRoot other))
 				return false;
-			final NonRoot other = (NonRoot) o;
 			final Object this$id = this.getId();
 			final Object other$id = other.getId();
-			if (this$id == null ? other$id != null : !this$id.equals(other$id))
+			if (!Objects.equals(this$id, other$id))
 				return false;
 			final Object this$name = this.getName();
 			final Object other$name = other.getName();
-			if (this$name == null ? other$name != null : !this$name.equals(other$name))
-				return false;
-			return true;
+			return Objects.equals(this$name, other$name);
 		}
 
 		public int hashCode() {

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/JdbcAggregateTemplateSchemaIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/JdbcAggregateTemplateSchemaIntegrationTests.java
@@ -17,10 +17,8 @@ package org.springframework.data.jdbc.core;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.springframework.data.jdbc.testing.TestDatabaseFeatures.Feature.*;
-import static org.springframework.test.context.TestExecutionListeners.MergeMode.*;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
@@ -29,26 +27,19 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.jdbc.core.convert.DataAccessStrategy;
 import org.springframework.data.jdbc.core.convert.JdbcConverter;
-import org.springframework.data.jdbc.testing.AssumeFeatureTestExecutionListener;
 import org.springframework.data.jdbc.testing.EnabledOnFeature;
+import org.springframework.data.jdbc.testing.IntegrationTest;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.relational.core.mapping.NamingStrategy;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestExecutionListeners;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Integration tests for {@link JdbcAggregateTemplate} using an entity mapped with an explicit schema.
  *
  * @author Jens Schauder
  */
-@ContextConfiguration
-@Transactional
-@TestExecutionListeners(value = AssumeFeatureTestExecutionListener.class, mergeMode = MERGE_WITH_DEFAULTS)
-@ExtendWith(SpringExtension.class)
+@IntegrationTest
 public class JdbcAggregateTemplateSchemaIntegrationTests {
 
 	@Autowired JdbcAggregateOperations template;

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/dialect/PostgresDialectIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/dialect/PostgresDialectIntegrationTests.java
@@ -17,7 +17,6 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Profile;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.convert.CustomConversions;
@@ -64,17 +63,11 @@ public class PostgresDialectIntegrationTests {
 		});
 	}
 
-	@Profile("postgres")
 	@Configuration
 	@Import(TestConfiguration.class)
 	@EnableJdbcRepositories(considerNestedRepositories = true,
 			includeFilters = @ComponentScan.Filter(value = CustomerRepository.class, type = FilterType.ASSIGNABLE_TYPE))
 	static class Config {
-
-		@Bean
-		Class<?> testClass() {
-			return PostgresDialectIntegrationTests.class;
-		}
 
 		@Bean
 		CustomConversions jdbcCustomConversions(Dialect dialect) {

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/dialect/PostgresDialectIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/dialect/PostgresDialectIntegrationTests.java
@@ -6,11 +6,10 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.postgresql.util.PGobject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -25,14 +24,14 @@ import org.springframework.data.convert.CustomConversions;
 import org.springframework.data.jdbc.core.convert.JdbcCustomConversions;
 import org.springframework.data.jdbc.core.mapping.JdbcSimpleTypes;
 import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories;
+import org.springframework.data.jdbc.testing.DatabaseType;
+import org.springframework.data.jdbc.testing.EnabledOnDatabase;
+import org.springframework.data.jdbc.testing.IntegrationTest;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.mapping.model.SimpleTypeHolder;
 import org.springframework.data.relational.core.dialect.Dialect;
 import org.springframework.data.relational.core.mapping.Table;
 import org.springframework.data.repository.CrudRepository;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Integration tests for PostgreSQL Dialect. Start this test with {@code -Dspring.profiles.active=postgres}.
@@ -40,10 +39,8 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Nikita Konev
  * @author Mark Paluch
  */
-@EnabledIfSystemProperty(named = "spring.profiles.active", matches = "postgres")
-@ContextConfiguration
-@Transactional
-@ExtendWith(SpringExtension.class)
+@IntegrationTest
+@EnabledOnDatabase(DatabaseType.POSTGRES)
 public class PostgresDialectIntegrationTests {
 
 	@Autowired CustomerRepository customerRepository;
@@ -161,26 +158,23 @@ public class PostgresDialectIntegrationTests {
 		public boolean equals(final Object o) {
 			if (o == this)
 				return true;
-			if (!(o instanceof Customer))
+			if (!(o instanceof final Customer other))
 				return false;
-			final Customer other = (Customer) o;
 			final Object this$id = this.getId();
 			final Object other$id = other.getId();
-			if (this$id == null ? other$id != null : !this$id.equals(other$id))
+			if (!Objects.equals(this$id, other$id))
 				return false;
 			final Object this$name = this.getName();
 			final Object other$name = other.getName();
-			if (this$name == null ? other$name != null : !this$name.equals(other$name))
+			if (!Objects.equals(this$name, other$name))
 				return false;
 			final Object this$personData = this.getPersonData();
 			final Object other$personData = other.getPersonData();
-			if (this$personData == null ? other$personData != null : !this$personData.equals(other$personData))
+			if (!Objects.equals(this$personData, other$personData))
 				return false;
 			final Object this$sessionData = this.getSessionData();
 			final Object other$sessionData = other.getSessionData();
-			if (this$sessionData == null ? other$sessionData != null : !this$sessionData.equals(other$sessionData))
-				return false;
-			return true;
+			return Objects.equals(this$sessionData, other$sessionData);
 		}
 
 		public int hashCode() {

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryBeforeSaveHsqlIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryBeforeSaveHsqlIntegrationTests.java
@@ -29,10 +29,10 @@ import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories;
-import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
 import org.springframework.data.jdbc.testing.DatabaseType;
 import org.springframework.data.jdbc.testing.EnabledOnDatabase;
 import org.springframework.data.jdbc.testing.IntegrationTest;
+import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.relational.core.mapping.NamingStrategy;
 import org.springframework.data.relational.core.mapping.event.BeforeSaveCallback;
 import org.springframework.data.repository.ListCrudRepository;
@@ -47,29 +47,11 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 @EnabledOnDatabase(DatabaseType.HSQL)
 public class JdbcRepositoryBeforeSaveHsqlIntegrationTests {
 
-	@Configuration
-	@Import(TestConfiguration.class)
-	static class Config {
-
-		@Autowired
-		JdbcRepositoryFactory factory;
-
-		@Bean
-		Class<?> testClass() {
-			return JdbcRepositoryBeforeSaveHsqlIntegrationTests.class;
-		}
-	}
-
-	@Autowired
-	NamedParameterJdbcTemplate template;
-	@Autowired
-	ImmutableEntityRepository immutableWithManualIdEntityRepository;
-	@Autowired
-	MutableEntityRepository mutableEntityRepository;
-	@Autowired
-	MutableWithImmutableIdEntityRepository mutableWithImmutableIdEntityRepository;
-	@Autowired
-	ImmutableWithMutableIdEntityRepository immutableWithMutableIdEntityRepository;
+	@Autowired NamedParameterJdbcTemplate template;
+	@Autowired ImmutableEntityRepository immutableWithManualIdEntityRepository;
+	@Autowired MutableEntityRepository mutableEntityRepository;
+	@Autowired MutableWithImmutableIdEntityRepository mutableWithImmutableIdEntityRepository;
+	@Autowired ImmutableWithMutableIdEntityRepository immutableWithMutableIdEntityRepository;
 
 	@Test // GH-1199
 	public void immutableEntity() {
@@ -135,13 +117,10 @@ public class JdbcRepositoryBeforeSaveHsqlIntegrationTests {
 		assertThat(reloaded.getName()).isEqualTo("fromBeforeSaveCallback");
 	}
 
-	private interface ImmutableEntityRepository extends ListCrudRepository<ImmutableEntity, Long> {
-	}
+	private interface ImmutableEntityRepository extends ListCrudRepository<ImmutableEntity, Long> {}
 
 	static final class ImmutableEntity {
-		@Id
-		private final
-		Long id;
+		@Id private final Long id;
 		private final String name;
 
 		public ImmutableEntity(Long id, String name) {
@@ -158,7 +137,8 @@ public class JdbcRepositoryBeforeSaveHsqlIntegrationTests {
 		}
 
 		public boolean equals(final Object o) {
-			if (o == this) return true;
+			if (o == this)
+				return true;
 			if (!(o instanceof final ImmutableEntity other))
 				return false;
 			final Object this$id = this.getId();
@@ -181,7 +161,8 @@ public class JdbcRepositoryBeforeSaveHsqlIntegrationTests {
 		}
 
 		public String toString() {
-			return "JdbcRepositoryBeforeSaveHsqlIntegrationTests.ImmutableEntity(id=" + this.getId() + ", name=" + this.getName() + ")";
+			return "JdbcRepositoryBeforeSaveHsqlIntegrationTests.ImmutableEntity(id=" + this.getId() + ", name="
+					+ this.getName() + ")";
 		}
 
 		public ImmutableEntity withId(Long id) {
@@ -193,12 +174,10 @@ public class JdbcRepositoryBeforeSaveHsqlIntegrationTests {
 		}
 	}
 
-	private interface MutableEntityRepository extends ListCrudRepository<MutableEntity, Long> {
-	}
+	private interface MutableEntityRepository extends ListCrudRepository<MutableEntity, Long> {}
 
 	static class MutableEntity {
-		@Id
-		private Long id;
+		@Id private Long id;
 		private String name;
 
 		public MutableEntity(Long id, String name) {
@@ -224,12 +203,10 @@ public class JdbcRepositoryBeforeSaveHsqlIntegrationTests {
 	}
 
 	private interface MutableWithImmutableIdEntityRepository
-			extends ListCrudRepository<MutableWithImmutableIdEntity, Long> {
-	}
+			extends ListCrudRepository<MutableWithImmutableIdEntity, Long> {}
 
 	static class MutableWithImmutableIdEntity {
-		@Id
-		private final Long id;
+		@Id private final Long id;
 		private String name;
 
 		public MutableWithImmutableIdEntity(Long id, String name) {
@@ -251,12 +228,10 @@ public class JdbcRepositoryBeforeSaveHsqlIntegrationTests {
 	}
 
 	private interface ImmutableWithMutableIdEntityRepository
-			extends ListCrudRepository<ImmutableWithMutableIdEntity, Long> {
-	}
+			extends ListCrudRepository<ImmutableWithMutableIdEntity, Long> {}
 
 	static class ImmutableWithMutableIdEntity {
-		@Id
-		private Long id;
+		@Id private Long id;
 		private final String name;
 
 		public ImmutableWithMutableIdEntity(Long id, String name) {
@@ -282,15 +257,10 @@ public class JdbcRepositoryBeforeSaveHsqlIntegrationTests {
 	}
 
 	@Configuration
-	@ComponentScan("org.springframework.data.jdbc.testing")
 	@EnableJdbcRepositories(considerNestedRepositories = true,
 			includeFilters = @ComponentScan.Filter(value = ListCrudRepository.class, type = FilterType.ASSIGNABLE_TYPE))
-	static class TestConfiguration {
-
-		@Bean
-		Class<?> testClass() {
-			return JdbcRepositoryBeforeSaveHsqlIntegrationTests.class;
-		}
+	@Import(TestConfiguration.class)
+	static class Config {
 
 		/**
 		 * {@link NamingStrategy} that harmlessly uppercases the table name, demonstrating how to inject one while not

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryBeforeSaveHsqlIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryBeforeSaveHsqlIntegrationTests.java
@@ -15,8 +15,12 @@
  */
 package org.springframework.data.jdbc.repository;
 
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+import java.util.Objects;
+
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -26,26 +30,21 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories;
 import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
+import org.springframework.data.jdbc.testing.DatabaseType;
+import org.springframework.data.jdbc.testing.EnabledOnDatabase;
+import org.springframework.data.jdbc.testing.IntegrationTest;
 import org.springframework.data.relational.core.mapping.NamingStrategy;
 import org.springframework.data.relational.core.mapping.event.BeforeSaveCallback;
 import org.springframework.data.repository.ListCrudRepository;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.*;
 
 /**
  * Integration tests for the {@link BeforeSaveCallback}.
  *
  * @author Chirag Tailor
  */
-@ContextConfiguration
-@ExtendWith(SpringExtension.class)
-@ActiveProfiles("hsql")
+@IntegrationTest
+@EnabledOnDatabase(DatabaseType.HSQL)
 public class JdbcRepositoryBeforeSaveHsqlIntegrationTests {
 
 	@Configuration
@@ -160,15 +159,15 @@ public class JdbcRepositoryBeforeSaveHsqlIntegrationTests {
 
 		public boolean equals(final Object o) {
 			if (o == this) return true;
-			if (!(o instanceof ImmutableEntity)) return false;
-			final ImmutableEntity other = (ImmutableEntity) o;
+			if (!(o instanceof final ImmutableEntity other))
+				return false;
 			final Object this$id = this.getId();
 			final Object other$id = other.getId();
-			if (this$id == null ? other$id != null : !this$id.equals(other$id)) return false;
+			if (!Objects.equals(this$id, other$id))
+				return false;
 			final Object this$name = this.getName();
 			final Object other$name = other.getName();
-			if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
-			return true;
+			return Objects.equals(this$name, other$name);
 		}
 
 		public int hashCode() {

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryConcurrencyIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryConcurrencyIntegrationTests.java
@@ -15,7 +15,18 @@
  */
 package org.springframework.data.jdbc.repository;
 
+import static org.assertj.core.api.Assertions.*;
+
 import junit.framework.AssertionFailedError;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.StringJoiner;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.UnaryOperator;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,22 +40,13 @@ import org.springframework.context.annotation.Import;
 import org.springframework.dao.IncorrectUpdateSemanticsDataAccessException;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
+import org.springframework.data.jdbc.testing.TestClass;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.StringJoiner;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.CountDownLatch;
-import java.util.function.UnaryOperator;
-
-import static org.assertj.core.api.Assertions.*;
 
 /**
  * Tests that highly concurrent update operations of an entity don't cause deadlocks.
@@ -59,16 +61,13 @@ public class JdbcRepositoryConcurrencyIntegrationTests {
 	@Import(TestConfiguration.class)
 	static class Config {
 
-		@Autowired
-		JdbcRepositoryFactory factory;
-
 		@Bean
-		Class<?> testClass() {
-			return JdbcRepositoryConcurrencyIntegrationTests.class;
+		TestClass testClass() {
+			return TestClass.of(JdbcRepositoryConcurrencyIntegrationTests.class);
 		}
 
 		@Bean
-		DummyEntityRepository dummyEntityRepository() {
+		DummyEntityRepository dummyEntityRepository(JdbcRepositoryFactory factory) {
 			return factory.getRepository(DummyEntityRepository.class);
 		}
 	}
@@ -107,7 +106,7 @@ public class JdbcRepositoryConcurrencyIntegrationTests {
 
 	private static void printThrowable(StringJoiner joiner, Throwable t) {
 
-		joiner.add(t.toString() + ExceptionUtils.readStackTrace(t));
+		joiner.add(t + ExceptionUtils.readStackTrace(t));
 		if (t.getCause() != null) {
 
 			joiner.add("\ncaused by:\n");

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryCreateIfNotFoundLookUpStrategyTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryCreateIfNotFoundLookUpStrategyTests.java
@@ -16,7 +16,6 @@
 package org.springframework.data.jdbc.repository;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -25,11 +24,9 @@ import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories;
 import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
+import org.springframework.data.jdbc.testing.IntegrationTest;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.repository.query.QueryLookupStrategy;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Test to verify that
@@ -39,9 +36,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Diego Krupitza
  * @author Jens Schauder
  */
-@ContextConfiguration
-@Transactional
-@ExtendWith(SpringExtension.class)
+@IntegrationTest
 class JdbcRepositoryCreateIfNotFoundLookUpStrategyTests
 		extends AbstractJdbcRepositoryLookUpStrategyTests {
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryCreateIfNotFoundLookUpStrategyTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryCreateIfNotFoundLookUpStrategyTests.java
@@ -16,15 +16,14 @@
 package org.springframework.data.jdbc.repository;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories;
-import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
 import org.springframework.data.jdbc.testing.IntegrationTest;
+import org.springframework.data.jdbc.testing.TestClass;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.repository.query.QueryLookupStrategy;
 
@@ -37,8 +36,7 @@ import org.springframework.data.repository.query.QueryLookupStrategy;
  * @author Jens Schauder
  */
 @IntegrationTest
-class JdbcRepositoryCreateIfNotFoundLookUpStrategyTests
-		extends AbstractJdbcRepositoryLookUpStrategyTests {
+class JdbcRepositoryCreateIfNotFoundLookUpStrategyTests extends AbstractJdbcRepositoryLookUpStrategyTests {
 
 	@Test // GH-1043
 	void declaredQueryShouldWork() {
@@ -56,16 +54,14 @@ class JdbcRepositoryCreateIfNotFoundLookUpStrategyTests
 	@Import(TestConfiguration.class)
 	@EnableJdbcRepositories(considerNestedRepositories = true,
 			queryLookupStrategy = QueryLookupStrategy.Key.CREATE_IF_NOT_FOUND,
-			includeFilters = @ComponentScan.Filter(
-					value = AbstractJdbcRepositoryLookUpStrategyTests.OnesRepository.class,
+			includeFilters = @ComponentScan.Filter(value = AbstractJdbcRepositoryLookUpStrategyTests.OnesRepository.class,
 					type = FilterType.ASSIGNABLE_TYPE))
 	static class Config {
 
-		@Autowired JdbcRepositoryFactory factory;
-
 		@Bean
-		Class<?> testClass() {
-			return AbstractJdbcRepositoryLookUpStrategyTests.class;
+		TestClass testClass() {
+			// boostrap with a different SQL init script
+			return TestClass.of(AbstractJdbcRepositoryLookUpStrategyTests.class);
 		}
 	}
 }

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryCreateLookUpStrategyTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryCreateLookUpStrategyTests.java
@@ -16,15 +16,14 @@
 package org.springframework.data.jdbc.repository;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories;
-import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
 import org.springframework.data.jdbc.testing.IntegrationTest;
+import org.springframework.data.jdbc.testing.TestClass;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.repository.query.QueryLookupStrategy;
 
@@ -58,11 +57,10 @@ class JdbcRepositoryCreateLookUpStrategyTests extends AbstractJdbcRepositoryLook
 			includeFilters = @ComponentScan.Filter(value = OnesRepository.class, type = FilterType.ASSIGNABLE_TYPE))
 	static class Config {
 
-		@Autowired JdbcRepositoryFactory factory;
-
 		@Bean
-		Class<?> testClass() {
-			return AbstractJdbcRepositoryLookUpStrategyTests.class;
+		TestClass testClass() {
+			// boostrap with a different SQL init script
+			return TestClass.of(AbstractJdbcRepositoryLookUpStrategyTests.class);
 		}
 	}
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryCreateLookUpStrategyTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryCreateLookUpStrategyTests.java
@@ -16,7 +16,6 @@
 package org.springframework.data.jdbc.repository;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -25,12 +24,9 @@ import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories;
 import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
+import org.springframework.data.jdbc.testing.IntegrationTest;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.repository.query.QueryLookupStrategy;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Test to verify that <code>@EnableJdbcRepositories(queryLookupStrategy = QueryLookupStrategy.Key.CREATE)</code> works
@@ -39,9 +35,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Diego Krupitza
  * @author Jens Schauder
  */
-@ContextConfiguration
-@Transactional
-@ExtendWith(SpringExtension.class)
+@IntegrationTest
 class JdbcRepositoryCreateLookUpStrategyTests extends AbstractJdbcRepositoryLookUpStrategyTests {
 
 	@Test // GH-1043

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryCrossAggregateHsqlIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryCrossAggregateHsqlIntegrationTests.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
@@ -27,7 +26,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.jdbc.core.mapping.AggregateReference;
 import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories;
-import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
 import org.springframework.data.jdbc.testing.DatabaseType;
 import org.springframework.data.jdbc.testing.EnabledOnDatabase;
 import org.springframework.data.jdbc.testing.IntegrationTest;
@@ -57,12 +55,6 @@ public class JdbcRepositoryCrossAggregateHsqlIntegrationTests {
 			includeFilters = @ComponentScan.Filter(value = Ones.class, type = FilterType.ASSIGNABLE_TYPE))
 	static class Config {
 
-		@Autowired JdbcRepositoryFactory factory;
-
-		@Bean
-		Class<?> testClass() {
-			return JdbcRepositoryCrossAggregateHsqlIntegrationTests.class;
-		}
 	}
 
 	@Autowired NamedParameterJdbcTemplate template;

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryCrossAggregateHsqlIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryCrossAggregateHsqlIntegrationTests.java
@@ -18,7 +18,6 @@ package org.springframework.data.jdbc.repository;
 import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -29,16 +28,14 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.jdbc.core.mapping.AggregateReference;
 import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories;
 import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
+import org.springframework.data.jdbc.testing.DatabaseType;
+import org.springframework.data.jdbc.testing.EnabledOnDatabase;
+import org.springframework.data.jdbc.testing.IntegrationTest;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.repository.CrudRepository;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.jdbc.JdbcTestUtils;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Very simple use cases for creation and usage of JdbcRepositories.
@@ -47,10 +44,9 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Salim Achouche
  * @author Salim Achouche
  */
-@ContextConfiguration
-@Transactional
-@ActiveProfiles("hsql")
-@ExtendWith(SpringExtension.class)
+
+@IntegrationTest
+@EnabledOnDatabase(DatabaseType.HSQL)
 public class JdbcRepositoryCrossAggregateHsqlIntegrationTests {
 
 	private static final long TWO_ID = 23L;
@@ -101,7 +97,7 @@ public class JdbcRepositoryCrossAggregateHsqlIntegrationTests {
 
 		assertThat( //
 				JdbcTestUtils.countRowsInTableWhere( //
-						(JdbcTemplate) template.getJdbcOperations(), //
+						template.getJdbcOperations(), //
 						"aggregate_one", //
 						"two = " + TWO_ID) //
 		).isEqualTo(1);

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryCustomConversionIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryCustomConversionIntegrationTests.java
@@ -18,7 +18,6 @@ package org.springframework.data.jdbc.repository;
 import static java.util.Arrays.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.SoftAssertions.*;
-import static org.springframework.test.context.TestExecutionListeners.MergeMode.*;
 
 import java.math.BigDecimal;
 import java.sql.JDBCType;
@@ -27,7 +26,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -40,13 +38,9 @@ import org.springframework.data.jdbc.core.convert.JdbcCustomConversions;
 import org.springframework.data.jdbc.core.mapping.JdbcValue;
 import org.springframework.data.jdbc.repository.query.Query;
 import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
-import org.springframework.data.jdbc.testing.AssumeFeatureTestExecutionListener;
+import org.springframework.data.jdbc.testing.IntegrationTest;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.repository.CrudRepository;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestExecutionListeners;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Tests storing and retrieving data types that get processed by custom conversions.
@@ -55,10 +49,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Sanghyuk Jung
  * @author Chirag Tailor
  */
-@ContextConfiguration
-@Transactional
-@TestExecutionListeners(value = AssumeFeatureTestExecutionListener.class, mergeMode = MERGE_WITH_DEFAULTS)
-@ExtendWith(SpringExtension.class)
+@IntegrationTest
 public class JdbcRepositoryCustomConversionIntegrationTests {
 
 	@Configuration

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryCustomConversionIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryCustomConversionIntegrationTests.java
@@ -56,15 +56,8 @@ public class JdbcRepositoryCustomConversionIntegrationTests {
 	@Import(TestConfiguration.class)
 	static class Config {
 
-		@Autowired JdbcRepositoryFactory factory;
-
 		@Bean
-		Class<?> testClass() {
-			return JdbcRepositoryCustomConversionIntegrationTests.class;
-		}
-
-		@Bean
-		EntityWithStringyBigDecimalRepository repository() {
+		EntityWithStringyBigDecimalRepository repository(JdbcRepositoryFactory factory) {
 			return factory.getRepository(EntityWithStringyBigDecimalRepository.class);
 		}
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryDeclaredLookUpStrategyTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryDeclaredLookUpStrategyTests.java
@@ -3,7 +3,6 @@ package org.springframework.data.jdbc.repository;
 import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -11,7 +10,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories;
-import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
+import org.springframework.data.jdbc.testing.TestClass;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.repository.query.QueryLookupStrategy;
 
@@ -22,8 +21,7 @@ import org.springframework.data.repository.query.QueryLookupStrategy;
  *
  * @author Diego Krupitza
  */
-class JdbcRepositoryDeclaredLookUpStrategyTests
-		extends AbstractJdbcRepositoryLookUpStrategyTests {
+class JdbcRepositoryDeclaredLookUpStrategyTests extends AbstractJdbcRepositoryLookUpStrategyTests {
 
 	@Test // GH-1043
 	void contextCannotByCreatedDueToFindByNameNotDeclaredQuery() {
@@ -43,16 +41,14 @@ class JdbcRepositoryDeclaredLookUpStrategyTests
 	@Import(TestConfiguration.class)
 	@EnableJdbcRepositories(considerNestedRepositories = true,
 			queryLookupStrategy = QueryLookupStrategy.Key.USE_DECLARED_QUERY,
-			includeFilters = @ComponentScan.Filter(
-					value = AbstractJdbcRepositoryLookUpStrategyTests.OnesRepository.class,
+			includeFilters = @ComponentScan.Filter(value = AbstractJdbcRepositoryLookUpStrategyTests.OnesRepository.class,
 					type = FilterType.ASSIGNABLE_TYPE))
 	static class Config {
 
-		@Autowired JdbcRepositoryFactory factory;
-
+		// use a different SQL script to bootstrap the test class.
 		@Bean
-		Class<?> testClass() {
-			return AbstractJdbcRepositoryLookUpStrategyTests.class;
+		TestClass testClass() {
+			return TestClass.of(JdbcRepositoryIntegrationTests.class);
 		}
 	}
 }

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryEmbeddedImmutableIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryEmbeddedImmutableIntegrationTests.java
@@ -15,33 +15,30 @@
  */
 package org.springframework.data.jdbc.repository;
 
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Objects;
+
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
+import org.springframework.data.jdbc.testing.IntegrationTest;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.relational.core.mapping.Embedded;
 import org.springframework.data.relational.core.mapping.Embedded.OnEmpty;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.transaction.annotation.Transactional;
-
-import static org.assertj.core.api.Assertions.*;
 
 /**
  * Very simple use cases for creation and usage of JdbcRepositories with {@link Embedded} annotation in Entities.
  *
  * @author Bastian Wilhelm
  */
-@ContextConfiguration
-@Transactional
-@ExtendWith(SpringExtension.class)
+@IntegrationTest
 public class JdbcRepositoryEmbeddedImmutableIntegrationTests {
 
 	@Configuration
@@ -106,16 +103,15 @@ public class JdbcRepositoryEmbeddedImmutableIntegrationTests {
 
 		public boolean equals(final Object o) {
 			if (o == this) return true;
-			if (!(o instanceof DummyEntity)) return false;
-			final DummyEntity other = (DummyEntity) o;
+			if (!(o instanceof final DummyEntity other))
+				return false;
 			final Object this$id = this.getId();
 			final Object other$id = other.getId();
-			if (this$id == null ? other$id != null : !this$id.equals(other$id)) return false;
+			if (!Objects.equals(this$id, other$id))
+				return false;
 			final Object this$prefixedEmbeddable = this.getPrefixedEmbeddable();
 			final Object other$prefixedEmbeddable = other.getPrefixedEmbeddable();
-			if (this$prefixedEmbeddable == null ? other$prefixedEmbeddable != null : !this$prefixedEmbeddable.equals(other$prefixedEmbeddable))
-				return false;
-			return true;
+			return Objects.equals(this$prefixedEmbeddable, other$prefixedEmbeddable);
 		}
 
 		public int hashCode() {
@@ -161,15 +157,15 @@ public class JdbcRepositoryEmbeddedImmutableIntegrationTests {
 
 		public boolean equals(final Object o) {
 			if (o == this) return true;
-			if (!(o instanceof Embeddable)) return false;
-			final Embeddable other = (Embeddable) o;
+			if (!(o instanceof final Embeddable other))
+				return false;
 			final Object this$attr1 = this.getAttr1();
 			final Object other$attr1 = other.getAttr1();
-			if (this$attr1 == null ? other$attr1 != null : !this$attr1.equals(other$attr1)) return false;
+			if (!Objects.equals(this$attr1, other$attr1))
+				return false;
 			final Object this$attr2 = this.getAttr2();
 			final Object other$attr2 = other.getAttr2();
-			if (this$attr2 == null ? other$attr2 != null : !this$attr2.equals(other$attr2)) return false;
-			return true;
+			return Objects.equals(this$attr2, other$attr2);
 		}
 
 		public int hashCode() {

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryEmbeddedImmutableIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryEmbeddedImmutableIntegrationTests.java
@@ -45,15 +45,8 @@ public class JdbcRepositoryEmbeddedImmutableIntegrationTests {
 	@Import(TestConfiguration.class)
 	static class Config {
 
-		@Autowired JdbcRepositoryFactory factory;
-
 		@Bean
-		Class<?> testClass() {
-			return JdbcRepositoryEmbeddedImmutableIntegrationTests.class;
-		}
-
-		@Bean
-		DummyEntityRepository dummyEntityRepository() {
+		DummyEntityRepository dummyEntityRepository(JdbcRepositoryFactory factory) {
 			return factory.getRepository(DummyEntityRepository.class);
 		}
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryEmbeddedIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryEmbeddedIntegrationTests.java
@@ -22,7 +22,6 @@ import java.util.List;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -30,6 +29,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
+import org.springframework.data.jdbc.testing.IntegrationTest;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Embedded;
@@ -37,12 +37,8 @@ import org.springframework.data.relational.core.mapping.Embedded.OnEmpty;
 import org.springframework.data.relational.core.mapping.Table;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.PagingAndSortingRepository;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.jdbc.JdbcTestUtils;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Very simple use cases for creation and usage of JdbcRepositories with test {@link Embedded} annotation in Entities.
@@ -51,9 +47,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Christoph Strobl
  * @author Mikhail Polivakha
  */
-@ContextConfiguration
-@Transactional
-@ExtendWith(SpringExtension.class)
+@IntegrationTest
 public class JdbcRepositoryEmbeddedIntegrationTests {
 
 	@Configuration
@@ -94,7 +88,7 @@ public class JdbcRepositoryEmbeddedIntegrationTests {
 
 		DummyEntity entity = repository.save(createDummyEntity());
 
-		assertThat(JdbcTestUtils.countRowsInTableWhere((JdbcTemplate) template.getJdbcOperations(), "dummy_entity",
+		assertThat(JdbcTestUtils.countRowsInTableWhere(template.getJdbcOperations(), "dummy_entity",
 				"id = " + entity.getId())).isEqualTo(1);
 	}
 
@@ -234,7 +228,7 @@ public class JdbcRepositoryEmbeddedIntegrationTests {
 
 		DummyEntity entity = repository.save(new DummyEntity());
 
-		assertThat(JdbcTestUtils.countRowsInTableWhere((JdbcTemplate) template.getJdbcOperations(), "dummy_entity",
+		assertThat(JdbcTestUtils.countRowsInTableWhere(template.getJdbcOperations(), "dummy_entity",
 				"id = " + entity.getId())).isEqualTo(1);
 	}
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryEmbeddedIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryEmbeddedIntegrationTests.java
@@ -54,25 +54,18 @@ public class JdbcRepositoryEmbeddedIntegrationTests {
 	@Import(TestConfiguration.class)
 	static class Config {
 
-		@Autowired JdbcRepositoryFactory factory;
-
 		@Bean
-		Class<?> testClass() {
-			return JdbcRepositoryEmbeddedIntegrationTests.class;
-		}
-
-		@Bean
-		DummyEntityRepository dummyEntityRepository() {
+		DummyEntityRepository dummyEntityRepository(JdbcRepositoryFactory factory) {
 			return factory.getRepository(DummyEntityRepository.class);
 		}
 
 		@Bean
-		PersonRepository personRepository() {
+		PersonRepository personRepository(JdbcRepositoryFactory factory) {
 			return factory.getRepository(PersonRepository.class);
 		}
 
 		@Bean
-		WithDotColumnRepo withDotColumnRepo() {
+		WithDotColumnRepo withDotColumnRepo(JdbcRepositoryFactory factory) {
 			return factory.getRepository(WithDotColumnRepo.class);
 		}
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryEmbeddedNotInAggregateRootIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryEmbeddedNotInAggregateRootIntegrationTests.java
@@ -15,15 +15,19 @@
  */
 package org.springframework.data.jdbc.repository;
 
+import static java.util.Arrays.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.sql.SQLException;
+
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
-import org.springframework.data.jdbc.testing.AssumeFeatureTestExecutionListener;
+import org.springframework.data.jdbc.testing.IntegrationTest;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.relational.core.dialect.Dialect;
 import org.springframework.data.relational.core.mapping.Column;
@@ -31,29 +35,15 @@ import org.springframework.data.relational.core.mapping.Embedded;
 import org.springframework.data.relational.core.mapping.Embedded.OnEmpty;
 import org.springframework.data.relational.core.sql.SqlIdentifier;
 import org.springframework.data.repository.CrudRepository;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestExecutionListeners;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.jdbc.JdbcTestUtils;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.sql.SQLException;
-
-import static java.util.Arrays.*;
-import static org.assertj.core.api.Assertions.*;
-import static org.springframework.test.context.TestExecutionListeners.MergeMode.*;
 
 /**
  * Very simple use cases for creation and usage of JdbcRepositories with test {@link Embedded} annotation in Entities.
  *
  * @author Bastian Wilhelm
  */
-@ContextConfiguration
-@Transactional
-@TestExecutionListeners(value = AssumeFeatureTestExecutionListener.class, mergeMode = MERGE_WITH_DEFAULTS)
-@ExtendWith(SpringExtension.class)
+@IntegrationTest
 public class JdbcRepositoryEmbeddedNotInAggregateRootIntegrationTests {
 
 	@Autowired NamedParameterJdbcTemplate template;
@@ -91,7 +81,7 @@ public class JdbcRepositoryEmbeddedNotInAggregateRootIntegrationTests {
 		SqlIdentifier id = SqlIdentifier.quoted("ID");
 		String whereClause = id.toSql(dialect.getIdentifierProcessing()) + " = " + idValue;
 
-		return JdbcTestUtils.countRowsInTableWhere((JdbcTemplate) template.getJdbcOperations(), name, whereClause);
+		return JdbcTestUtils.countRowsInTableWhere(template.getJdbcOperations(), name, whereClause);
 	}
 
 	@Test // DATAJDBC-111

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryEmbeddedNotInAggregateRootIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryEmbeddedNotInAggregateRootIntegrationTests.java
@@ -219,15 +219,8 @@ public class JdbcRepositoryEmbeddedNotInAggregateRootIntegrationTests {
 	@Import(TestConfiguration.class)
 	static class Config {
 
-		@Autowired JdbcRepositoryFactory factory;
-
 		@Bean
-		Class<?> testClass() {
-			return JdbcRepositoryEmbeddedNotInAggregateRootIntegrationTests.class;
-		}
-
-		@Bean
-		DummyEntityRepository dummyEntityRepository() {
+		DummyEntityRepository dummyEntityRepository(JdbcRepositoryFactory factory) {
 			return factory.getRepository(DummyEntityRepository.class);
 		}
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryEmbeddedWithCollectionIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryEmbeddedWithCollectionIntegrationTests.java
@@ -23,13 +23,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
+import org.springframework.data.jdbc.testing.IntegrationTest;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.relational.core.dialect.Dialect;
 import org.springframework.data.relational.core.mapping.Column;
@@ -38,21 +38,15 @@ import org.springframework.data.relational.core.mapping.Embedded.OnEmpty;
 import org.springframework.data.relational.core.mapping.MappedCollection;
 import org.springframework.data.relational.core.sql.SqlIdentifier;
 import org.springframework.data.repository.CrudRepository;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.jdbc.JdbcTestUtils;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Very simple use cases for creation and usage of JdbcRepositories with test {@link Embedded} annotation in Entities.
  *
  * @author Bastian Wilhelm
  */
-@ContextConfiguration
-@Transactional
-@ExtendWith(SpringExtension.class)
+@IntegrationTest
 public class JdbcRepositoryEmbeddedWithCollectionIntegrationTests {
 
 	@Configuration
@@ -91,7 +85,7 @@ public class JdbcRepositoryEmbeddedWithCollectionIntegrationTests {
 		SqlIdentifier id = SqlIdentifier.quoted("ID");
 		String whereClause = id.toSql(dialect.getIdentifierProcessing()) + " = " + idValue;
 
-		return JdbcTestUtils.countRowsInTableWhere((JdbcTemplate) template.getJdbcOperations(), name, whereClause);
+		return JdbcTestUtils.countRowsInTableWhere(template.getJdbcOperations(), name, whereClause);
 	}
 
 	@Test // DATAJDBC-111

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryEmbeddedWithCollectionIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryEmbeddedWithCollectionIntegrationTests.java
@@ -53,15 +53,8 @@ public class JdbcRepositoryEmbeddedWithCollectionIntegrationTests {
 	@Import(TestConfiguration.class)
 	static class Config {
 
-		@Autowired JdbcRepositoryFactory factory;
-
 		@Bean
-		Class<?> testClass() {
-			return JdbcRepositoryEmbeddedWithCollectionIntegrationTests.class;
-		}
-
-		@Bean
-		DummyEntityRepository dummyEntityRepository() {
+		DummyEntityRepository dummyEntityRepository(JdbcRepositoryFactory factory) {
 			return factory.getRepository(DummyEntityRepository.class);
 		}
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryEmbeddedWithReferenceIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryEmbeddedWithReferenceIntegrationTests.java
@@ -243,15 +243,8 @@ public class JdbcRepositoryEmbeddedWithReferenceIntegrationTests {
 	@Import(TestConfiguration.class)
 	static class Config {
 
-		@Autowired JdbcRepositoryFactory factory;
-
 		@Bean
-		Class<?> testClass() {
-			return JdbcRepositoryEmbeddedWithReferenceIntegrationTests.class;
-		}
-
-		@Bean
-		DummyEntityRepository dummyEntityRepository() {
+		DummyEntityRepository dummyEntityRepository(JdbcRepositoryFactory factory) {
 			return factory.getRepository(DummyEntityRepository.class);
 		}
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryEmbeddedWithReferenceIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryEmbeddedWithReferenceIntegrationTests.java
@@ -17,19 +17,17 @@ package org.springframework.data.jdbc.repository;
 
 import static java.util.Arrays.*;
 import static org.assertj.core.api.Assertions.*;
-import static org.springframework.test.context.TestExecutionListeners.MergeMode.*;
 
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
-import org.springframework.data.jdbc.testing.AssumeFeatureTestExecutionListener;
+import org.springframework.data.jdbc.testing.IntegrationTest;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.relational.core.dialect.Dialect;
 import org.springframework.data.relational.core.mapping.Column;
@@ -37,13 +35,8 @@ import org.springframework.data.relational.core.mapping.Embedded;
 import org.springframework.data.relational.core.mapping.Embedded.OnEmpty;
 import org.springframework.data.relational.core.sql.SqlIdentifier;
 import org.springframework.data.repository.CrudRepository;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestExecutionListeners;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.jdbc.JdbcTestUtils;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Very simple use cases for creation and usage of JdbcRepositories with test {@link Embedded} annotation in Entities.
@@ -51,10 +44,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Bastian Wilhelm
  * @author Jens Schauder
  */
-@ContextConfiguration
-@Transactional
-@TestExecutionListeners(value = AssumeFeatureTestExecutionListener.class, mergeMode = MERGE_WITH_DEFAULTS)
-@ExtendWith(SpringExtension.class)
+@IntegrationTest
 public class JdbcRepositoryEmbeddedWithReferenceIntegrationTests {
 
 	@Autowired NamedParameterJdbcTemplate template;
@@ -93,7 +83,7 @@ public class JdbcRepositoryEmbeddedWithReferenceIntegrationTests {
 		SqlIdentifier id = SqlIdentifier.quoted("ID");
 		String whereClause = id.toSql(dialect.getIdentifierProcessing()) + " = " + idValue;
 
-		return JdbcTestUtils.countRowsInTableWhere((JdbcTemplate) template.getJdbcOperations(), name, whereClause);
+		return JdbcTestUtils.countRowsInTableWhere(template.getJdbcOperations(), name, whereClause);
 	}
 
 	@Test // DATAJDBC-111

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryIdGenerationIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryIdGenerationIntegrationTests.java
@@ -29,9 +29,9 @@ import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories;
-import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
 import org.springframework.data.jdbc.repository.support.SimpleJdbcRepository;
 import org.springframework.data.jdbc.testing.IntegrationTest;
+import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.relational.core.mapping.NamingStrategy;
 import org.springframework.data.relational.core.mapping.event.BeforeConvertCallback;
 import org.springframework.data.repository.CrudRepository;
@@ -45,18 +45,6 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
  */
 @IntegrationTest
 public class JdbcRepositoryIdGenerationIntegrationTests {
-
-	@Configuration
-	@Import(TestConfiguration.class)
-	static class Config {
-
-		@Autowired JdbcRepositoryFactory factory;
-
-		@Bean
-		Class<?> testClass() {
-			return JdbcRepositoryIdGenerationIntegrationTests.class;
-		}
-	}
 
 	@Autowired NamedParameterJdbcTemplate template;
 	@Autowired ReadOnlyIdEntityRepository readOnlyIdrepository;
@@ -113,8 +101,7 @@ public class JdbcRepositoryIdGenerationIntegrationTests {
 
 	static final class ReadOnlyIdEntity {
 
-		@Id
-		private final Long id;
+		@Id private final Long id;
 		private final String name;
 
 		public ReadOnlyIdEntity(Long id, String name) {
@@ -131,7 +118,8 @@ public class JdbcRepositoryIdGenerationIntegrationTests {
 		}
 
 		public boolean equals(final Object o) {
-			if (o == this) return true;
+			if (o == this)
+				return true;
 			if (!(o instanceof final ReadOnlyIdEntity other))
 				return false;
 			final Object this$id = this.getId();
@@ -154,14 +142,14 @@ public class JdbcRepositoryIdGenerationIntegrationTests {
 		}
 
 		public String toString() {
-			return "JdbcRepositoryIdGenerationIntegrationTests.ReadOnlyIdEntity(id=" + this.getId() + ", name=" + this.getName() + ")";
+			return "JdbcRepositoryIdGenerationIntegrationTests.ReadOnlyIdEntity(id=" + this.getId() + ", name="
+					+ this.getName() + ")";
 		}
 	}
 
 	static class PrimitiveIdEntity {
 
-		@Id
-		private long id;
+		@Id private long id;
 		String name;
 
 		public long getId() {
@@ -182,8 +170,7 @@ public class JdbcRepositoryIdGenerationIntegrationTests {
 	}
 
 	static final class ImmutableWithManualIdEntity {
-		@Id
-		private final Long id;
+		@Id private final Long id;
 		private final String name;
 
 		public ImmutableWithManualIdEntity(Long id, String name) {
@@ -200,7 +187,8 @@ public class JdbcRepositoryIdGenerationIntegrationTests {
 		}
 
 		public boolean equals(final Object o) {
-			if (o == this) return true;
+			if (o == this)
+				return true;
 			if (!(o instanceof final ImmutableWithManualIdEntity other))
 				return false;
 			final Object this$id = this.getId();
@@ -223,7 +211,8 @@ public class JdbcRepositoryIdGenerationIntegrationTests {
 		}
 
 		public String toString() {
-			return "JdbcRepositoryIdGenerationIntegrationTests.ImmutableWithManualIdEntity(id=" + this.getId() + ", name=" + this.getName() + ")";
+			return "JdbcRepositoryIdGenerationIntegrationTests.ImmutableWithManualIdEntity(id=" + this.getId() + ", name="
+					+ this.getName() + ")";
 		}
 
 		public ImmutableWithManualIdEntity withId(Long id) {
@@ -236,17 +225,12 @@ public class JdbcRepositoryIdGenerationIntegrationTests {
 	}
 
 	@Configuration
-	@ComponentScan("org.springframework.data.jdbc.testing")
 	@EnableJdbcRepositories(considerNestedRepositories = true,
 			includeFilters = @ComponentScan.Filter(value = CrudRepository.class, type = FilterType.ASSIGNABLE_TYPE))
-	static class TestConfiguration {
+	@Import(TestConfiguration.class)
+	static class Config {
 
 		AtomicLong lastId = new AtomicLong(0);
-
-		@Bean
-		Class<?> testClass() {
-			return JdbcRepositoryIdGenerationIntegrationTests.class;
-		}
 
 		/**
 		 * {@link NamingStrategy} that harmlessly uppercases the table name, demonstrating how to inject one while not

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryIdGenerationIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryIdGenerationIntegrationTests.java
@@ -15,8 +15,12 @@
  */
 package org.springframework.data.jdbc.repository;
 
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -27,16 +31,11 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories;
 import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
 import org.springframework.data.jdbc.repository.support.SimpleJdbcRepository;
+import org.springframework.data.jdbc.testing.IntegrationTest;
 import org.springframework.data.relational.core.mapping.NamingStrategy;
 import org.springframework.data.relational.core.mapping.event.BeforeConvertCallback;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-
-import java.util.concurrent.atomic.AtomicLong;
-
-import static org.assertj.core.api.Assertions.*;
 
 /**
  * Testing special cases for id generation with {@link SimpleJdbcRepository}.
@@ -44,8 +43,7 @@ import static org.assertj.core.api.Assertions.*;
  * @author Jens Schauder
  * @author Greg Turnquist
  */
-@ContextConfiguration
-@ExtendWith(SpringExtension.class)
+@IntegrationTest
 public class JdbcRepositoryIdGenerationIntegrationTests {
 
 	@Configuration
@@ -134,15 +132,15 @@ public class JdbcRepositoryIdGenerationIntegrationTests {
 
 		public boolean equals(final Object o) {
 			if (o == this) return true;
-			if (!(o instanceof ReadOnlyIdEntity)) return false;
-			final ReadOnlyIdEntity other = (ReadOnlyIdEntity) o;
+			if (!(o instanceof final ReadOnlyIdEntity other))
+				return false;
 			final Object this$id = this.getId();
 			final Object other$id = other.getId();
-			if (this$id == null ? other$id != null : !this$id.equals(other$id)) return false;
+			if (!Objects.equals(this$id, other$id))
+				return false;
 			final Object this$name = this.getName();
 			final Object other$name = other.getName();
-			if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
-			return true;
+			return Objects.equals(this$name, other$name);
 		}
 
 		public int hashCode() {
@@ -203,15 +201,15 @@ public class JdbcRepositoryIdGenerationIntegrationTests {
 
 		public boolean equals(final Object o) {
 			if (o == this) return true;
-			if (!(o instanceof ImmutableWithManualIdEntity)) return false;
-			final ImmutableWithManualIdEntity other = (ImmutableWithManualIdEntity) o;
+			if (!(o instanceof final ImmutableWithManualIdEntity other))
+				return false;
 			final Object this$id = this.getId();
 			final Object other$id = other.getId();
-			if (this$id == null ? other$id != null : !this$id.equals(other$id)) return false;
+			if (!Objects.equals(this$id, other$id))
+				return false;
 			final Object this$name = this.getName();
 			final Object other$name = other.getName();
-			if (this$name == null ? other$name != null : !this$name.equals(other$name)) return false;
-			return true;
+			return Objects.equals(this$name, other$name);
 		}
 
 		public int hashCode() {

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryIntegrationTests.java
@@ -19,7 +19,6 @@ import static java.util.Arrays.*;
 import static java.util.Collections.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.SoftAssertions.*;
-import static org.springframework.test.context.TestExecutionListeners.MergeMode.*;
 
 import java.io.IOException;
 import java.sql.ResultSet;
@@ -39,7 +38,6 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -65,8 +63,8 @@ import org.springframework.data.jdbc.core.mapping.AggregateReference;
 import org.springframework.data.jdbc.repository.query.Modifying;
 import org.springframework.data.jdbc.repository.query.Query;
 import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
-import org.springframework.data.jdbc.testing.AssumeFeatureTestExecutionListener;
 import org.springframework.data.jdbc.testing.EnabledOnFeature;
+import org.springframework.data.jdbc.testing.IntegrationTest;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.jdbc.testing.TestDatabaseFeatures;
 import org.springframework.data.relational.core.mapping.Column;
@@ -87,14 +85,10 @@ import org.springframework.data.repository.query.QueryByExampleExecutor;
 import org.springframework.data.spel.spi.EvaluationContextExtension;
 import org.springframework.data.support.WindowIterator;
 import org.springframework.data.util.Streamable;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.lang.Nullable;
-import org.springframework.test.context.TestExecutionListeners;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.jdbc.JdbcTestUtils;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Very simple use cases for creation and usage of JdbcRepositories.
@@ -106,9 +100,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Christopher Klein
  * @author Mikhail Polivakha
  */
-@Transactional
-@TestExecutionListeners(value = AssumeFeatureTestExecutionListener.class, mergeMode = MERGE_WITH_DEFAULTS)
-@ExtendWith(SpringExtension.class)
+@IntegrationTest
 public class JdbcRepositoryIntegrationTests {
 
 	@Autowired NamedParameterJdbcTemplate template;
@@ -139,7 +131,7 @@ public class JdbcRepositoryIntegrationTests {
 
 		DummyEntity entity = repository.save(createDummyEntity());
 
-		assertThat(JdbcTestUtils.countRowsInTableWhere((JdbcTemplate) template.getJdbcOperations(), "dummy_entity",
+		assertThat(JdbcTestUtils.countRowsInTableWhere(template.getJdbcOperations(), "dummy_entity",
 				"id_Prop = " + entity.getIdProp())).isEqualTo(1);
 	}
 
@@ -1513,26 +1505,23 @@ public class JdbcRepositoryIntegrationTests {
 		public boolean equals(final Object o) {
 			if (o == this)
 				return true;
-			if (!(o instanceof Root))
+			if (!(o instanceof final Root other))
 				return false;
-			final Root other = (Root) o;
 			final Object this$id = this.getId();
 			final Object other$id = other.getId();
-			if (this$id == null ? other$id != null : !this$id.equals(other$id))
+			if (!Objects.equals(this$id, other$id))
 				return false;
 			final Object this$name = this.getName();
 			final Object other$name = other.getName();
-			if (this$name == null ? other$name != null : !this$name.equals(other$name))
+			if (!Objects.equals(this$name, other$name))
 				return false;
 			final Object this$intermediate = this.getIntermediate();
 			final Object other$intermediate = other.getIntermediate();
-			if (this$intermediate == null ? other$intermediate != null : !this$intermediate.equals(other$intermediate))
+			if (!Objects.equals(this$intermediate, other$intermediate))
 				return false;
 			final Object this$intermediates = this.getIntermediates();
 			final Object other$intermediates = other.getIntermediates();
-			if (this$intermediates == null ? other$intermediates != null : !this$intermediates.equals(other$intermediates))
-				return false;
-			return true;
+			return Objects.equals(this$intermediates, other$intermediates);
 		}
 
 		public int hashCode() {
@@ -1619,26 +1608,23 @@ public class JdbcRepositoryIntegrationTests {
 		public boolean equals(final Object o) {
 			if (o == this)
 				return true;
-			if (!(o instanceof Intermediate))
+			if (!(o instanceof final Intermediate other))
 				return false;
-			final Intermediate other = (Intermediate) o;
 			final Object this$id = this.getId();
 			final Object other$id = other.getId();
-			if (this$id == null ? other$id != null : !this$id.equals(other$id))
+			if (!Objects.equals(this$id, other$id))
 				return false;
 			final Object this$name = this.getName();
 			final Object other$name = other.getName();
-			if (this$name == null ? other$name != null : !this$name.equals(other$name))
+			if (!Objects.equals(this$name, other$name))
 				return false;
 			final Object this$leaf = this.getLeaf();
 			final Object other$leaf = other.getLeaf();
-			if (this$leaf == null ? other$leaf != null : !this$leaf.equals(other$leaf))
+			if (!Objects.equals(this$leaf, other$leaf))
 				return false;
 			final Object this$leaves = this.getLeaves();
 			final Object other$leaves = other.getLeaves();
-			if (this$leaves == null ? other$leaves != null : !this$leaves.equals(other$leaves))
-				return false;
-			return true;
+			return Objects.equals(this$leaves, other$leaves);
 		}
 
 		public int hashCode() {
@@ -1682,18 +1668,15 @@ public class JdbcRepositoryIntegrationTests {
 		public boolean equals(final Object o) {
 			if (o == this)
 				return true;
-			if (!(o instanceof Leaf))
+			if (!(o instanceof final Leaf other))
 				return false;
-			final Leaf other = (Leaf) o;
 			final Object this$id = this.getId();
 			final Object other$id = other.getId();
-			if (this$id == null ? other$id != null : !this$id.equals(other$id))
+			if (!Objects.equals(this$id, other$id))
 				return false;
 			final Object this$name = this.getName();
 			final Object other$name = other.getName();
-			if (this$name == null ? other$name != null : !this$name.equals(other$name))
-				return false;
-			return true;
+			return Objects.equals(this$name, other$name);
 		}
 
 		public int hashCode() {
@@ -1737,6 +1720,7 @@ public class JdbcRepositoryIntegrationTests {
 			}
 		}
 
+		@Override
 		public Object getRootObject() {
 			return new ExtensionRoot();
 		}
@@ -1854,14 +1838,11 @@ public class JdbcRepositoryIntegrationTests {
 		public boolean equals(final Object o) {
 			if (o == this)
 				return true;
-			if (!(o instanceof DtoProjection))
+			if (!(o instanceof final DtoProjection other))
 				return false;
-			final DtoProjection other = (DtoProjection) o;
 			final Object this$name = this.getName();
 			final Object other$name = other.getName();
-			if (this$name == null ? other$name != null : !this$name.equals(other$name))
-				return false;
-			return true;
+			return Objects.equals(this$name, other$name);
 		}
 
 		public int hashCode() {

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryPropertyConversionIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryPropertyConversionIntegrationTests.java
@@ -158,15 +158,8 @@ public class JdbcRepositoryPropertyConversionIntegrationTests {
 	@Import(TestConfiguration.class)
 	static class Config {
 
-		@Autowired JdbcRepositoryFactory factory;
-
 		@Bean
-		Class<?> testClass() {
-			return JdbcRepositoryPropertyConversionIntegrationTests.class;
-		}
-
-		@Bean
-		DummyEntityRepository dummyEntityRepository() {
+		DummyEntityRepository dummyEntityRepository(JdbcRepositoryFactory factory) {
 			return factory.getRepository(DummyEntityRepository.class);
 		}
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryPropertyConversionIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryPropertyConversionIntegrationTests.java
@@ -18,7 +18,6 @@ package org.springframework.data.jdbc.repository;
 import static java.util.Collections.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.springframework.data.jdbc.testing.TestDatabaseFeatures.Feature.*;
-import static org.springframework.test.context.TestExecutionListeners.MergeMode.*;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -32,7 +31,6 @@ import java.util.Set;
 import org.assertj.core.api.Condition;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
@@ -40,16 +38,12 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
-import org.springframework.data.jdbc.testing.AssumeFeatureTestExecutionListener;
 import org.springframework.data.jdbc.testing.EnabledOnFeature;
+import org.springframework.data.jdbc.testing.IntegrationTest;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.relational.core.mapping.MappedCollection;
 import org.springframework.data.relational.core.mapping.event.BeforeConvertEvent;
 import org.springframework.data.repository.CrudRepository;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestExecutionListeners;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Tests storing and retrieving various data types that are considered essential and that might need conversion to
@@ -60,10 +54,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Yunyung LEE
  * @author Chirag Tailor
  */
-@ContextConfiguration
-@Transactional
-@TestExecutionListeners(value = AssumeFeatureTestExecutionListener.class, mergeMode = MERGE_WITH_DEFAULTS)
-@ExtendWith(SpringExtension.class)
+@IntegrationTest
 public class JdbcRepositoryPropertyConversionIntegrationTests {
 
 	@Autowired DummyEntityRepository repository;

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryResultSetExtractorIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryResultSetExtractorIntegrationTests.java
@@ -15,25 +15,7 @@
  */
 package org.springframework.data.jdbc.repository;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
-import org.springframework.dao.DataAccessException;
-import org.springframework.dao.RecoverableDataAccessException;
-import org.springframework.data.annotation.Id;
-import org.springframework.data.jdbc.repository.query.Query;
-import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
-import org.springframework.data.jdbc.testing.TestConfiguration;
-import org.springframework.data.repository.CrudRepository;
-import org.springframework.jdbc.core.ResultSetExtractor;
-import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.transaction.annotation.Transactional;
+import static org.assertj.core.api.Assertions.*;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -43,16 +25,29 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.RecoverableDataAccessException;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.jdbc.repository.query.Query;
+import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
+import org.springframework.data.jdbc.testing.IntegrationTest;
+import org.springframework.data.jdbc.testing.TestConfiguration;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.jdbc.core.ResultSetExtractor;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
 /**
  * Very simple use cases for creation and usage of {@link ResultSetExtractor}s in JdbcRepository.
  *
  * @author Evgeni Dimitrov
  */
-@ContextConfiguration
-@Transactional
-@ExtendWith(SpringExtension.class)
+@IntegrationTest
 public class JdbcRepositoryResultSetExtractorIntegrationTests {
 
 	@Configuration

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryResultSetExtractorIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryResultSetExtractorIntegrationTests.java
@@ -54,15 +54,8 @@ public class JdbcRepositoryResultSetExtractorIntegrationTests {
 	@Import(TestConfiguration.class)
 	static class Config {
 
-		@Autowired JdbcRepositoryFactory factory;
-
 		@Bean
-		Class<?> testClass() {
-			return JdbcRepositoryResultSetExtractorIntegrationTests.class;
-		}
-
-		@Bean
-		PersonRepository personEntityRepository() {
+		PersonRepository personEntityRepository(JdbcRepositoryFactory factory) {
 			return factory.getRepository(PersonRepository.class);
 		}
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryWithCollectionsAndManuallyAssignedIdHsqlIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryWithCollectionsAndManuallyAssignedIdHsqlIntegrationTests.java
@@ -56,15 +56,8 @@ public class JdbcRepositoryWithCollectionsAndManuallyAssignedIdHsqlIntegrationTe
 	@Import(TestConfiguration.class)
 	static class Config {
 
-		@Autowired JdbcRepositoryFactory factory;
-
 		@Bean
-		Class<?> testClass() {
-			return JdbcRepositoryWithCollectionsAndManuallyAssignedIdHsqlIntegrationTests.class;
-		}
-
-		@Bean
-		DummyEntityRepository dummyEntityRepository() {
+		DummyEntityRepository dummyEntityRepository(JdbcRepositoryFactory factory) {
 			return factory.getRepository(DummyEntityRepository.class);
 		}
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryWithCollectionsAndManuallyAssignedIdHsqlIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryWithCollectionsAndManuallyAssignedIdHsqlIntegrationTests.java
@@ -15,9 +15,16 @@
  */
 package org.springframework.data.jdbc.repository;
 
+import static org.assertj.core.api.Assertions.*;
+
 import junit.framework.AssertionFailedError;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
@@ -25,21 +32,13 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
+import org.springframework.data.jdbc.testing.DatabaseType;
+import org.springframework.data.jdbc.testing.EnabledOnDatabase;
+import org.springframework.data.jdbc.testing.IntegrationTest;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.relational.core.mapping.event.BeforeConvertEvent;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
-
-import static org.assertj.core.api.Assertions.*;
 
 /**
  * Very simple use cases for creation and usage of JdbcRepositories.
@@ -47,10 +46,8 @@ import static org.assertj.core.api.Assertions.*;
  * @author Jens Schauder
  * @author Chirag Tailor
  */
-@ContextConfiguration
-@Transactional
-@ActiveProfiles("hsql")
-@ExtendWith(SpringExtension.class)
+@IntegrationTest
+@EnabledOnDatabase(DatabaseType.HSQL)
 public class JdbcRepositoryWithCollectionsAndManuallyAssignedIdHsqlIntegrationTests {
 
 	static AtomicLong id = new AtomicLong(0);

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryWithCollectionsIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryWithCollectionsIntegrationTests.java
@@ -186,15 +186,8 @@ public class JdbcRepositoryWithCollectionsIntegrationTests {
 	@Import(TestConfiguration.class)
 	static class Config {
 
-		@Autowired JdbcRepositoryFactory factory;
-
 		@Bean
-		Class<?> testClass() {
-			return JdbcRepositoryWithCollectionsIntegrationTests.class;
-		}
-
-		@Bean
-		DummyEntityRepository dummyEntityRepository() {
+		DummyEntityRepository dummyEntityRepository(JdbcRepositoryFactory factory) {
 			return factory.getRepository(DummyEntityRepository.class);
 		}
 	}

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryWithCollectionsIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryWithCollectionsIntegrationTests.java
@@ -17,7 +17,6 @@ package org.springframework.data.jdbc.repository;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.springframework.data.jdbc.testing.TestDatabaseFeatures.Feature.*;
-import static org.springframework.test.context.TestExecutionListeners.MergeMode.*;
 
 import junit.framework.AssertionFailedError;
 
@@ -26,22 +25,17 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
-import org.springframework.data.jdbc.testing.AssumeFeatureTestExecutionListener;
 import org.springframework.data.jdbc.testing.EnabledOnFeature;
+import org.springframework.data.jdbc.testing.IntegrationTest;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestExecutionListeners;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Very simple use cases for creation and usage of JdbcRepositories.
@@ -49,10 +43,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Jens Schauder
  * @author Thomas Lang
  */
-@ContextConfiguration
-@Transactional
-@TestExecutionListeners(value = AssumeFeatureTestExecutionListener.class, mergeMode = MERGE_WITH_DEFAULTS)
-@ExtendWith(SpringExtension.class)
+@IntegrationTest
 public class JdbcRepositoryWithCollectionsIntegrationTests {
 
 	@Autowired NamedParameterJdbcTemplate template;

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryWithListsIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryWithListsIntegrationTests.java
@@ -218,20 +218,13 @@ public class JdbcRepositoryWithListsIntegrationTests {
 	@Import(TestConfiguration.class)
 	static class Config {
 
-		@Autowired JdbcRepositoryFactory factory;
-
 		@Bean
-		Class<?> testClass() {
-			return JdbcRepositoryWithListsIntegrationTests.class;
-		}
-
-		@Bean
-		DummyEntityRepository dummyEntityRepository() {
+		DummyEntityRepository dummyEntityRepository(JdbcRepositoryFactory factory) {
 			return factory.getRepository(DummyEntityRepository.class);
 		}
 
 		@Bean
-		RootRepository rootRepository() {
+		RootRepository rootRepository(JdbcRepositoryFactory factory) {
 			return factory.getRepository(RootRepository.class);
 		}
 	}

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryWithListsIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryWithListsIntegrationTests.java
@@ -18,31 +18,26 @@ package org.springframework.data.jdbc.repository;
 import static java.util.Arrays.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.springframework.data.jdbc.testing.TestDatabaseFeatures.Feature.*;
-import static org.springframework.test.context.TestExecutionListeners.MergeMode.*;
 
 import junit.framework.AssertionFailedError;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Objects;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
-import org.springframework.data.jdbc.testing.AssumeFeatureTestExecutionListener;
 import org.springframework.data.jdbc.testing.EnabledOnFeature;
+import org.springframework.data.jdbc.testing.IntegrationTest;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestExecutionListeners;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Very simple use cases for creation and usage of JdbcRepositories for Entities that contain {@link List}s.
@@ -51,10 +46,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Thomas Lang
  * @author Chirag Tailor
  */
-@ContextConfiguration
-@Transactional
-@TestExecutionListeners(value = AssumeFeatureTestExecutionListener.class, mergeMode = MERGE_WITH_DEFAULTS)
-@ExtendWith(SpringExtension.class)
+@IntegrationTest
 public class JdbcRepositoryWithListsIntegrationTests {
 
 	@Autowired NamedParameterJdbcTemplate template;
@@ -339,14 +331,11 @@ public class JdbcRepositoryWithListsIntegrationTests {
 		public boolean equals(final Object o) {
 			if (o == this)
 				return true;
-			if (!(o instanceof Leaf))
+			if (!(o instanceof final Leaf other))
 				return false;
-			final Leaf other = (Leaf) o;
 			final Object this$name = this.getName();
 			final Object other$name = other.getName();
-			if (this$name == null ? other$name != null : !this$name.equals(other$name))
-				return false;
-			return true;
+			return Objects.equals(this$name, other$name);
 		}
 
 		public int hashCode() {

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryWithMapsIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryWithMapsIntegrationTests.java
@@ -17,7 +17,6 @@ package org.springframework.data.jdbc.repository;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.springframework.data.jdbc.testing.TestDatabaseFeatures.Feature.*;
-import static org.springframework.test.context.TestExecutionListeners.MergeMode.*;
 
 import junit.framework.AssertionFailedError;
 
@@ -25,22 +24,17 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
-import org.springframework.data.jdbc.testing.AssumeFeatureTestExecutionListener;
 import org.springframework.data.jdbc.testing.EnabledOnFeature;
+import org.springframework.data.jdbc.testing.IntegrationTest;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestExecutionListeners;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Very simple use cases for creation and usage of JdbcRepositories for Entities that contain {@link java.util.Map}s.
@@ -48,10 +42,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Jens Schauder
  * @author Thomas Lang
  */
-@ContextConfiguration
-@Transactional
-@TestExecutionListeners(value = AssumeFeatureTestExecutionListener.class, mergeMode = MERGE_WITH_DEFAULTS)
-@ExtendWith(SpringExtension.class)
+@IntegrationTest
 public class JdbcRepositoryWithMapsIntegrationTests {
 
 	@Configuration

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryWithMapsIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryWithMapsIntegrationTests.java
@@ -49,15 +49,8 @@ public class JdbcRepositoryWithMapsIntegrationTests {
 	@Import(TestConfiguration.class)
 	static class Config {
 
-		@Autowired JdbcRepositoryFactory factory;
-
 		@Bean
-		Class<?> testClass() {
-			return JdbcRepositoryWithMapsIntegrationTests.class;
-		}
-
-		@Bean
-		DummyEntityRepository dummyEntityRepository() {
+		DummyEntityRepository dummyEntityRepository(JdbcRepositoryFactory factory) {
 			return factory.getRepository(DummyEntityRepository.class);
 		}
 	}

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/StringBasedJdbcQueryMappingConfigurationIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/StringBasedJdbcQueryMappingConfigurationIntegrationTests.java
@@ -60,11 +60,6 @@ public class StringBasedJdbcQueryMappingConfigurationIntegrationTests {
 	static class Config {
 
 		@Bean
-		Class<?> testClass() {
-			return StringBasedJdbcQueryMappingConfigurationIntegrationTests.class;
-		}
-
-		@Bean
 		QueryMappingConfiguration mappers() {
 			return new DefaultQueryMappingConfiguration();
 		}

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/StringBasedJdbcQueryMappingConfigurationIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/StringBasedJdbcQueryMappingConfigurationIntegrationTests.java
@@ -20,11 +20,9 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -36,14 +34,12 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.jdbc.repository.config.DefaultQueryMappingConfiguration;
 import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories;
 import org.springframework.data.jdbc.repository.query.Query;
+import org.springframework.data.jdbc.testing.IntegrationTest;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Very simple use cases for creation and usage of {@link ResultSetExtractor}s in JdbcRepository.
@@ -51,9 +47,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Evgeni Dimitrov
  * @author Hebert Coelho
  */
-@ContextConfiguration
-@Transactional
-@ExtendWith(SpringExtension.class)
+@IntegrationTest
 public class StringBasedJdbcQueryMappingConfigurationIntegrationTests {
 
 	private final static String CAR_MODEL = "ResultSetExtractor Car";
@@ -98,7 +92,7 @@ public class StringBasedJdbcQueryMappingConfigurationIntegrationTests {
 
 		@Override
 		public List<Car> extractData(ResultSet rs) throws SQLException, DataAccessException {
-			return Arrays.asList(new Car(1L, customerService.process()));
+			return List.of(new Car(1L, customerService.process()));
 		}
 
 	}
@@ -107,6 +101,7 @@ public class StringBasedJdbcQueryMappingConfigurationIntegrationTests {
 
 		@Autowired private CustomerService customerService;
 
+		@Override
 		public String mapRow(ResultSet rs, int rowNum) throws SQLException {
 			return customerService.process();
 		}

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/config/EnableJdbcAuditingHsqlIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/config/EnableJdbcAuditingHsqlIntegrationTests.java
@@ -30,7 +30,8 @@ import org.springframework.context.ApplicationListener;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
@@ -39,12 +40,16 @@ import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jdbc.testing.DatabaseType;
+import org.springframework.data.jdbc.testing.EnabledOnDatabase;
+import org.springframework.data.jdbc.testing.IntegrationTest;
+import org.springframework.data.jdbc.testing.TestClass;
+import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.relational.core.mapping.NamingStrategy;
 import org.springframework.data.relational.core.mapping.event.BeforeConvertCallback;
 import org.springframework.data.relational.core.mapping.event.BeforeSaveEvent;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Component;
-import org.springframework.test.context.ActiveProfiles;
 
 /**
  * Tests the {@link EnableJdbcAuditing} annotation.
@@ -53,7 +58,8 @@ import org.springframework.test.context.ActiveProfiles;
  * @author Jens Schauder
  * @author Salim Achouche
  */
-@ActiveProfiles("hsql")
+@IntegrationTest
+@EnabledOnDatabase(DatabaseType.HSQL)
 public class EnableJdbcAuditingHsqlIntegrationTests {
 
 	SoftAssertions softly = new SoftAssertions();
@@ -63,7 +69,7 @@ public class EnableJdbcAuditingHsqlIntegrationTests {
 
 		configureRepositoryWith( //
 				AuditingAnnotatedDummyEntityRepository.class, //
-				TestConfiguration.class, //
+				Config.class, //
 				AuditingConfiguration.class) //
 						.accept(repository -> {
 
@@ -120,7 +126,7 @@ public class EnableJdbcAuditingHsqlIntegrationTests {
 
 		configureRepositoryWith( //
 				DummyEntityRepository.class, //
-				TestConfiguration.class, //
+				Config.class, //
 				AuditingConfiguration.class) //
 						.accept(repository -> {
 
@@ -142,7 +148,7 @@ public class EnableJdbcAuditingHsqlIntegrationTests {
 
 		configureRepositoryWith( //
 				AuditingAnnotatedDummyEntityRepository.class, //
-				TestConfiguration.class, //
+				Config.class, //
 				CustomizeAuditorAwareAndDateTimeProvider.class) //
 						.accept(repository -> {
 
@@ -164,7 +170,7 @@ public class EnableJdbcAuditingHsqlIntegrationTests {
 
 		configureRepositoryWith( //
 				AuditingAnnotatedDummyEntityRepository.class, //
-				TestConfiguration.class, //
+				Config.class, //
 				CustomizeAuditorAware.class) //
 						.accept(repository -> {
 
@@ -183,7 +189,7 @@ public class EnableJdbcAuditingHsqlIntegrationTests {
 
 		configureRepositoryWith( //
 				AuditingAnnotatedDummyEntityRepository.class, //
-				TestConfiguration.class, //
+				Config.class, //
 				AuditingConfiguration.class, //
 				OrderAssertingEventListener.class, //
 				OrderAssertingCallback.class //
@@ -310,8 +316,10 @@ public class EnableJdbcAuditingHsqlIntegrationTests {
 
 		@Override
 		public boolean equals(Object o) {
-			if (this == o) return true;
-			if (o == null || getClass() != o.getClass()) return false;
+			if (this == o)
+				return true;
+			if (o == null || getClass() != o.getClass())
+				return false;
 			DummyEntity that = (DummyEntity) o;
 			return Objects.equals(id, that.id) && Objects.equals(name, that.name);
 		}
@@ -322,13 +330,14 @@ public class EnableJdbcAuditingHsqlIntegrationTests {
 		}
 	}
 
-	@ComponentScan("org.springframework.data.jdbc.testing")
+	@Configuration
 	@EnableJdbcRepositories(considerNestedRepositories = true)
-	static class TestConfiguration {
+	@Import(TestConfiguration.class)
+	static class Config {
 
 		@Bean
-		Class<?> testClass() {
-			return EnableJdbcAuditingHsqlIntegrationTests.class;
+		TestClass testClass() {
+			return TestClass.of(EnableJdbcAuditingHsqlIntegrationTests.class);
 		}
 
 		@Bean
@@ -336,6 +345,7 @@ public class EnableJdbcAuditingHsqlIntegrationTests {
 
 			return new NamingStrategy() {
 
+				@Override
 				public String getTableName(Class<?> type) {
 					return "DummyEntity";
 				}

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/config/EnableJdbcAuditingHsqlIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/config/EnableJdbcAuditingHsqlIntegrationTests.java
@@ -24,7 +24,6 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -62,8 +61,6 @@ import org.springframework.stereotype.Component;
 @EnabledOnDatabase(DatabaseType.HSQL)
 public class EnableJdbcAuditingHsqlIntegrationTests {
 
-	SoftAssertions softly = new SoftAssertions();
-
 	@Test // DATAJDBC-204
 	public void auditForAnnotatedEntity() {
 
@@ -78,25 +75,23 @@ public class EnableJdbcAuditingHsqlIntegrationTests {
 
 							AuditingAnnotatedDummyEntity entity = repository.save(new AuditingAnnotatedDummyEntity());
 
-							softly.assertThat(entity.id).as("id not null").isNotNull();
-							softly.assertThat(entity.getCreatedBy()).as("created by set").isEqualTo("user01");
-							softly.assertThat(entity.getCreatedDate()).as("created date set").isAfter(now);
-							softly.assertThat(entity.getLastModifiedBy()).as("modified by set").isEqualTo("user01");
-							softly.assertThat(entity.getLastModifiedDate()).as("modified date set")
+							assertThat(entity.id).as("id not null").isNotNull();
+							assertThat(entity.getCreatedBy()).as("created by set").isEqualTo("user01");
+							assertThat(entity.getCreatedDate()).as("created date set").isAfter(now);
+							assertThat(entity.getLastModifiedBy()).as("modified by set").isEqualTo("user01");
+							assertThat(entity.getLastModifiedDate()).as("modified date set")
 									.isAfterOrEqualTo(entity.getCreatedDate());
-							softly.assertThat(entity.getLastModifiedDate()).as("modified date after instance creation").isAfter(now);
+							assertThat(entity.getLastModifiedDate()).as("modified date after instance creation").isAfter(now);
 
 							AuditingAnnotatedDummyEntity reloaded = repository.findById(entity.id).get();
 
-							softly.assertThat(reloaded.getCreatedBy()).as("reload created by").isNotNull();
-							softly.assertThat(reloaded.getCreatedDate()).as("reload created date").isNotNull();
-							softly.assertThat(reloaded.getLastModifiedBy()).as("reload modified by").isNotNull();
-							softly.assertThat(reloaded.getLastModifiedDate()).as("reload modified date").isNotNull();
+							assertThat(reloaded.getCreatedBy()).as("reload created by").isNotNull();
+							assertThat(reloaded.getCreatedDate()).as("reload created date").isNotNull();
+							assertThat(reloaded.getLastModifiedBy()).as("reload modified by").isNotNull();
+							assertThat(reloaded.getLastModifiedDate()).as("reload modified date").isNotNull();
 
 							LocalDateTime beforeCreatedDate = entity.getCreatedDate();
 							LocalDateTime beforeLastModifiedDate = entity.getLastModifiedDate();
-
-							softly.assertAll();
 
 							sleepMillis(10);
 
@@ -104,20 +99,18 @@ public class EnableJdbcAuditingHsqlIntegrationTests {
 
 							entity = repository.save(entity);
 
-							softly.assertThat(entity.getCreatedBy()).as("created by unchanged").isEqualTo("user01");
-							softly.assertThat(entity.getCreatedDate()).as("created date unchanged").isEqualTo(beforeCreatedDate);
-							softly.assertThat(entity.getLastModifiedBy()).as("modified by updated").isEqualTo("user02");
-							softly.assertThat(entity.getLastModifiedDate()).as("modified date updated")
+							assertThat(entity.getCreatedBy()).as("created by unchanged").isEqualTo("user01");
+							assertThat(entity.getCreatedDate()).as("created date unchanged").isEqualTo(beforeCreatedDate);
+							assertThat(entity.getLastModifiedBy()).as("modified by updated").isEqualTo("user02");
+							assertThat(entity.getLastModifiedDate()).as("modified date updated")
 									.isAfter(beforeLastModifiedDate);
 
 							reloaded = repository.findById(entity.id).get();
 
-							softly.assertThat(reloaded.getCreatedBy()).as("2. reload created by").isNotNull();
-							softly.assertThat(reloaded.getCreatedDate()).as("2. reload created date").isNotNull();
-							softly.assertThat(reloaded.getLastModifiedBy()).as("2. reload modified by").isNotNull();
-							softly.assertThat(reloaded.getLastModifiedDate()).as("2. reload modified date").isNotNull();
-
-							softly.assertAll();
+							assertThat(reloaded.getCreatedBy()).as("2. reload created by").isNotNull();
+							assertThat(reloaded.getCreatedDate()).as("2. reload created date").isNotNull();
+							assertThat(reloaded.getLastModifiedBy()).as("2. reload modified by").isNotNull();
+							assertThat(reloaded.getLastModifiedDate()).as("2. reload modified date").isNotNull();
 						});
 	}
 
@@ -132,10 +125,8 @@ public class EnableJdbcAuditingHsqlIntegrationTests {
 
 							DummyEntity entity = repository.save(new DummyEntity());
 
-							softly.assertThat(entity.id).isNotNull();
-							softly.assertThat(repository.findById(entity.id).get()).isEqualTo(entity);
-
-							softly.assertAll();
+							assertThat(entity.id).isNotNull();
+							assertThat(repository.findById(entity.id).get()).isEqualTo(entity);
 
 							entity = repository.save(entity);
 
@@ -157,11 +148,11 @@ public class EnableJdbcAuditingHsqlIntegrationTests {
 
 							AuditingAnnotatedDummyEntity entity = repository.save(new AuditingAnnotatedDummyEntity());
 
-							softly.assertThat(entity.id).isNotNull();
-							softly.assertThat(entity.getCreatedBy()).isEqualTo("custom user");
-							softly.assertThat(entity.getCreatedDate()).isEqualTo(currentDateTime);
-							softly.assertThat(entity.getLastModifiedBy()).isNull();
-							softly.assertThat(entity.getLastModifiedDate()).isNull();
+							assertThat(entity.id).isNotNull();
+							assertThat(entity.getCreatedBy()).isEqualTo("custom user");
+							assertThat(entity.getCreatedDate()).isEqualTo(currentDateTime);
+							assertThat(entity.getLastModifiedBy()).isNull();
+							assertThat(entity.getLastModifiedDate()).isNull();
 						});
 	}
 
@@ -176,11 +167,11 @@ public class EnableJdbcAuditingHsqlIntegrationTests {
 
 							AuditingAnnotatedDummyEntity entity = repository.save(new AuditingAnnotatedDummyEntity());
 
-							softly.assertThat(entity.id).isNotNull();
-							softly.assertThat(entity.getCreatedBy()).isEqualTo("user");
-							softly.assertThat(entity.getCreatedDate()).isNull();
-							softly.assertThat(entity.getLastModifiedBy()).isEqualTo("user");
-							softly.assertThat(entity.getLastModifiedDate()).isNull();
+							assertThat(entity.id).isNotNull();
+							assertThat(entity.getCreatedBy()).isEqualTo("user");
+							assertThat(entity.getCreatedDate()).isNull();
+							assertThat(entity.getLastModifiedBy()).isEqualTo("user");
+							assertThat(entity.getLastModifiedDate()).isNull();
 						});
 	}
 
@@ -223,8 +214,6 @@ public class EnableJdbcAuditingHsqlIntegrationTests {
 			try (ConfigurableApplicationContext context = new AnnotationConfigApplicationContext(configurationClasses)) {
 
 				test.accept(context.getBean(repositoryType));
-
-				softly.assertAll();
 			}
 		};
 	}

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/config/EnableJdbcRepositoriesBrokenTransactionManagerRefIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/config/EnableJdbcRepositoriesBrokenTransactionManagerRefIntegrationTests.java
@@ -18,25 +18,23 @@ package org.springframework.data.jdbc.repository.config;
 import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.jdbc.testing.IntegrationTest;
+import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.repository.CrudRepository;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
  * Tests the {@link EnableJdbcRepositories} annotation.
  *
  * @author Jens Schauder
  */
-@ExtendWith(SpringExtension.class)
-@ContextConfiguration(
-		classes = EnableJdbcRepositoriesBrokenTransactionManagerRefIntegrationTests.TestConfiguration.class)
+@IntegrationTest
 public class EnableJdbcRepositoriesBrokenTransactionManagerRefIntegrationTests {
 
 	@Autowired DummyRepository repository;
@@ -62,15 +60,12 @@ public class EnableJdbcRepositoriesBrokenTransactionManagerRefIntegrationTests {
 		}
 	}
 
-	@ComponentScan("org.springframework.data.jdbc.testing")
+	@Configuration
 	@EnableJdbcRepositories(considerNestedRepositories = true,
 			includeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = DummyRepository.class),
 			transactionManagerRef = "no-such-transaction-manager")
-	static class TestConfiguration {
+	@Import(TestConfiguration.class)
+	static class Config {
 
-		@Bean
-		Class<?> testClass() {
-			return EnableJdbcRepositoriesBrokenTransactionManagerRefIntegrationTests.class;
-		}
 	}
 }

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/config/EnableJdbcRepositoriesIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/config/EnableJdbcRepositoriesIntegrationTests.java
@@ -25,12 +25,13 @@ import javax.sql.DataSource;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.jdbc.core.JdbcAggregateTemplate;
 import org.springframework.data.jdbc.core.convert.BatchJdbcOperations;
@@ -41,8 +42,9 @@ import org.springframework.data.jdbc.core.convert.JdbcConverter;
 import org.springframework.data.jdbc.core.convert.SqlGeneratorSource;
 import org.springframework.data.jdbc.core.convert.SqlParametersFactory;
 import org.springframework.data.jdbc.repository.QueryMappingConfiguration;
-import org.springframework.data.jdbc.repository.config.EnableJdbcRepositoriesIntegrationTests.TestConfiguration;
 import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactoryBean;
+import org.springframework.data.jdbc.testing.IntegrationTest;
+import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.relational.core.dialect.Dialect;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
@@ -50,8 +52,6 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.util.ReflectionUtils;
 
 /**
@@ -64,8 +64,7 @@ import org.springframework.util.ReflectionUtils;
  * @author Chirag Tailor
  * @author Diego Krupitza
  */
-@ExtendWith(SpringExtension.class)
-@ContextConfiguration(classes = TestConfiguration.class)
+@IntegrationTest
 public class EnableJdbcRepositoriesIntegrationTests {
 
 	static final Field MAPPER_MAP = ReflectionUtils.findField(JdbcRepositoryFactoryBean.class,
@@ -143,17 +142,13 @@ public class EnableJdbcRepositoriesIntegrationTests {
 		}
 	}
 
-	@ComponentScan("org.springframework.data.jdbc.testing")
+	@Configuration
 	@EnableJdbcRepositories(considerNestedRepositories = true,
 			includeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = DummyRepository.class),
 			jdbcOperationsRef = "qualifierJdbcOperations", dataAccessStrategyRef = "qualifierDataAccessStrategy",
 			repositoryBaseClass = DummyRepositoryBaseClass.class)
-	static class TestConfiguration {
-
-		@Bean
-		Class<?> testClass() {
-			return EnableJdbcRepositoriesIntegrationTests.class;
-		}
+	@Import(TestConfiguration.class)
+	static class Config {
 
 		@Bean
 		QueryMappingConfiguration rowMappers() {
@@ -172,8 +167,8 @@ public class EnableJdbcRepositoriesIntegrationTests {
 		DataAccessStrategy defaultDataAccessStrategy(
 				@Qualifier("namedParameterJdbcTemplate") NamedParameterJdbcOperations template,
 				RelationalMappingContext context, JdbcConverter converter, Dialect dialect) {
-			return new DataAccessStrategyFactory(new SqlGeneratorSource(context, converter, dialect), converter,
-					template, new SqlParametersFactory(context, converter),
+			return new DataAccessStrategyFactory(new SqlGeneratorSource(context, converter, dialect), converter, template,
+					new SqlParametersFactory(context, converter),
 					new InsertStrategyFactory(template, new BatchJdbcOperations(template.getJdbcOperations()), dialect)).create();
 		}
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/query/QueryAnnotationHsqlIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/query/QueryAnnotationHsqlIntegrationTests.java
@@ -26,7 +26,6 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
@@ -60,10 +59,6 @@ public class QueryAnnotationHsqlIntegrationTests {
 			includeFilters = @ComponentScan.Filter(value = DummyEntityRepository.class, type = FilterType.ASSIGNABLE_TYPE))
 	static class Config {
 
-		@Bean
-		Class<?> testClass() {
-			return QueryAnnotationHsqlIntegrationTests.class;
-		}
 	}
 
 	@Autowired DummyEntityRepository repository;

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/query/QueryAnnotationHsqlIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/query/QueryAnnotationHsqlIntegrationTests.java
@@ -25,7 +25,6 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -35,13 +34,13 @@ import org.springframework.context.annotation.Import;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories;
+import org.springframework.data.jdbc.testing.DatabaseType;
+import org.springframework.data.jdbc.testing.EnabledOnDatabase;
+import org.springframework.data.jdbc.testing.IntegrationTest;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.lang.Nullable;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Tests the execution of queries from {@link Query} annotations on repository methods.
@@ -51,9 +50,8 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Mark Paluch
  * @author Dennis Effing
  */
-@Transactional
-@ActiveProfiles("hsql")
-@ExtendWith(SpringExtension.class)
+@IntegrationTest
+@EnabledOnDatabase(DatabaseType.HSQL)
 public class QueryAnnotationHsqlIntegrationTests {
 
 	@Configuration

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/AssumeFeatureTestExecutionListener.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/AssumeFeatureTestExecutionListener.java
@@ -15,11 +15,12 @@
  */
 package org.springframework.data.jdbc.testing;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 import org.springframework.context.ApplicationContext;
+import org.springframework.data.jdbc.testing.TestDatabaseFeatures.Feature;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestExecutionListener;
 
@@ -37,7 +38,7 @@ public class AssumeFeatureTestExecutionListener implements TestExecutionListener
 		ApplicationContext applicationContext = testContext.getApplicationContext();
 		TestDatabaseFeatures databaseFeatures = applicationContext.getBean(TestDatabaseFeatures.class);
 
-		List<TestDatabaseFeatures.Feature> requiredFeatures = new ArrayList<>();
+		Set<Feature> requiredFeatures = new LinkedHashSet<>();
 
 		EnabledOnFeature classAnnotation = testContext.getTestClass().getAnnotation(EnabledOnFeature.class);
 		if (classAnnotation != null) {

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/CombiningActiveProfileResolver.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/CombiningActiveProfileResolver.java
@@ -16,9 +16,10 @@
 
 package org.springframework.data.jdbc.testing;
 
-import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
-import org.jetbrains.annotations.NotNull;
 import org.springframework.test.context.ActiveProfilesResolver;
 import org.springframework.test.context.support.DefaultActiveProfilesResolver;
 
@@ -28,7 +29,7 @@ import org.springframework.test.context.support.DefaultActiveProfilesResolver;
  *
  * @author Jens Schauder
  */
-public class CombiningActiveProfileResolver implements ActiveProfilesResolver {
+class CombiningActiveProfileResolver implements ActiveProfilesResolver {
 
 	private static final String SPRING_PROFILES_ACTIVE = "spring.profiles.active";
 	private final DefaultActiveProfilesResolver defaultActiveProfilesResolver = new DefaultActiveProfilesResolver();
@@ -36,29 +37,23 @@ public class CombiningActiveProfileResolver implements ActiveProfilesResolver {
 	@Override
 	public String[] resolve(Class<?> testClass) {
 
-		ArrayList<Object> combinedProfiles = new ArrayList<>();
+		Set<String> combinedProfiles = new LinkedHashSet<>();
 
-		for (String profile : defaultActiveProfilesResolver.resolve(testClass)) {
-			combinedProfiles.add(profile);
-		}
-		for (String profile : getSystemProfiles()) {
-			combinedProfiles.add(profile);
-		}
-		for (String profile : getEnvironmentProfiles()) {
-			combinedProfiles.add(profile);
-		}
+		combinedProfiles.addAll(Arrays.asList(defaultActiveProfilesResolver.resolve(testClass)));
+		combinedProfiles.addAll(Arrays.asList(getSystemProfiles()));
+		combinedProfiles.addAll(Arrays.asList(getEnvironmentProfiles()));
 
 		return combinedProfiles.toArray(new String[0]);
 	}
 
-	@NotNull
 	private static String[] getSystemProfiles() {
 
 		if (System.getProperties().containsKey(SPRING_PROFILES_ACTIVE)) {
 
-			final String profiles = System.getProperty(SPRING_PROFILES_ACTIVE);
+			String profiles = System.getProperty(SPRING_PROFILES_ACTIVE);
 			return profiles.split("\\s*,\\s*");
 		}
+
 		return new String[0];
 	}
 
@@ -69,6 +64,7 @@ public class CombiningActiveProfileResolver implements ActiveProfilesResolver {
 			String profiles = System.getenv().get(SPRING_PROFILES_ACTIVE);
 			return profiles.split("\\s*,\\s*");
 		}
+
 		return new String[0];
 
 	}

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/ConditionalOnDatabase.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/ConditionalOnDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,26 +15,34 @@
  */
 package org.springframework.data.jdbc.testing;
 
-import org.springframework.test.annotation.IfProfileValue;
-
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
-import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.context.annotation.Conditional;
+
 /**
- * Run the annotated test only against a HsqlDb database.
+ * Indicates that a component is eligible for registration/evaluation when a profile for a {@link DatabaseType} is
+ * activated.
+ * <p>
+ * This annotation can be used on Spring components and on tests to indicate that a test should be only run when the
+ * appropriate profile is activated.
  *
- * Requires the use of {@code @ProfileValueSourceConfiguration(DatabaseProfileValueSource.class)} on the test.
- *
- * @author Jens Schauder
+ * @author Mark Paluch
+ * @see Conditional
+ * @see DatabaseTypeCondition
  */
-@Target({ElementType.TYPE, ElementType.METHOD})
+@Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@Inherited
-@IfProfileValue(name = "current.database.is.not.hsqldb", value = "false")
-public @interface HsqlDbOnly {
+@Conditional(DatabaseTypeCondition.class)
+public @interface ConditionalOnDatabase {
+
+	/**
+	 * Database type on which the annotated class should be enabled.
+	 */
+	DatabaseType value();
+
 }

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/DatabaseType.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/DatabaseType.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jdbc.testing;
+
+import java.util.Locale;
+
+/**
+ * Supported database types. Types are defined to express against which database a particular test is expected to run.
+ *
+ * @author Mark Paluch
+ */
+public enum DatabaseType {
+
+	DB2, HSQL, H2, MARIADB, MYSQL, ORACLE, POSTGRES, SQL_SEVER("mssql");
+
+	private final String profile;
+
+	DatabaseType() {
+		this.profile = name().toLowerCase(Locale.ROOT);
+	}
+
+	DatabaseType(String profile) {
+		this.profile = profile;
+	}
+
+	/**
+	 * @return the profile string as used in Spring profiles.
+	 */
+	public String getProfile() {
+		return profile;
+	}
+}

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/DatabaseTypeCondition.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/DatabaseTypeCondition.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jdbc.testing;
+
+import static org.assertj.core.api.Assumptions.*;
+
+import java.lang.reflect.AnnotatedElement;
+import java.util.Optional;
+
+import org.junit.platform.commons.util.AnnotationUtils;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.TestExecutionListener;
+import org.springframework.util.MultiValueMap;
+
+/**
+ * {@link Condition} and {@link TestExecutionListener} to test whether the required {@link DatabaseType} configuration
+ * has been configured. The usage through {@link Condition} requires an existing application context while the
+ * {@link TestExecutionListener} usage detects the activated profiles early to avoid expensive application context
+ * startup if the condition does not match.
+ *
+ * @author Mark Paluch
+ */
+@Order(Integer.MIN_VALUE)
+class DatabaseTypeCondition implements Condition, TestExecutionListener {
+
+	@Override
+	public void prepareTestInstance(TestContext testContext) {
+		evaluate(testContext.getTestClass(), new StandardEnvironment(), true);
+	}
+
+	@Override
+	public void beforeTestMethod(TestContext testContext) {
+		evaluate(testContext.getTestMethod(),
+				(ConfigurableEnvironment) testContext.getApplicationContext().getEnvironment(), false);
+	}
+
+	private static void evaluate(AnnotatedElement element, ConfigurableEnvironment environment,
+			boolean enabledByDefault) {
+
+		Optional<DatabaseType> databaseType = AnnotationUtils.findAnnotation(element, ConditionalOnDatabase.class)
+				.map(ConditionalOnDatabase::value);
+
+		if (databaseType.isEmpty()) {
+			databaseType = AnnotationUtils.findAnnotation(element, EnabledOnDatabase.class).map(EnabledOnDatabase::value);
+		}
+
+		if (databaseType.isPresent()) {
+
+			DatabaseType type = databaseType.get();
+
+			if (enabledByDefault) {
+				EnabledOnDatabaseCustomizer.customizeEnvironment(environment, type);
+			}
+
+			assumeThat(environment.getActiveProfiles()).as("Enabled profiles").contains(type.getProfile());
+		}
+	}
+
+	@Override
+	public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+
+		MultiValueMap<String, Object> attrs = metadata.getAllAnnotationAttributes(ConditionalOnDatabase.class.getName());
+		if (attrs != null) {
+			for (Object value : attrs.get("value")) {
+
+				DatabaseType type = (DatabaseType) value;
+
+				if (context.getEnvironment().matchesProfiles(type.getProfile())) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		return true;
+	}
+
+}

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/Db2DataSourceConfiguration.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/Db2DataSourceConfiguration.java
@@ -20,6 +20,7 @@ import javax.sql.DataSource;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.testcontainers.containers.Db2Container;
@@ -30,7 +31,7 @@ import org.testcontainers.containers.Db2Container;
  * @author Jens Schauder
  * @author Mark Paluch
  */
-@Configuration
+@Configuration(proxyBeanMethods = false)
 @ConditionalOnDatabase(DatabaseType.DB2)
 class Db2DataSourceConfiguration extends DataSourceConfiguration {
 
@@ -38,6 +39,10 @@ class Db2DataSourceConfiguration extends DataSourceConfiguration {
 	private static final Log LOG = LogFactory.getLog(Db2DataSourceConfiguration.class);
 
 	private static Db2Container DB_2_CONTAINER;
+
+	public Db2DataSourceConfiguration(TestClass testClass, Environment environment) {
+		super(testClass, environment);
+	}
 
 	@Override
 	protected DataSource createDataSource() {

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/Db2DataSourceConfiguration.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/Db2DataSourceConfiguration.java
@@ -19,12 +19,9 @@ import javax.sql.DataSource;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
-
 import org.testcontainers.containers.Db2Container;
 
 /**
@@ -34,7 +31,7 @@ import org.testcontainers.containers.Db2Container;
  * @author Mark Paluch
  */
 @Configuration
-@Profile("db2")
+@ConditionalOnDatabase(DatabaseType.DB2)
 class Db2DataSourceConfiguration extends DataSourceConfiguration {
 
 	public static final String DOCKER_IMAGE_NAME = "ibmcom/db2:11.5.7.0a";

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/EnabledOnDatabase.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/EnabledOnDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 the original author or authors.
+ * Copyright 2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,35 +17,41 @@ package org.springframework.data.jdbc.testing;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.core.env.Environment;
+import org.springframework.data.jdbc.testing.EnabledOnDatabaseCustomizer.EnabledOnDatabaseCustomizerFactory;
+import org.springframework.data.jdbc.testing.TestClassCustomizer.TestClassCustomizerFactory;
+import org.springframework.test.context.ContextCustomizerFactories;
+
 /**
- * {@code @RequiredFeature} is used to express that the annotated test class or test method is only <em>enabled</em> on
- * one or more specified Spring Data JDBC {@link org.springframework.data.jdbc.testing.TestDatabaseFeatures.Feature
- * features} are supported by the underlying database.
+ * Selects a database configuration on which the test class is enabled.
  * <p>
- * When applied at the class level, all test methods within that class will be enabled if they support all database
- * features.
+ * Using this annotation will enable the test configuration if no test environment is given. If a test environment is
+ * configured through {@link Environment#getActiveProfiles()}, then the test class will be skipped if the environment
+ * doesn't match the specified {@link DatabaseType}.
  * <p>
  * If a test method is disabled via this annotation, that does not prevent the test class from being instantiated.
  * Rather, it prevents the execution of the test method and method-level lifecycle callbacks such as {@code @BeforeEach}
  * methods, {@code @AfterEach} methods, and corresponding extension APIs. When annotated on method and class level, all
  * annotated features must match to run a test.
  *
- * @author Jens Schauder
  * @author Mark Paluch
+ * @see DatabaseTypeCondition
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.METHOD, ElementType.TYPE })
+@Target(ElementType.TYPE)
+// required twice as the annotation lookup doesn't merge multiple occurences of the same annotation
+@ContextCustomizerFactories(value = { TestClassCustomizerFactory.class, EnabledOnDatabaseCustomizerFactory.class })
 @Documented
-public @interface EnabledOnFeature {
+@Inherited
+public @interface EnabledOnDatabase {
 
 	/**
-	 * Databases features on which the annotated class or method should be enabled.
-	 *
-	 * @see TestDatabaseFeatures.Feature
+	 * Database type on which the annotated class should be enabled.
 	 */
-	TestDatabaseFeatures.Feature[] value();
+	DatabaseType value();
 }

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/EnabledOnDatabaseCustomizer.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/EnabledOnDatabaseCustomizer.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jdbc.testing;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.annotation.MergedAnnotation;
+import org.springframework.core.annotation.MergedAnnotations;
+import org.springframework.core.annotation.MergedAnnotations.SearchStrategy;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.test.context.ContextConfigurationAttributes;
+import org.springframework.test.context.ContextCustomizer;
+import org.springframework.test.context.ContextCustomizerFactory;
+import org.springframework.test.context.MergedContextConfiguration;
+
+/**
+ * {@link ContextCustomizer} to select a specific configuration profile based on the {@code @EnabledOnDatabase}
+ * annotation.
+ *
+ * @author Mark Paluch
+ * @see EnabledOnDatabase
+ */
+public class EnabledOnDatabaseCustomizer implements ContextCustomizer {
+
+	private final Class<?> testClass;
+
+	public EnabledOnDatabaseCustomizer(Class<?> testClass) {
+		this.testClass = testClass;
+	}
+
+	@Override
+	public void customizeContext(ConfigurableApplicationContext context, MergedContextConfiguration mergedConfig) {
+
+		MergedAnnotation<EnabledOnDatabase> annotation = MergedAnnotations.from(testClass, SearchStrategy.TYPE_HIERARCHY)
+				.get(EnabledOnDatabase.class);
+
+		if (annotation.isPresent()) {
+
+			DatabaseType value = annotation.getEnum("value", DatabaseType.class);
+
+			customizeEnvironment(context.getEnvironment(), value);
+		}
+	}
+
+	static void customizeEnvironment(ConfigurableEnvironment environment, DatabaseType value) {
+
+		List<String> profiles = Arrays.asList(environment.getActiveProfiles());
+
+		for (DatabaseType databaseType : DatabaseType.values()) {
+
+			if (profiles.contains(databaseType.getProfile())) {
+				return;
+			}
+		}
+
+		environment.addActiveProfile(value.getProfile());
+	}
+
+	public static class EnabledOnDatabaseCustomizerFactory implements ContextCustomizerFactory {
+
+		@Override
+		public ContextCustomizer createContextCustomizer(Class<?> testClass,
+				List<ContextConfigurationAttributes> configAttributes) {
+			return new EnabledOnDatabaseCustomizer(testClass);
+		}
+
+	}
+
+}

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/H2DataSourceConfiguration.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/H2DataSourceConfiguration.java
@@ -20,7 +20,6 @@ import javax.sql.DataSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 
@@ -30,7 +29,7 @@ import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
  * @author Mark Paluch
  */
 @Configuration
-@Profile({ "h2" })
+@ConditionalOnDatabase(DatabaseType.H2)
 class H2DataSourceConfiguration {
 
 	@Autowired Class<?> context;

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/H2DataSourceConfiguration.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/H2DataSourceConfiguration.java
@@ -17,7 +17,6 @@ package org.springframework.data.jdbc.testing;
 
 import javax.sql.DataSource;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
@@ -28,11 +27,15 @@ import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
  *
  * @author Mark Paluch
  */
-@Configuration
+@Configuration(proxyBeanMethods = false)
 @ConditionalOnDatabase(DatabaseType.H2)
 class H2DataSourceConfiguration {
 
-	@Autowired Class<?> context;
+	private final TestClass testClass;
+
+	public H2DataSourceConfiguration(TestClass testClass) {
+		this.testClass = testClass;
+	}
 
 	@Bean
 	DataSource dataSource() {
@@ -42,7 +45,7 @@ class H2DataSourceConfiguration {
 				.setType(EmbeddedDatabaseType.H2) //
 				.setScriptEncoding("UTF-8") //
 				.ignoreFailedDrops(true) //
-				.addScript(TestUtils.createScriptName(context, "h2")) //
+				.addScript(TestUtils.createScriptName(testClass.getTestClass(), "h2")) //
 				.build();
 	}
 }

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/HsqlDataSourceConfiguration.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/HsqlDataSourceConfiguration.java
@@ -17,7 +17,6 @@ package org.springframework.data.jdbc.testing;
 
 import javax.sql.DataSource;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -30,11 +29,15 @@ import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
  * @author Jens Schauder
  * @author Oliver Gierke
  */
-@Configuration
+@Configuration(proxyBeanMethods = false)
 @Profile({ "hsql", "!h2 && !mysql && !mariadb && !postgres && !oracle && !db2 && !mssql" })
 class HsqlDataSourceConfiguration {
 
-	@Autowired Class<?> context;
+	private final TestClass testClass;
+
+	public HsqlDataSourceConfiguration(TestClass testClass) {
+		this.testClass = testClass;
+	}
 
 	@Bean
 	DataSource dataSource() {
@@ -44,7 +47,7 @@ class HsqlDataSourceConfiguration {
 				.setType(EmbeddedDatabaseType.HSQL) //
 				.setScriptEncoding("UTF-8") //
 				.ignoreFailedDrops(true) //
-				.addScript(TestUtils.createScriptName(context, "hsql")) //
+				.addScript(TestUtils.createScriptName(testClass.getTestClass(), "hsql")) //
 				.build();
 	}
 }

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/IntegrationTest.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/IntegrationTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jdbc.testing;
+
+import static org.springframework.test.context.TestExecutionListeners.MergeMode.*;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.data.jdbc.testing.EnabledOnDatabaseCustomizer.EnabledOnDatabaseCustomizerFactory;
+import org.springframework.data.jdbc.testing.TestClassCustomizer.TestClassCustomizerFactory;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextCustomizerFactories;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * {@code @IntegrationTest} is a <em>composed annotation</em> that combines
+ * {@link ExtendWith @ExtendWith(SpringExtension.class)} from JUnit Jupiter with
+ * {@link ContextConfiguration @ContextConfiguration} and {@link TestExecutionListeners @TestExecutionListeners} from
+ * the <em>Spring TestContext Framework</em> enabling transaction management.
+ * <p>
+ * Integration tests use the Spring Context and a potential profile to create an environment for tests to run against.
+ * As integration tests require a specific set of infrastructure components, test classes and configuration components
+ * can be annotated with {@link EnabledOnDatabase @EnabledOnDatabase} or
+ * {@link ConditionalOnDatabase @ConditionalOnDatabase} to enable and restrict or only restrict configuration on which
+ * tests are ran.
+ *
+ * @author Mark Paluch
+ * @see ConditionalOnDatabase
+ * @see EnabledOnDatabase
+ */
+@TestExecutionListeners(value = AssumeFeatureTestExecutionListener.class, mergeMode = MERGE_WITH_DEFAULTS)
+// required twice as the annotation lookup doesn't merge multiple occurences of the same annotation
+@ContextCustomizerFactories(value = { TestClassCustomizerFactory.class, EnabledOnDatabaseCustomizerFactory.class })
+@ActiveProfiles(resolver = CombiningActiveProfileResolver.class)
+@ExtendWith(SpringExtension.class)
+@Transactional
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface IntegrationTest {
+
+}

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/LicenseListener.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/LicenseListener.java
@@ -15,17 +15,14 @@
  */
 package org.springframework.data.jdbc.testing;
 
+import static org.springframework.data.jdbc.testing.MsSqlDataSourceConfiguration.*;
+
 import org.junit.AssumptionViolatedException;
 import org.springframework.core.annotation.Order;
-import org.springframework.core.env.Profiles;
 import org.springframework.core.env.StandardEnvironment;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestExecutionListener;
-import org.testcontainers.containers.Db2Container;
-import org.testcontainers.containers.MSSQLServerContainer;
 import org.testcontainers.utility.LicenseAcceptance;
-
-import static org.springframework.data.jdbc.testing.MsSqlDataSourceConfiguration.*;
 
 /**
  * {@link TestExecutionListener} to selectively skip tests if the license for a particular database container was not
@@ -35,20 +32,18 @@ import static org.springframework.data.jdbc.testing.MsSqlDataSourceConfiguration
  * @author Jens Schauder
  */
 @Order(Integer.MIN_VALUE)
-public class LicenseListener implements TestExecutionListener {
+class LicenseListener implements TestExecutionListener {
 
-	private StandardEnvironment environment;
+	private final StandardEnvironment environment = new StandardEnvironment();
 
 	@Override
 	public void prepareTestInstance(TestContext testContext) {
 
-		environment = new StandardEnvironment();
-
-		if (environment.acceptsProfiles(Profiles.of("db2"))) {
+		if (environment.matchesProfiles(DatabaseType.DB2.getProfile())) {
 			assumeLicenseAccepted(Db2DataSourceConfiguration.DOCKER_IMAGE_NAME);
 		}
 
-		if (environment.acceptsProfiles(Profiles.of("mssql"))) {
+		if (environment.matchesProfiles(DatabaseType.SQL_SEVER.getProfile())) {
 			assumeLicenseAccepted(MS_SQL_SERVER_VERSION);
 		}
 	}

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/MariaDBDataSourceConfiguration.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/MariaDBDataSourceConfiguration.java
@@ -23,6 +23,7 @@ import javax.sql.DataSource;
 import org.mariadb.jdbc.MariaDbDataSource;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.jdbc.datasource.init.ScriptUtils;
 import org.testcontainers.containers.MariaDBContainer;
@@ -34,11 +35,15 @@ import org.testcontainers.containers.MariaDBContainer;
  * @author Mark Paluch
  * @author Jens Schauder
  */
-@Configuration
+@Configuration(proxyBeanMethods = false)
 @ConditionalOnDatabase(DatabaseType.MARIADB)
 class MariaDBDataSourceConfiguration extends DataSourceConfiguration implements InitializingBean {
 
 	private static MariaDBContainer<?> MARIADB_CONTAINER;
+
+	public MariaDBDataSourceConfiguration(TestClass testClass, Environment environment) {
+		super(testClass, environment);
+	}
 
 	@Override
 	protected DataSource createDataSource() {

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/MariaDBDataSourceConfiguration.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/MariaDBDataSourceConfiguration.java
@@ -23,7 +23,6 @@ import javax.sql.DataSource;
 import org.mariadb.jdbc.MariaDbDataSource;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.jdbc.datasource.init.ScriptUtils;
 import org.testcontainers.containers.MariaDBContainer;
@@ -36,7 +35,7 @@ import org.testcontainers.containers.MariaDBContainer;
  * @author Jens Schauder
  */
 @Configuration
-@Profile("mariadb")
+@ConditionalOnDatabase(DatabaseType.MARIADB)
 class MariaDBDataSourceConfiguration extends DataSourceConfiguration implements InitializingBean {
 
 	private static MariaDBContainer<?> MARIADB_CONTAINER;

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/MsSqlDataSourceConfiguration.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/MsSqlDataSourceConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.data.jdbc.testing;
 import javax.sql.DataSource;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.testcontainers.containers.MSSQLServerContainer;
 
@@ -32,12 +33,16 @@ import com.microsoft.sqlserver.jdbc.SQLServerDataSource;
  * @author Mark Paluch
  * @see <a href="https://github.com/testcontainers/testcontainers-java/tree/master/modules/mssqlserver"></a>
  */
-@Configuration
+@Configuration(proxyBeanMethods = false)
 @ConditionalOnDatabase(DatabaseType.MARIADB)
 public class MsSqlDataSourceConfiguration extends DataSourceConfiguration {
 
 	public static final String MS_SQL_SERVER_VERSION = "mcr.microsoft.com/mssql/server:2022-CU5-ubuntu-20.04";
 	private static MSSQLServerContainer<?> MSSQL_CONTAINER;
+
+	public MsSqlDataSourceConfiguration(TestClass testClass, Environment environment) {
+		super(testClass, environment);
+	}
 
 	@Override
 	protected DataSource createDataSource() {

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/MsSqlDataSourceConfiguration.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/MsSqlDataSourceConfiguration.java
@@ -18,7 +18,6 @@ package org.springframework.data.jdbc.testing;
 import javax.sql.DataSource;
 
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.testcontainers.containers.MSSQLServerContainer;
 
@@ -34,7 +33,7 @@ import com.microsoft.sqlserver.jdbc.SQLServerDataSource;
  * @see <a href="https://github.com/testcontainers/testcontainers-java/tree/master/modules/mssqlserver"></a>
  */
 @Configuration
-@Profile({ "mssql" })
+@ConditionalOnDatabase(DatabaseType.MARIADB)
 public class MsSqlDataSourceConfiguration extends DataSourceConfiguration {
 
 	public static final String MS_SQL_SERVER_VERSION = "mcr.microsoft.com/mssql/server:2022-CU5-ubuntu-20.04";

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/MySqlDataSourceConfiguration.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/MySqlDataSourceConfiguration.java
@@ -21,6 +21,7 @@ import javax.sql.DataSource;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.jdbc.datasource.init.ScriptUtils;
 import org.testcontainers.containers.MySQLContainer;
@@ -36,11 +37,15 @@ import com.mysql.cj.jdbc.MysqlDataSource;
  * @author Sedat Gokcen
  * @author Mark Paluch
  */
-@Configuration
+@Configuration(proxyBeanMethods = false)
 @ConditionalOnDatabase(DatabaseType.MYSQL)
 class MySqlDataSourceConfiguration extends DataSourceConfiguration implements InitializingBean {
 
 	private static MySQLContainer<?> MYSQL_CONTAINER;
+
+	public MySqlDataSourceConfiguration(TestClass testClass, Environment environment) {
+		super(testClass, environment);
+	}
 
 	@Override
 	protected DataSource createDataSource() {

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/MySqlDataSourceConfiguration.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/MySqlDataSourceConfiguration.java
@@ -21,7 +21,6 @@ import javax.sql.DataSource;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.jdbc.datasource.init.ScriptUtils;
 import org.testcontainers.containers.MySQLContainer;
@@ -38,7 +37,7 @@ import com.mysql.cj.jdbc.MysqlDataSource;
  * @author Mark Paluch
  */
 @Configuration
-@Profile("mysql")
+@ConditionalOnDatabase(DatabaseType.MYSQL)
 class MySqlDataSourceConfiguration extends DataSourceConfiguration implements InitializingBean {
 
 	private static MySQLContainer<?> MYSQL_CONTAINER;

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/OracleDataSourceConfiguration.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/OracleDataSourceConfiguration.java
@@ -20,7 +20,6 @@ import javax.sql.DataSource;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
@@ -38,7 +37,7 @@ import org.testcontainers.utility.DockerImageName;
  * @author Jens Schauder
  */
 @Configuration
-@Profile("oracle")
+@ConditionalOnDatabase(DatabaseType.ORACLE)
 public class OracleDataSourceConfiguration extends DataSourceConfiguration {
 
 	private static final Log LOG = LogFactory.getLog(OracleDataSourceConfiguration.class);

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/OracleDataSourceConfiguration.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/OracleDataSourceConfiguration.java
@@ -20,6 +20,7 @@ import javax.sql.DataSource;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
@@ -36,13 +37,17 @@ import org.testcontainers.utility.DockerImageName;
  * @author Thomas Lang
  * @author Jens Schauder
  */
-@Configuration
+@Configuration(proxyBeanMethods = false)
 @ConditionalOnDatabase(DatabaseType.ORACLE)
 public class OracleDataSourceConfiguration extends DataSourceConfiguration {
 
 	private static final Log LOG = LogFactory.getLog(OracleDataSourceConfiguration.class);
 
 	private static OracleContainer ORACLE_CONTAINER;
+
+	public OracleDataSourceConfiguration(TestClass testClass, Environment environment) {
+		super(testClass, environment);
+	}
 
 	@Override
 	protected DataSource createDataSource() {

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/PostgresDataSourceConfiguration.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/PostgresDataSourceConfiguration.java
@@ -19,6 +19,7 @@ import javax.sql.DataSource;
 
 import org.postgresql.ds.PGSimpleDataSource;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.testcontainers.containers.PostgreSQLContainer;
 
@@ -30,11 +31,15 @@ import org.testcontainers.containers.PostgreSQLContainer;
  * @author Sedat Gokcen
  * @author Mark Paluch
  */
-@Configuration
+@Configuration(proxyBeanMethods = false)
 @ConditionalOnDatabase(DatabaseType.POSTGRES)
 public class PostgresDataSourceConfiguration extends DataSourceConfiguration {
 
 	private static PostgreSQLContainer<?> POSTGRESQL_CONTAINER;
+
+	public PostgresDataSourceConfiguration(TestClass testClass, Environment environment) {
+		super(testClass, environment);
+	}
 
 	@Override
 	protected DataSource createDataSource() {

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/PostgresDataSourceConfiguration.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/PostgresDataSourceConfiguration.java
@@ -18,11 +18,8 @@ package org.springframework.data.jdbc.testing;
 import javax.sql.DataSource;
 
 import org.postgresql.ds.PGSimpleDataSource;
-
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
-
 import org.testcontainers.containers.PostgreSQLContainer;
 
 /**
@@ -34,7 +31,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
  * @author Mark Paluch
  */
 @Configuration
-@Profile("postgres")
+@ConditionalOnDatabase(DatabaseType.POSTGRES)
 public class PostgresDataSourceConfiguration extends DataSourceConfiguration {
 
 	private static PostgreSQLContainer<?> POSTGRESQL_CONTAINER;

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/TestClass.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/TestClass.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jdbc.testing;
+
+import org.springframework.util.Assert;
+
+/**
+ * Value object to represent the underlying test class.
+ *
+ * @author Mark Paluch
+ */
+public final class TestClass {
+
+	private final Class<?> testClass;
+
+	private TestClass(Class<?> testClass) {
+		this.testClass = testClass;
+	}
+
+	/**
+	 * Create a new {@link TestClass} given {@code testClass}.
+	 *
+	 * @param testClass must not be {@literal null}.
+	 * @return the new {@link TestClass}.
+	 */
+	public static TestClass of(Class<?> testClass) {
+
+		Assert.notNull(testClass, "TestClass must not be null");
+
+		return new TestClass(testClass);
+	}
+
+	public Class<?> getTestClass() {
+		return testClass;
+	}
+}

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/TestClassCustomizer.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/TestClassCustomizer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jdbc.testing;
+
+import java.util.List;
+
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.context.ContextConfigurationAttributes;
+import org.springframework.test.context.ContextCustomizer;
+import org.springframework.test.context.ContextCustomizerFactory;
+import org.springframework.test.context.MergedContextConfiguration;
+
+/**
+ * {@link ContextCustomizer} registering {@link TestClass}.
+ *
+ * @author Mark Paluch
+ */
+class TestClassCustomizer implements ContextCustomizer {
+
+	private final Class<?> testClass;
+
+	public TestClassCustomizer(Class<?> testClass) {
+		this.testClass = testClass;
+	}
+
+	@Override
+	public void customizeContext(ConfigurableApplicationContext context, MergedContextConfiguration mergedConfig) {
+		context.getBeanFactory().registerSingleton(TestClass.class.getSimpleName(), TestClass.of(testClass));
+	}
+
+	static class TestClassCustomizerFactory implements ContextCustomizerFactory {
+
+		@Override
+		public ContextCustomizer createContextCustomizer(Class<?> testClass,
+				List<ContextConfigurationAttributes> configAttributes) {
+			return new TestClassCustomizer(testClass);
+		}
+
+	}
+}

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/TestConfiguration.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/TestConfiguration.java
@@ -31,6 +31,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.convert.CustomConversions;
 import org.springframework.data.jdbc.core.convert.*;
@@ -92,6 +93,7 @@ public class TestConfiguration {
 	}
 
 	@Bean
+	@Primary
 	NamedParameterJdbcOperations namedParameterJdbcTemplate() {
 		return new NamedParameterJdbcTemplate(dataSource);
 	}

--- a/spring-data-jdbc/src/test/resources/META-INF/spring.factories
+++ b/spring-data-jdbc/src/test/resources/META-INF/spring.factories
@@ -1,1 +1,1 @@
-org.springframework.test.context.TestExecutionListener=org.springframework.data.jdbc.testing.LicenseListener
+org.springframework.test.context.TestExecutionListener=org.springframework.data.jdbc.testing.LicenseListener,org.springframework.data.jdbc.testing.DatabaseTypeCondition

--- a/spring-data-r2dbc/pom.xml
+++ b/spring-data-r2dbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-r2dbc</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-GH-1620-SNAPSHOT</version>
 
 	<name>Spring Data R2DBC</name>
 	<description>Spring Data module for R2DBC</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-GH-1620-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-relational</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-GH-1620-SNAPSHOT</version>
 
 	<name>Spring Data Relational</name>
 	<description>Spring Data Relational support</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-GH-1620-SNAPSHOT</version>
 	</parent>
 
 	<properties>


### PR DESCRIPTION
Simplify test configuration, introduce `@EnabledOnDatabase` (run on a particular database if nothing else is configured, otherwise skip) and `@ConditionalOnDatabase` (test for a configuration). Also, introduce `@IntegrationTest` to apply common annotations to an integration test.

Replace `@Autowired Class` with `TestClass` to define a concept what this is for.

Replace closely distributed occurrences of profile strings with `DatabaseType` enumeration.