### PR TITLE
Add support for forein keys in schema generation within aggregates

### DIFF
--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/schema/DefaultSqlTypeMapping.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/schema/DefaultSqlTypeMapping.java
@@ -63,4 +63,9 @@ public class DefaultSqlTypeMapping implements SqlTypeMapping {
 	public String getColumnType(RelationalPersistentProperty property) {
 		return typeMap.get(ClassUtils.resolvePrimitiveIfNecessary(property.getActualType()));
 	}
+
+	@Override
+	public String getColumnTypeByClass(Class clazz) {
+		return typeMap.get(clazz);
+	}
 }

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/schema/ForeignKey.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/schema/ForeignKey.java
@@ -1,11 +1,13 @@
 package org.springframework.data.jdbc.core.mapping.schema;
 
+import java.util.List;
+
 /**
  * Models a Foreign Key for generating SQL for Schema generation.
  *
  * @author Evgenii Koba
  * @since 3.2
  */
-record ForeignKey(String name, String tableName, String columnName, String referencedTableName,
-									String referencedColumnName) {
+record ForeignKey(String name, String tableName, List<String> columnNames, String referencedTableName,
+									List<String> referencedColumnNames) {
 }

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/schema/ForeignKey.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/schema/ForeignKey.java
@@ -1,6 +1,7 @@
 package org.springframework.data.jdbc.core.mapping.schema;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Models a Foreign Key for generating SQL for Schema generation.
@@ -10,4 +11,20 @@ import java.util.List;
  */
 record ForeignKey(String name, String tableName, List<String> columnNames, String referencedTableName,
 									List<String> referencedColumnNames) {
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		ForeignKey that = (ForeignKey) o;
+		return Objects.equals(tableName, that.tableName) && Objects.equals(columnNames, that.columnNames) && Objects.equals(
+				referencedTableName, that.referencedTableName) && Objects.equals(referencedColumnNames,
+				that.referencedColumnNames);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(tableName, columnNames, referencedTableName, referencedColumnNames);
+	}
 }

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/schema/ForeignKey.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/schema/ForeignKey.java
@@ -1,0 +1,27 @@
+package org.springframework.data.jdbc.core.mapping.schema;
+
+import java.util.Objects;
+
+/**
+ * Models a Foreign Key for generating SQL for Schema generation.
+ *
+ * @author Evgenii Koba
+ * @since 3.2
+ */
+record ForeignKey(String name, String tableName, String columnName, String referencedTableName,
+									String referencedColumnName) {
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		ForeignKey that = (ForeignKey) o;
+		return Objects.equals(name, that.name);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(name);
+	}
+}

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/schema/ForeignKey.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/schema/ForeignKey.java
@@ -1,7 +1,5 @@
 package org.springframework.data.jdbc.core.mapping.schema;
 
-import java.util.Objects;
-
 /**
  * Models a Foreign Key for generating SQL for Schema generation.
  *
@@ -10,18 +8,4 @@ import java.util.Objects;
  */
 record ForeignKey(String name, String tableName, String columnName, String referencedTableName,
 									String referencedColumnName) {
-	@Override
-	public boolean equals(Object o) {
-		if (this == o)
-			return true;
-		if (o == null || getClass() != o.getClass())
-			return false;
-		ForeignKey that = (ForeignKey) o;
-		return Objects.equals(name, that.name);
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(name);
-	}
 }

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/schema/LiquibaseChangeSetWriter.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/schema/LiquibaseChangeSetWriter.java
@@ -483,12 +483,12 @@ public class LiquibaseChangeSetWriter {
 
 		return table.getOutgoingForeignKeys().stream().map(foreignKey -> {
 			String tableName = foreignKey.getForeignKeyTable().getName();
-			String columnName = foreignKey.getForeignKeyColumns().stream().findFirst()
-					.map(liquibase.structure.core.Column::getName).get();
+			List<String> columnNames = foreignKey.getForeignKeyColumns().stream()
+					.map(liquibase.structure.core.Column::getName).toList();
 			String referencedTableName = foreignKey.getPrimaryKeyTable().getName();
-			String referencedColumnName = foreignKey.getPrimaryKeyColumns().stream().findFirst()
-					.map(liquibase.structure.core.Column::getName).get();
-			return new ForeignKey(foreignKey.getName(), tableName, columnName, referencedTableName, referencedColumnName);
+			List<String> referencedColumnNames = foreignKey.getPrimaryKeyColumns().stream()
+					.map(liquibase.structure.core.Column::getName).toList();
+			return new ForeignKey(foreignKey.getName(), tableName, columnNames, referencedTableName, referencedColumnNames);
 		}).collect(Collectors.toList());
 	}
 
@@ -579,9 +579,9 @@ public class LiquibaseChangeSetWriter {
 		AddForeignKeyConstraintChange change = new AddForeignKeyConstraintChange();
 		change.setConstraintName(foreignKey.name());
 		change.setBaseTableName(foreignKey.tableName());
-		change.setBaseColumnNames(foreignKey.columnName());
+		change.setBaseColumnNames(String.join(",", foreignKey.columnNames()));
 		change.setReferencedTableName(foreignKey.referencedTableName());
-		change.setReferencedColumnNames(foreignKey.referencedColumnName());
+		change.setReferencedColumnNames(String.join(",", foreignKey.referencedColumnNames()));
 		return change;
 	}
 

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/schema/SchemaDiff.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/schema/SchemaDiff.java
@@ -96,7 +96,7 @@ record SchemaDiff(List<Table> tableAdditions, List<Table> tableDeletions, List<T
 			// Identify deleted columns
 			tableDiff.columnsToDrop().addAll(findDiffs(mappedColumns, existingColumns, nameComparator));
 			// Identify added columns and add columns in order. This order can interleave with existing columns.
-			List<Column> addedColumns = new ArrayList<>(findDiffs(existingColumns, mappedColumns, nameComparator));
+			Collection<Column> addedColumns = findDiffs(existingColumns, mappedColumns, nameComparator);
 			for (Column column : mappedEntity.columns()) {
 				if (addedColumns.contains(column)) {
 					tableDiff.columnsToAdd().add(column);
@@ -107,9 +107,9 @@ record SchemaDiff(List<Table> tableAdditions, List<Table> tableDeletions, List<T
 					nameComparator);
 			Map<String, ForeignKey> existingForeignKeys = createMapping(existingTable.foreignKeys(), ForeignKey::name,
 					nameComparator);
-			// Identify deleted columns
+			// Identify deleted foreign keys
 			tableDiff.fkToDrop().addAll(findDiffs(mappedForeignKeys, existingForeignKeys, nameComparator));
-			// Identify added columns
+			// Identify added foreign keys
 			tableDiff.fkToAdd().addAll(findDiffs(existingForeignKeys, mappedForeignKeys, nameComparator));
 
 			tableDiffs.add(tableDiff);

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/schema/SchemaDiff.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/schema/SchemaDiff.java
@@ -16,6 +16,7 @@
 package org.springframework.data.jdbc.core.mapping.schema;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -91,41 +92,38 @@ record SchemaDiff(List<Table> tableAdditions, List<Table> tableDeletions, List<T
 			TableDiff tableDiff = new TableDiff(mappedEntity);
 
 			Map<String, Column> mappedColumns = createMapping(mappedEntity.columns(), Column::name, nameComparator);
-			mappedEntity.keyColumns().forEach(it -> mappedColumns.put(it.name(), it));
-
 			Map<String, Column> existingColumns = createMapping(existingTable.columns(), Column::name, nameComparator);
-			existingTable.keyColumns().forEach(it -> existingColumns.put(it.name(), it));
-
 			// Identify deleted columns
-			Map<String, Column> toDelete = new TreeMap<>(nameComparator);
-			toDelete.putAll(existingColumns);
-			mappedColumns.keySet().forEach(toDelete::remove);
-
-			tableDiff.columnsToDrop().addAll(toDelete.values());
-
-			// Identify added columns
-			Map<String, Column> addedColumns = new TreeMap<>(nameComparator);
-			addedColumns.putAll(mappedColumns);
-
-			existingColumns.keySet().forEach(addedColumns::remove);
-
-			// Add columns in order. This order can interleave with existing columns.
-			for (Column column : mappedEntity.keyColumns()) {
-				if (addedColumns.containsKey(column.name())) {
-					tableDiff.columnsToAdd().add(column);
-				}
-			}
-
+			tableDiff.columnsToDrop().addAll(findDiffs(mappedColumns, existingColumns, nameComparator));
+			// Identify added columns and add columns in order. This order can interleave with existing columns.
+			List<Column> addedColumns = new ArrayList<>(findDiffs(existingColumns, mappedColumns, nameComparator));
 			for (Column column : mappedEntity.columns()) {
-				if (addedColumns.containsKey(column.name())) {
+				if (addedColumns.contains(column)) {
 					tableDiff.columnsToAdd().add(column);
 				}
 			}
+
+			Map<String, ForeignKey> mappedForeignKeys = createMapping(mappedEntity.foreignKeys(), ForeignKey::name,
+					nameComparator);
+			Map<String, ForeignKey> existingForeignKeys = createMapping(existingTable.foreignKeys(), ForeignKey::name,
+					nameComparator);
+			// Identify deleted columns
+			tableDiff.fkToDrop().addAll(findDiffs(mappedForeignKeys, existingForeignKeys, nameComparator));
+			// Identify added columns
+			tableDiff.fkToAdd().addAll(findDiffs(existingForeignKeys, mappedForeignKeys, nameComparator));
 
 			tableDiffs.add(tableDiff);
 		}
 
 		return tableDiffs;
+	}
+
+	private static <T> Collection<T> findDiffs(Map<String, T> baseMapping, Map<String, T> toCompareMapping,
+			Comparator<String> nameComparator) {
+		Map<String, T> diff = new TreeMap<>(nameComparator);
+		diff.putAll(toCompareMapping);
+		baseMapping.keySet().forEach(diff::remove);
+		return diff.values();
 	}
 
 	private static <T> SortedMap<String, T> createMapping(List<T> items, Function<T, String> keyFunction,

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/schema/SqlTypeMapping.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/schema/SqlTypeMapping.java
@@ -41,6 +41,18 @@ public interface SqlTypeMapping {
 	String getColumnType(RelationalPersistentProperty property);
 
 	/**
+	 * Determines a column type for Class.
+	 *
+	 * @param clazz class for which the type should be determined.
+	 * @return the SQL type to use, such as {@code VARCHAR} or {@code NUMERIC}. Can be {@literal null} if the strategy
+	 *         cannot provide a column type.
+	 */
+	@Nullable
+	default String getColumnTypeByClass(Class clazz) {
+		return null;
+	}
+
+	/**
 	 * Returns the required column type for a persistent property or throws {@link IllegalArgumentException} if the type
 	 * cannot be determined.
 	 *

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/schema/Table.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/schema/Table.java
@@ -18,6 +18,7 @@ package org.springframework.data.jdbc.core.mapping.schema;
 import java.util.ArrayList;
 import java.util.List;
 
+import java.util.stream.Collectors;
 import org.springframework.lang.Nullable;
 import org.springframework.util.ObjectUtils;
 
@@ -35,6 +36,10 @@ record Table(@Nullable String schema, String name, List<Column> columns, List<Fo
 
 	public Table(String name) {
 		this(null, name);
+	}
+
+	public List<Column> getIdColumns() {
+		return columns().stream().filter(Column::identity).collect(Collectors.toList());
 	}
 
 	@Override

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/schema/Table.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/schema/Table.java
@@ -27,7 +27,7 @@ import org.springframework.util.ObjectUtils;
  * @author Kurt Niemi
  * @since 3.2
  */
-record Table(@Nullable String schema, String name, List<Column> keyColumns, List<Column> columns) {
+record Table(@Nullable String schema, String name, List<Column> columns, List<ForeignKey> foreignKeys) {
 
 	public Table(@Nullable String schema, String name) {
 		this(schema, name, new ArrayList<>(), new ArrayList<>());

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/schema/TableDiff.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/schema/TableDiff.java
@@ -25,10 +25,11 @@ import java.util.List;
  * @author Kurt Niemi
  * @since 3.2
  */
-record TableDiff(Table table, List<Column> columnsToAdd, List<Column> columnsToDrop) {
+record TableDiff(Table table, List<Column> columnsToAdd, List<Column> columnsToDrop, List<ForeignKey> fkToAdd,
+								 List<ForeignKey> fkToDrop) {
 
 	public TableDiff(Table table) {
-		this(table, new ArrayList<>(), new ArrayList<>());
+		this(table, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
 	}
 
 }

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/schema/Tables.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/schema/Tables.java
@@ -15,14 +15,19 @@
  */
 package org.springframework.data.jdbc.core.mapping.schema;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mapping.context.MappingContext;
+import org.springframework.data.relational.core.mapping.MappedCollection;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
@@ -37,15 +42,16 @@ import org.springframework.lang.Nullable;
 record Tables(List<Table> tables) {
 
 	public static Tables from(RelationalMappingContext context) {
-		return from(context.getPersistentEntities().stream(), new DefaultSqlTypeMapping(), null);
+		return from(context.getPersistentEntities().stream(), new DefaultSqlTypeMapping(), null, context);
 	}
 
-	// TODO: Add support (i.e. create tickets) to support mapped collections, entities, embedded properties, and aggregate
-	// references.
+	// TODO: Add support (i.e. create tickets) to support entities, embedded properties, and aggregate references.
 
 	public static Tables from(Stream<? extends RelationalPersistentEntity<?>> persistentEntities,
-			SqlTypeMapping sqlTypeMapping, @Nullable String defaultSchema) {
+			SqlTypeMapping sqlTypeMapping, @Nullable String defaultSchema,
+			MappingContext<? extends RelationalPersistentEntity<?>, ? extends RelationalPersistentProperty> context) {
 
+		Map<String, List<ColumnWithForeignKey>> colAndFKByTableName = new HashMap<>();
 		List<Table> tables = persistentEntities
 				.filter(it -> it.isAnnotationPresent(org.springframework.data.relational.core.mapping.Table.class)) //
 				.map(entity -> {
@@ -54,6 +60,7 @@ record Tables(List<Table> tables) {
 
 					Set<RelationalPersistentProperty> identifierColumns = new LinkedHashSet<>();
 					entity.getPersistentProperties(Id.class).forEach(identifierColumns::add);
+					collectForeignKeysInfo(entity, context, colAndFKByTableName, sqlTypeMapping);
 
 					for (RelationalPersistentProperty property : entity) {
 
@@ -61,19 +68,77 @@ record Tables(List<Table> tables) {
 							continue;
 						}
 
-						String columnType = sqlTypeMapping.getRequiredColumnType(property);
-
 						Column column = new Column(property.getColumnName().getReference(), sqlTypeMapping.getColumnType(property),
-								sqlTypeMapping.isNullable(property), identifierColumns.contains(property));
+												   sqlTypeMapping.isNullable(property), identifierColumns.contains(property));
 						table.columns().add(column);
 					}
 					return table;
 				}).collect(Collectors.toList());
+
+		applyForeignKeys(tables, colAndFKByTableName);
 
 		return new Tables(tables);
 	}
 
 	public static Tables empty() {
 		return new Tables(Collections.emptyList());
+	}
+
+	private static void applyForeignKeys(List<Table> tables,
+			Map<String, List<ColumnWithForeignKey>> colAndFKByTableName) {
+
+		colAndFKByTableName.forEach(
+				(tableName, colsAndFK) -> tables.stream().filter(table -> table.name().equals(tableName)).forEach(table -> {
+
+					colsAndFK.forEach(colAndFK -> {
+						if (!table.columns().contains(colAndFK.column())) {
+							table.columns().add(colAndFK.column());
+						}
+					});
+
+					colsAndFK.forEach(colAndFK -> table.foreignKeys().add(colAndFK.foreignKey()));
+				}));
+	}
+
+	private static void collectForeignKeysInfo(RelationalPersistentEntity<?> entity,
+			MappingContext<? extends RelationalPersistentEntity<?>, ? extends RelationalPersistentProperty> context,
+			Map<String, List<ColumnWithForeignKey>> keyColumnsByTableName, SqlTypeMapping sqlTypeMapping) {
+
+		RelationalPersistentProperty identifierColumn = entity.getPersistentProperty(Id.class);
+
+		entity.getPersistentProperties(MappedCollection.class).forEach(property -> {
+			if (property.isEntity()) {
+				property.getPersistentEntityTypeInformation().forEach(typeInformation -> {
+
+					String tableName = context.getRequiredPersistentEntity(typeInformation).getTableName().getReference();
+					String columnName = property.getReverseColumnName(entity).getReference();
+					String referencedTableName = entity.getTableName().getReference();
+					String referencedColumnName = identifierColumn.getColumnName().getReference();
+
+					ForeignKey foreignKey = new ForeignKey(getForeignKeyName(referencedTableName, referencedColumnName),
+							tableName, columnName, referencedTableName, referencedColumnName);
+					Column column = new Column(columnName, sqlTypeMapping.getColumnType(identifierColumn), true, false);
+
+					ColumnWithForeignKey columnWithForeignKey = new ColumnWithForeignKey(column, foreignKey);
+					keyColumnsByTableName.compute(
+							context.getRequiredPersistentEntity(typeInformation).getTableName().getReference(), (key, value) -> {
+								if (value == null) {
+									return new ArrayList<>(List.of(columnWithForeignKey));
+								} else {
+									value.add(columnWithForeignKey);
+									return value;
+								}
+							});
+				});
+			}
+		});
+	}
+
+	//TODO should we place it in BasicRelationalPersistentProperty/BasicRelationalPersistentEntity and generate using NamingStrategy?
+	private static String getForeignKeyName(String referencedTableName, String referencedColumnName) {
+		return String.format("%s_%s_fk", referencedTableName, referencedColumnName);
+	}
+
+	private record ColumnWithForeignKey(Column column, ForeignKey foreignKey) {
 	}
 }

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/schema/Tables.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/schema/Tables.java
@@ -17,10 +17,11 @@ package org.springframework.data.jdbc.core.mapping.schema;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -52,7 +53,7 @@ record Tables(List<Table> tables) {
 			SqlTypeMapping sqlTypeMapping, @Nullable String defaultSchema,
 			MappingContext<? extends RelationalPersistentEntity<?>, ? extends RelationalPersistentProperty> context) {
 
-		List<NestedEntityMetadata> nestedEntityMetadataList = new ArrayList<>();
+		List<ForeignKeyMetadata> foreignKeyMetadataList = new ArrayList<>();
 		List<Table> tables = persistentEntities
 				.filter(it -> it.isAnnotationPresent(org.springframework.data.relational.core.mapping.Table.class)) //
 				.map(entity -> {
@@ -61,11 +62,11 @@ record Tables(List<Table> tables) {
 
 					Set<RelationalPersistentProperty> identifierColumns = new LinkedHashSet<>();
 					entity.getPersistentProperties(Id.class).forEach(identifierColumns::add);
-					collectNestedEntityMetadata(entity, context, nestedEntityMetadataList, sqlTypeMapping);
 
 					for (RelationalPersistentProperty property : entity) {
 
 						if (property.isEntity() && !property.isEmbedded()) {
+							foreignKeyMetadataList.add(createForeignKeyMetadata(entity, property, context, sqlTypeMapping));
 							continue;
 						}
 
@@ -76,7 +77,7 @@ record Tables(List<Table> tables) {
 					return table;
 				}).collect(Collectors.toList());
 
-		applyNestedEntityMetadata(tables, nestedEntityMetadataList);
+		applyForeignKeyMetadata(tables, foreignKeyMetadataList);
 
 		return new Tables(tables);
 	}
@@ -86,40 +87,34 @@ record Tables(List<Table> tables) {
 	}
 
 	/**
-	 * Apply all information we know about nested entities to correctly create foreign and primary keys
+	 * Apply all information we know about foreign keys to correctly create foreign and primary keys
 	 */
-	private static void applyNestedEntityMetadata(List<Table> tables, List<NestedEntityMetadata> nestedEntityMetadataList) {
-		nestedEntityMetadataList.forEach(nestedEntityMetadata -> {
-			while (nestedEntityMetadata.parentMetadata != null) {
-				NestedEntityMetadata current = nestedEntityMetadata;
-				NestedEntityMetadata parentMetadata = current.parentMetadata;
+	private static void applyForeignKeyMetadata(List<Table> tables, List<ForeignKeyMetadata> foreignKeyMetadataList) {
 
-				Table table = tables.stream().filter(t -> t.name().equals(current.tableName)).findAny().get();
+		foreignKeyMetadataList.forEach(foreignKeyMetadata -> {
+			Table table = tables.stream().filter(t -> t.name().equals(foreignKeyMetadata.tableName)).findAny().get();
 
-				List<Column> parentIdColumns = new ArrayList<>();
-				collectIdentityColumns(parentMetadata, parentIdColumns);
-				List<String> parentIdColumnNames = parentIdColumns.stream().map(Column::name).toList();
+			List<Column> parentIdColumns = collectParentIdentityColumns(foreignKeyMetadata, foreignKeyMetadataList, tables);
+			List<String> parentIdColumnNames = parentIdColumns.stream().map(Column::name).toList();
 
-				String foreignKeyName = getForeignKeyName(parentMetadata.tableName, parentIdColumnNames);
-				if(parentIdColumnNames.size() == 1) {
-					addIfAbsent(table.columns(), new Column(parentMetadata.referencedIdColumnName, parentMetadata.idColumnType,
-									false, current.idColumnName == null));
-					if(parentMetadata.referencedKeyColumnName != null) {
-						addIfAbsent(table.columns(), new Column(parentMetadata.referencedKeyColumnName, parentMetadata.referencedKeyColumnType,
-								false, true));
-					}
-					table.foreignKeys().add(new ForeignKey(foreignKeyName, current.tableName,
-							List.of(parentMetadata.referencedIdColumnName), parentMetadata.tableName, parentIdColumnNames));
-				} else {
-					addIfAbsent(table.columns(), parentIdColumns.toArray(new Column[0]));
-					addIfAbsent(table.columns(), new Column(parentMetadata.referencedKeyColumnName, parentMetadata.referencedKeyColumnType,
+			String foreignKeyName = getForeignKeyName(foreignKeyMetadata.parentTableName, parentIdColumnNames);
+			if(parentIdColumnNames.size() == 1) {
+				addIfAbsent(table.columns(), new Column(foreignKeyMetadata.referencingColumnName(), parentIdColumns.get(0).type(),
+						false, table.getIdColumns().isEmpty()));
+				if(foreignKeyMetadata.keyColumnName() != null) {
+					addIfAbsent(table.columns(), new Column(foreignKeyMetadata.keyColumnName(), foreignKeyMetadata.keyColumnType(),
 							false, true));
-					table.foreignKeys().add(new ForeignKey(foreignKeyName, current.tableName, parentIdColumnNames,
-							parentMetadata.tableName, parentIdColumnNames));
 				}
-
-				nestedEntityMetadata = nestedEntityMetadata.parentMetadata;
+				addIfAbsent(table.foreignKeys(), new ForeignKey(foreignKeyName, foreignKeyMetadata.tableName(),
+						List.of(foreignKeyMetadata.referencingColumnName()), foreignKeyMetadata.parentTableName(), parentIdColumnNames));
+			} else {
+				addIfAbsent(table.columns(), parentIdColumns.toArray(new Column[0]));
+				addIfAbsent(table.columns(), new Column(foreignKeyMetadata.keyColumnName(), foreignKeyMetadata.keyColumnType(),
+						false, true));
+				addIfAbsent(table.foreignKeys(), new ForeignKey(foreignKeyName, foreignKeyMetadata.tableName(), parentIdColumnNames,
+						foreignKeyMetadata.parentTableName(), parentIdColumnNames));
 			}
+
 		});
 	}
 
@@ -131,70 +126,77 @@ record Tables(List<Table> tables) {
 		}
 	}
 
-	private static void collectIdentityColumns(NestedEntityMetadata nestedEntityMetadata, List<Column> identityColumns) {
-		if(nestedEntityMetadata.idColumnName != null) {
-			if(identityColumns.isEmpty()) {
-				identityColumns.add(new Column(nestedEntityMetadata.idColumnName, nestedEntityMetadata.idColumnType,
-						false, true));
-			} else {
-				identityColumns.add(new Column(nestedEntityMetadata.referencedIdColumnName, nestedEntityMetadata.idColumnType,
-						false, true));
-			}
-			Collections.reverse(identityColumns);
+	private static List<Column> collectParentIdentityColumns(ForeignKeyMetadata child,
+			List<ForeignKeyMetadata> foreignKeyMetadataList, List<Table> tables) {
+		return collectParentIdentityColumns(child, foreignKeyMetadataList, tables, new HashSet<>());
+	}
+
+	private static List<Column> collectParentIdentityColumns(ForeignKeyMetadata child,
+			List<ForeignKeyMetadata> foreignKeyMetadataList, List<Table> tables, Set<String> excludeTables) {
+
+		excludeTables.add(child.tableName());
+
+		Table parentTable = findTableByName(tables, child.parentTableName());
+		ForeignKeyMetadata parentMetadata = findMetadataByTableName(foreignKeyMetadataList, child.parentTableName(), excludeTables);
+		List<Column> parentIdColumns = parentTable.getIdColumns();
+
+		if (!parentIdColumns.isEmpty()) {
+			return new ArrayList<>(parentIdColumns);
+		} else if(parentMetadata == null) {
+				//mustn't happen, probably wrong entity declaration
+				return new ArrayList<>();
 		} else {
-			NestedEntityMetadata parentMetadata = nestedEntityMetadata.parentMetadata;
-			identityColumns.add(new Column(parentMetadata.referencedKeyColumnName, parentMetadata.referencedKeyColumnType,
-					false, true));
-			collectIdentityColumns(parentMetadata, identityColumns);
+			List<Column> parentParentIdColumns = collectParentIdentityColumns(parentMetadata, foreignKeyMetadataList, tables);
+			if (parentParentIdColumns.size() == 1) {
+				Column parentParentIdColumn = parentParentIdColumns.get(0);
+				Column withChangedName = new Column(parentMetadata.referencingColumnName, parentParentIdColumn.type(), false, true);
+				parentParentIdColumns = new LinkedList<>(List.of(withChangedName));
+			}
+			if (parentMetadata.keyColumnName() != null) {
+				parentParentIdColumns.add(new Column(parentMetadata.keyColumnName(), parentMetadata.keyColumnType(), false, true));
+			}
+			return parentParentIdColumns;
 		}
 	}
 
-	private static void collectNestedEntityMetadata(RelationalPersistentEntity<?> entity,
+	@Nullable
+	private static Table findTableByName(List<Table> tables, String tableName) {
+		return tables.stream().filter(table -> table.name().equals(tableName)).findAny().orElse(null);
+	}
+
+	@Nullable
+	private static ForeignKeyMetadata findMetadataByTableName(List<ForeignKeyMetadata> metadata, String tableName,
+			Set<String> excludeTables) {
+		return metadata.stream()
+				.filter(m -> m.tableName().equals(tableName) && !excludeTables.contains(m.parentTableName()))
+				.findAny()
+				.orElse(null);
+	}
+
+	private static ForeignKeyMetadata createForeignKeyMetadata(
+			RelationalPersistentEntity<?> entity,
+			RelationalPersistentProperty property,
 			MappingContext<? extends RelationalPersistentEntity<?>, ? extends RelationalPersistentProperty> context,
-			List<NestedEntityMetadata> nestedEntityMetadataList, SqlTypeMapping sqlTypeMapping) {
+			SqlTypeMapping sqlTypeMapping) {
 
-		Optional<RelationalPersistentProperty> idColumn = Optional.ofNullable(entity.getPersistentProperty(Id.class));
+		RelationalPersistentEntity childEntity = context.getRequiredPersistentEntity(property.getActualType());
 
-		entity.getPersistentProperties(MappedCollection.class).forEach(property -> {
-			if (property.isEntity()) {
-				property.getPersistentEntityTypeInformation().forEach(typeInformation -> {
-
-					String referencedKeyColumnType = null;
-					if(property.getType() == List.class) {
-						referencedKeyColumnType = sqlTypeMapping.getColumnTypeByClass(Integer.class);
-					} else if (property.getType() == Map.class) {
-						referencedKeyColumnType = sqlTypeMapping.getColumnTypeByClass(property.getComponentType());
-					}
-
-					NestedEntityMetadata parent = new NestedEntityMetadata(
-							idColumn.map(column -> column.getColumnName().getReference()).orElse(null),
-							idColumn.map(column -> sqlTypeMapping.getColumnType(column)).orElse(null),
-							property.getReverseColumnName(entity).getReference(),
-							Optional.ofNullable(property.getKeyColumn()).map(SqlIdentifier::getReference).orElse(null),
-							referencedKeyColumnType,
-							entity.getTableName().getReference(),
-							null);
-
-					RelationalPersistentEntity childEntity = context.getRequiredPersistentEntity(typeInformation);
-					Optional<RelationalPersistentProperty> childIdColumn = Optional.ofNullable(entity.getPersistentProperty(Id.class));
-					NestedEntityMetadata child = new NestedEntityMetadata(
-							childIdColumn.map(column -> column.getColumnName().getReference()).orElse(null),
-							childIdColumn.map(column -> sqlTypeMapping.getColumnType(column)).orElse(null),
-							null,
-							null,
-							null,
-							childEntity.getTableName().getReference(),
-							parent);
-
-					boolean added = attachNewChild(nestedEntityMetadataList, child);
-					added = added || attachNewParent(nestedEntityMetadataList, child);
-					if(!added) {
-						nestedEntityMetadataList.add(child);
-					}
-
-				});
+		String referencedKeyColumnType = null;
+		if(property.isAnnotationPresent(MappedCollection.class)) {
+			if (property.getType() == List.class) {
+				referencedKeyColumnType = sqlTypeMapping.getColumnTypeByClass(Integer.class);
+			} else if (property.getType() == Map.class) {
+				referencedKeyColumnType = sqlTypeMapping.getColumnTypeByClass(property.getComponentType());
 			}
-		});
+		}
+
+		return new ForeignKeyMetadata(
+				childEntity.getTableName().getReference(),
+				property.getReverseColumnName(entity).getReference(),
+				Optional.ofNullable(property.getKeyColumn()).map(SqlIdentifier::getReference).orElse(null),
+				referencedKeyColumnType,
+				entity.getTableName().getReference()
+		);
 	}
 
 	//TODO should we place it in BasicRelationalPersistentProperty/BasicRelationalPersistentEntity and generate using NamingStrategy?
@@ -202,79 +204,8 @@ record Tables(List<Table> tables) {
 		return String.format("%s_%s_fk", referencedTableName, String.join("_", referencedColumnNames));
 	}
 
-	private static boolean attachNewParent(List<NestedEntityMetadata> nestedEntityMetadataList, NestedEntityMetadata newParent) {
+	private record ForeignKeyMetadata(String tableName, String referencingColumnName, @Nullable String keyColumnName,
+																		@Nullable String keyColumnType, String parentTableName) {
 
-		Optional<NestedEntityMetadata> oldParent
-				= nestedEntityMetadataList.stream().filter(elem -> elem.getLastParent().equals(newParent)).findAny();
-		if(oldParent.isEmpty()) {
-			return false;
-		} else {
-			oldParent.get().parentMetadata.parentMetadata = newParent.parentMetadata;
-			return true;
-		}
-	}
-
-	private static boolean attachNewChild(List<NestedEntityMetadata> nestedEntityMetadataList, NestedEntityMetadata newChild) {
-
-		int index = nestedEntityMetadataList.indexOf(newChild.parentMetadata);
-		if(index == -1) {
-			return false;
-		} else {
-			NestedEntityMetadata oldChild = nestedEntityMetadataList.remove(index);
-			newChild.parentMetadata.parentMetadata = oldChild.parentMetadata;
-			nestedEntityMetadataList.add(newChild);
-			return true;
-		}
-	}
-
-	private static class NestedEntityMetadata {
-
-		public NestedEntityMetadata(String idColumnName, String idColumnType, String referencedIdColumnName,
-				String referencedKeyColumnName, String referencedKeyColumnType, String tableName,
-				NestedEntityMetadata parentMetadata) {
-			this.idColumnName = idColumnName;
-			this.idColumnType = idColumnType;
-			this.referencedIdColumnName = referencedIdColumnName;
-			this.referencedKeyColumnName = referencedKeyColumnName;
-			this.referencedKeyColumnType = referencedKeyColumnType;
-			this.tableName = tableName;
-			this.parentMetadata = parentMetadata;
-		}
-
-		private String idColumnName;
-		private String idColumnType;
-		//column name for nested entity set by 'idColumn' of MappedCollection
-		private String referencedIdColumnName;
-		//column name for nested entity set by 'keyColumn' of MappedCollection
-		private String referencedKeyColumnName;
-		private String referencedKeyColumnType;
-		private String tableName;
-		private NestedEntityMetadata parentMetadata;
-
-		public NestedEntityMetadata getLastParent() {
-			if(parentMetadata == null) {
-				return null;
-			}
-			NestedEntityMetadata lastParent = parentMetadata;
-			while (lastParent.parentMetadata != null) {
-				lastParent = lastParent.parentMetadata;
-			}
-			return lastParent;
-		}
-
-		@Override
-		public boolean equals(Object o) {
-			if (this == o)
-				return true;
-			if (o == null || getClass() != o.getClass())
-				return false;
-			NestedEntityMetadata that = (NestedEntityMetadata) o;
-			return Objects.equals(tableName, that.tableName);
-		}
-
-		@Override
-		public int hashCode() {
-			return Objects.hash(tableName);
-		}
 	}
 }

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/mapping/schema/LiquibaseChangeSetWriterIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/mapping/schema/LiquibaseChangeSetWriterIntegrationTests.java
@@ -20,7 +20,9 @@ import static org.assertj.core.api.Assertions.*;
 import liquibase.change.AddColumnConfig;
 import liquibase.change.ColumnConfig;
 import liquibase.change.core.AddColumnChange;
+import liquibase.change.core.AddForeignKeyConstraintChange;
 import liquibase.change.core.DropColumnChange;
+import liquibase.change.core.DropForeignKeyConstraintChange;
 import liquibase.change.core.DropTableChange;
 import liquibase.changelog.ChangeSet;
 import liquibase.changelog.DatabaseChangeLog;
@@ -41,6 +43,7 @@ import org.springframework.core.io.ClassRelativeResourceLoader;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.jdbc.core.mapping.schema.LiquibaseChangeSetWriter.ChangeSetMetadata;
+import org.springframework.data.relational.core.mapping.MappedCollection;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.Table;
 import org.springframework.data.util.Predicates;
@@ -202,6 +205,93 @@ class LiquibaseChangeSetWriterIntegrationTests {
 		});
 	}
 
+	@Test // GH-1599
+	void dropAndCreateTableWithRightOrderOfFkChanges() {
+
+		withEmbeddedDatabase("drop-and-create-table-with-fk.sql", c -> {
+
+			H2Database h2Database = new H2Database();
+			h2Database.setConnection(new JdbcConnection(c));
+
+			LiquibaseChangeSetWriter writer = new LiquibaseChangeSetWriter(contextOf(GroupOfPersons.class));
+			writer.setDropTableFilter(Predicates.isTrue());
+
+			ChangeSet changeSet = writer.createChangeSet(ChangeSetMetadata.create(), h2Database, new DatabaseChangeLog());
+
+			assertThat(changeSet.getChanges()).hasSize(4);
+			assertThat(changeSet.getChanges().get(0)).isInstanceOf(DropForeignKeyConstraintChange.class);
+			assertThat(changeSet.getChanges().get(3)).isInstanceOf(AddForeignKeyConstraintChange.class);
+
+			DropForeignKeyConstraintChange dropForeignKey = (DropForeignKeyConstraintChange) changeSet.getChanges().get(0);
+			assertThat(dropForeignKey.getConstraintName()).isEqualToIgnoringCase("fk_to_drop");
+			assertThat(dropForeignKey.getBaseTableName()).isEqualToIgnoringCase("table_to_drop");
+
+			AddForeignKeyConstraintChange addForeignKey = (AddForeignKeyConstraintChange) changeSet.getChanges().get(3);
+			assertThat(addForeignKey.getBaseTableName()).isEqualToIgnoringCase("person");
+			assertThat(addForeignKey.getBaseColumnNames()).isEqualToIgnoringCase("group_id");
+			assertThat(addForeignKey.getReferencedTableName()).isEqualToIgnoringCase("group_of_persons");
+			assertThat(addForeignKey.getReferencedColumnNames()).isEqualToIgnoringCase("id");
+		});
+	}
+
+	@Test // GH-1599
+	void dropAndCreateFkInRightOrder() {
+
+		withEmbeddedDatabase("drop-and-create-fk.sql", c -> {
+
+			H2Database h2Database = new H2Database();
+			h2Database.setConnection(new JdbcConnection(c));
+
+			LiquibaseChangeSetWriter writer = new LiquibaseChangeSetWriter(contextOf(GroupOfPersons.class));
+			writer.setDropColumnFilter((s, s2) -> true);
+
+			ChangeSet changeSet = writer.createChangeSet(ChangeSetMetadata.create(), h2Database, new DatabaseChangeLog());
+
+			assertThat(changeSet.getChanges()).hasSize(3);
+			assertThat(changeSet.getChanges().get(0)).isInstanceOf(DropForeignKeyConstraintChange.class);
+			assertThat(changeSet.getChanges().get(2)).isInstanceOf(AddForeignKeyConstraintChange.class);
+
+			DropForeignKeyConstraintChange dropForeignKey = (DropForeignKeyConstraintChange) changeSet.getChanges().get(0);
+			assertThat(dropForeignKey.getConstraintName()).isEqualToIgnoringCase("fk_to_drop");
+			assertThat(dropForeignKey.getBaseTableName()).isEqualToIgnoringCase("person");
+
+			AddForeignKeyConstraintChange addForeignKey = (AddForeignKeyConstraintChange) changeSet.getChanges().get(2);
+			assertThat(addForeignKey.getBaseTableName()).isEqualToIgnoringCase("person");
+			assertThat(addForeignKey.getBaseColumnNames()).isEqualToIgnoringCase("group_id");
+			assertThat(addForeignKey.getReferencedTableName()).isEqualToIgnoringCase("group_of_persons");
+			assertThat(addForeignKey.getReferencedColumnNames()).isEqualToIgnoringCase("id");
+		});
+	}
+
+	@Test // GH-1599
+	void fieldForFkWillBeCreated() {
+
+		withEmbeddedDatabase("create-fk-with-field.sql", c -> {
+
+			H2Database h2Database = new H2Database();
+			h2Database.setConnection(new JdbcConnection(c));
+
+			LiquibaseChangeSetWriter writer = new LiquibaseChangeSetWriter(contextOf(GroupOfPersons.class));
+
+			ChangeSet changeSet = writer.createChangeSet(ChangeSetMetadata.create(), h2Database, new DatabaseChangeLog());
+
+			assertThat(changeSet.getChanges()).hasSize(2);
+			assertThat(changeSet.getChanges().get(0)).isInstanceOf(AddColumnChange.class);
+			assertThat(changeSet.getChanges().get(1)).isInstanceOf(AddForeignKeyConstraintChange.class);
+
+			AddColumnChange addColumn = (AddColumnChange) changeSet.getChanges().get(0);
+			assertThat(addColumn.getTableName()).isEqualToIgnoringCase("person");
+			assertThat(addColumn.getColumns()).hasSize(1);
+			assertThat(addColumn.getColumns()).extracting(AddColumnConfig::getName).containsExactly("group_id");
+
+			AddForeignKeyConstraintChange addForeignKey = (AddForeignKeyConstraintChange) changeSet.getChanges().get(1);
+			assertThat(addForeignKey.getBaseTableName()).isEqualToIgnoringCase("person");
+			assertThat(addForeignKey.getBaseColumnNames()).isEqualToIgnoringCase("group_id");
+			assertThat(addForeignKey.getReferencedTableName()).isEqualToIgnoringCase("group_of_persons");
+			assertThat(addForeignKey.getReferencedColumnNames()).isEqualToIgnoringCase("id");
+		});
+	}
+
 	RelationalMappingContext contextOf(Class<?>... classes) {
 
 		RelationalMappingContext context = new RelationalMappingContext();
@@ -244,6 +334,12 @@ class LiquibaseChangeSetWriterIntegrationTests {
 	static class DifferentPerson {
 		@Id int my_id;
 		String hello;
+	}
+
+	@Table
+	static class GroupOfPersons {
+		@Id int id;
+		@MappedCollection(idColumn = "group_id") Set<Person> persons;
 	}
 
 }

--- a/spring-data-jdbc/src/test/resources/org/springframework/data/jdbc/core/mapping/schema/create-fk-with-field.sql
+++ b/spring-data-jdbc/src/test/resources/org/springframework/data/jdbc/core/mapping/schema/create-fk-with-field.sql
@@ -1,0 +1,11 @@
+CREATE TABLE group_of_persons
+(
+    id         int primary key
+);
+
+CREATE TABLE person
+(
+    id         int,
+    first_name varchar(255),
+    last_name varchar(255)
+);

--- a/spring-data-jdbc/src/test/resources/org/springframework/data/jdbc/core/mapping/schema/drop-and-create-fk.sql
+++ b/spring-data-jdbc/src/test/resources/org/springframework/data/jdbc/core/mapping/schema/drop-and-create-fk.sql
@@ -1,0 +1,14 @@
+CREATE TABLE group_of_persons
+(
+    id         int primary key
+);
+
+CREATE TABLE person
+(
+    id         int,
+    first_name varchar(255),
+    last_name varchar(255),
+    group_id int,
+    group_id_to_drop int,
+    constraint fk_to_drop foreign key (group_id_to_drop) references group_of_persons(id)
+);

--- a/spring-data-jdbc/src/test/resources/org/springframework/data/jdbc/core/mapping/schema/drop-and-create-table-with-fk.sql
+++ b/spring-data-jdbc/src/test/resources/org/springframework/data/jdbc/core/mapping/schema/drop-and-create-table-with-fk.sql
@@ -1,0 +1,11 @@
+CREATE TABLE group_of_persons
+(
+    id         int primary key
+);
+
+CREATE TABLE table_to_drop
+(
+    id         int primary key,
+    persons int,
+    constraint fk_to_drop foreign key (persons) references group_of_persons(id)
+);


### PR DESCRIPTION
Done:
- [x] Generate column and foreign key for @MapedCollection annotated fields
- [x] Generate only foreign key for @MapedCollection annotated fields if column exists in child entry
- [x] Drop foreign keys
- [ ] Foreign key name generator (hardcoded now)

Always drop foreign keys before table drop. Always add foreign keys after table creation. The same for fields. (to be sore that referenced column always exists).

Closes #1599
Related tickets #756, #1600
