### PR TITLE
Add dynamic SQL support for r2dbc

### DIFF
--- a/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/repository/Query.java
+++ b/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/repository/Query.java
@@ -15,13 +15,13 @@
  */
 package org.springframework.data.r2dbc.repository;
 
+import org.springframework.data.annotation.QueryAnnotation;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import org.springframework.data.annotation.QueryAnnotation;
 
 /**
  * Annotation to provide SQL statements that will get used for executing the method.
@@ -33,9 +33,11 @@ import org.springframework.data.annotation.QueryAnnotation;
 @QueryAnnotation
 @Documented
 public @interface Query {
-
-	/**
-	 * The SQL statement to execute when the annotated method gets invoked.
-	 */
-	String value();
+    /**
+     * The SQL statement to execute when the annotated method gets invoked.
+     * When empty, use dynamic templates
+     *
+     * @see org.springframework.data.relational.core.query.template.DynamicTemplateProvider
+     */
+    String value() default "";
 }

--- a/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/repository/query/AbstractR2dbcQuery.java
+++ b/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/repository/query/AbstractR2dbcQuery.java
@@ -43,10 +43,10 @@ import org.springframework.util.Assert;
  */
 public abstract class AbstractR2dbcQuery implements RepositoryQuery {
 
-	private final R2dbcQueryMethod method;
-	private final R2dbcEntityOperations entityOperations;
-	private final R2dbcConverter converter;
-	private final EntityInstantiators instantiators;
+	protected final R2dbcQueryMethod method;
+	protected final R2dbcEntityOperations entityOperations;
+	protected final R2dbcConverter converter;
+	protected final EntityInstantiators instantiators;
 
 	/**
 	 * Creates a new {@link AbstractR2dbcQuery} from the given {@link R2dbcQueryMethod} and {@link R2dbcEntityOperations}.

--- a/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/repository/query/DynamicTemplateBasedR2dbcQuery.java
+++ b/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/repository/query/DynamicTemplateBasedR2dbcQuery.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2018-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.r2dbc.repository.query;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.data.r2dbc.convert.R2dbcConverter;
+import org.springframework.data.r2dbc.core.R2dbcEntityOperations;
+import org.springframework.data.r2dbc.core.ReactiveDataAccessStrategy;
+import org.springframework.data.relational.core.query.template.DynamicTemplateProvider;
+import org.springframework.data.relational.repository.query.RelationalParameters;
+import org.springframework.data.repository.query.ReactiveQueryMethodEvaluationContextProvider;
+import org.springframework.data.repository.query.SpelQueryContext;
+import org.springframework.data.util.Pair;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.util.Assert;
+import org.springframework.util.ReflectionUtils;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * Dynamic template-based {@link DynamicTemplateBasedR2dbcQuery} implementation.
+ * Dynamic template query, using external templates to provide dynamic SQL support, example: enjoy, freemarker, st etc...
+ *
+ * @author kfyty725
+ * @email kfyty725@hotmail.com
+ */
+public class DynamicTemplateBasedR2dbcQuery extends StringBasedR2dbcQuery {
+    private static final Log LOG = LogFactory.getLog(DynamicTemplateBasedR2dbcQuery.class);
+
+    /**
+     * Is it executing? Initialize the instance to false and create a new execution every time the statement is executed
+     */
+    private final boolean isRuntime;
+
+    /**
+     * Interface method
+     */
+    private final Method method;
+
+    /**
+     * The currently executing query statement
+     */
+    private final String query;
+
+    /**
+     * {@link DynamicTemplateProvider}
+     */
+    private final DynamicTemplateProvider<?> dynamicTemplateProvider;
+
+    /**
+     * {@link R2dbcQueryMethod} producer
+     */
+    private final Supplier<R2dbcQueryMethod> queryMethodProducer;
+
+    public DynamicTemplateBasedR2dbcQuery(boolean isRuntime,
+                                          Method method,
+                                          String query,
+                                          DynamicTemplateProvider<?> dynamicTemplateProvider,
+                                          Supplier<R2dbcQueryMethod> queryMethodProducer,
+                                          R2dbcQueryMethod queryMethod,
+                                          R2dbcEntityOperations entityOperations,
+                                          R2dbcConverter converter,
+                                          ReactiveDataAccessStrategy dataAccessStrategy,
+                                          ExpressionParser expressionParser,
+                                          ReactiveQueryMethodEvaluationContextProvider evaluationContextProvider) {
+        super(query, queryMethod, entityOperations, converter, dataAccessStrategy, expressionParser, evaluationContextProvider);
+        this.isRuntime = isRuntime;
+        this.method = method;
+        this.query = query;
+        this.dynamicTemplateProvider = dynamicTemplateProvider;
+        this.queryMethodProducer = queryMethodProducer;
+    }
+
+    @Override
+    public Object execute(Object[] parameters) {
+        if (this.dynamicTemplateProvider == null || !this.isDynamicTemplateQuery()) {
+            return super.execute(parameters);
+        }
+
+        if (!this.isRuntime) {
+            // When querying, it is necessary to first remove unused parameters, otherwise parameter binding will fail
+            String query = this.resolveTemplateQuery(parameters);
+            Pair<R2dbcQueryMethod, List<RelationalParameters.RelationalParameter>> relationalParameters = obtainNewMethodAndRelationalParameters();
+            List<String> used = searchQueryParameters(query);
+            this.removeUnusedParameter(used, relationalParameters.getSecond());
+            return new DynamicTemplateBasedR2dbcQuery(
+                    true,
+                    method,
+                    query,
+                    dynamicTemplateProvider,
+                    queryMethodProducer,
+                    relationalParameters.getFirst(),
+                    entityOperations,
+                    converter,
+                    dataAccessStrategy,
+                    expressionParser,
+                    evaluationContextProvider).execute(parameters);
+        }
+
+        return super.execute(parameters);
+    }
+
+    /**
+     * Is it a dynamic template query
+     *
+     * @return true if dynamic template
+     */
+    protected boolean isDynamicTemplateQuery() {
+        return super.method.getRequiredAnnotatedQuery().isBlank();
+    }
+
+    /**
+     * Obtain dynamic template SQL
+     *
+     * @param parameters Method parameters
+     * @return SQL
+     */
+    protected String resolveTemplateQuery(Object[] parameters) {
+        if (!this.isDynamicTemplateQuery()) {
+            return this.query;
+        }
+        Assert.notNull(this.dynamicTemplateProvider, "dynamicTemplateProvider can't null");
+        String statementId = this.dynamicTemplateProvider.resolveTemplateStatementId(this.method);
+        String query = this.dynamicTemplateProvider.renderTemplate(statementId, Map.of("root", parameters));
+        LOG.debug("resolve template SQL: " + query);
+        return query;
+    }
+
+    /**
+     * Search SQL Query Parameters
+     *
+     * @param query SQL
+     * @return Parameters and Index
+     */
+    public static List<String> searchQueryParameters(String query) {
+        List<String> parameterBindings = new LinkedList<>();
+        SpelQueryContext queryContext = SpelQueryContext.of((counter, expression) -> {
+            parameterBindings.add(expression);
+            return expression;
+        }, String::concat);
+        SpelQueryContext.SpelExtractor parsed = queryContext.parse(query);
+        return parameterBindings;
+    }
+
+    /**
+     * Build a new {@link R2dbcQueryMethod} and obtain the relational parameter
+     */
+    @SuppressWarnings("unchecked")
+    private Pair<R2dbcQueryMethod, List<RelationalParameters.RelationalParameter>> obtainNewMethodAndRelationalParameters() {
+        R2dbcQueryMethod r2dbcQueryMethod = this.queryMethodProducer.get();
+        RelationalParameters parameters = r2dbcQueryMethod.getParameters().getBindableParameters();
+        Field field = ReflectionUtils.findField(parameters.getClass(), "parameters");
+        ReflectionUtils.makeAccessible(field);
+        List<RelationalParameters.RelationalParameter> list = (List<RelationalParameters.RelationalParameter>) ReflectionUtils.getField(field, parameters);
+        return Pair.of(r2dbcQueryMethod, list);
+    }
+
+    /**
+     * Remove unused parameters
+     *
+     * @param used Parameters used in SQL
+     * @param list Original parameters
+     */
+    private void removeUnusedParameter(List<String> used, List<RelationalParameters.RelationalParameter> list) {
+        loop:
+        for (Iterator<RelationalParameters.RelationalParameter> i = list.iterator(); i.hasNext(); ) {
+            String name = i.next().getName().get();
+            for (String usedName : used) {
+                if (usedName.contains(name)) {
+                    continue loop;
+                }
+            }
+            i.remove();
+        }
+    }
+}

--- a/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/repository/query/StringBasedR2dbcQuery.java
+++ b/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/repository/query/StringBasedR2dbcQuery.java
@@ -15,15 +15,7 @@
  */
 package org.springframework.data.r2dbc.repository.query;
 
-import reactor.core.publisher.Mono;
-
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.jetbrains.annotations.NotNull;
-
 import org.springframework.data.r2dbc.convert.R2dbcConverter;
 import org.springframework.data.r2dbc.core.R2dbcEntityOperations;
 import org.springframework.data.r2dbc.core.ReactiveDataAccessStrategy;
@@ -41,6 +33,12 @@ import org.springframework.r2dbc.core.Parameter;
 import org.springframework.r2dbc.core.PreparedOperation;
 import org.springframework.r2dbc.core.binding.BindTarget;
 import org.springframework.util.Assert;
+import reactor.core.publisher.Mono;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * String-based {@link StringBasedR2dbcQuery} implementation.
@@ -52,12 +50,12 @@ import org.springframework.util.Assert;
  */
 public class StringBasedR2dbcQuery extends AbstractR2dbcQuery {
 
-	private final ExpressionQuery expressionQuery;
-	private final ExpressionEvaluatingParameterBinder binder;
-	private final ExpressionParser expressionParser;
-	private final ReactiveQueryMethodEvaluationContextProvider evaluationContextProvider;
-	private final ExpressionDependencies expressionDependencies;
-	private final ReactiveDataAccessStrategy dataAccessStrategy;
+	final ExpressionQuery expressionQuery;
+	final ExpressionEvaluatingParameterBinder binder;
+	protected final ExpressionParser expressionParser;
+	protected final ReactiveQueryMethodEvaluationContextProvider evaluationContextProvider;
+	protected final ExpressionDependencies expressionDependencies;
+	protected final ReactiveDataAccessStrategy dataAccessStrategy;
 
 	/**
 	 * Creates a new {@link StringBasedR2dbcQuery} for the given {@link StringBasedR2dbcQuery}, {@link DatabaseClient},
@@ -96,7 +94,9 @@ public class StringBasedR2dbcQuery extends AbstractR2dbcQuery {
 		this.expressionParser = expressionParser;
 		this.evaluationContextProvider = evaluationContextProvider;
 
-		Assert.hasText(query, "Query must not be empty");
+		if (this.getClass() == StringBasedR2dbcQuery.class) {
+			Assert.hasText(query, "Query must not be empty");
+		}
 
 		this.dataAccessStrategy = dataAccessStrategy;
 		this.expressionQuery = ExpressionQuery.create(query);

--- a/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/repository/query/template/DynamicTemplateQueryUnitTests.java
+++ b/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/repository/query/template/DynamicTemplateQueryUnitTests.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2020-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.r2dbc.repository.query.template;
+
+import io.r2dbc.h2.H2ConnectionConfiguration;
+import io.r2dbc.h2.H2ConnectionFactory;
+import io.r2dbc.spi.ConnectionFactory;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.r2dbc.core.R2dbcEntityTemplate;
+import org.springframework.data.r2dbc.repository.Query;
+import org.springframework.data.r2dbc.repository.R2dbcRepository;
+import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories;
+import org.springframework.data.r2dbc.repository.query.DynamicTemplateBasedR2dbcQuery;
+import org.springframework.data.relational.core.query.template.AbstractDynamicTemplateProvider;
+import org.springframework.data.relational.core.query.template.TemplateStatement;
+import org.springframework.r2dbc.connection.init.ConnectionFactoryInitializer;
+import org.springframework.r2dbc.connection.init.ResourceDatabasePopulator;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Unit tests for {@link DynamicTemplateBasedR2dbcQuery}.
+ *
+ * @author kfyty725
+ */
+@Configuration
+@EnableR2dbcRepositories(value = "org.springframework.data.r2dbc.repository.query.template", considerNestedRepositories = true)
+class DynamicTemplateQueryUnitTests {
+
+    @Test
+    void dynamicTemplate() {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(DynamicTemplateQueryUnitTests.class);
+        CarDao carDao = context.getBean(CarDao.class);
+
+        List<Car> car = carDao.list(1L).collectList().block();          // id query, should one record
+        List<Car> cars = carDao.list(null).collectList().block();       // null query, should two records
+
+        Assertions.assertTrue(car.size() == 1);
+        Assertions.assertTrue(cars.size() == 2);
+    }
+
+    @Bean
+    public ConnectionFactory connectionFactory() {
+        return new H2ConnectionFactory(H2ConnectionConfiguration.builder()
+                .inMemory("PUBLIC")
+                .property("DB_CLOSE_DELAY", "-1")
+                .username("SA")
+                .password("12").build());
+    }
+
+    @Bean
+    public R2dbcEntityTemplate r2dbcEntityTemplate(ConnectionFactory connectionFactory) {
+        return new R2dbcEntityTemplate(connectionFactory);
+    }
+
+    @Bean
+    public AbstractDynamicTemplateProvider<StringTemplateStatement> dynamicTemplateProvider() {
+        AbstractDynamicTemplateProvider<StringTemplateStatement> templateProvider = new AbstractDynamicTemplateProvider<>() {
+
+            @Override
+            public String renderTemplate(String statementId, Map<String, Object> params) {
+                Object[] param = (Object[]) params.get("root");
+                StringTemplateStatement templateStatement = this.templateStatements.get(statementId);
+                if (param[0] == null) {
+                    return templateStatement.getTemplate().substring(0, templateStatement.getTemplate().lastIndexOf("#if root[0]"));
+                }
+                return templateStatement.getTemplate().replace("#if root[0]", "");
+            }
+
+            @Override
+            protected StringTemplateStatement resolveInternal(String namespace, String id, String labelType, String content) {
+                return new StringTemplateStatement(id, labelType, content);
+            }
+        };
+        templateProvider.setTemplatePath(Collections.singletonList("/r2dbc/*.xml"));
+        return templateProvider;
+    }
+
+    @Bean
+    public ConnectionFactoryInitializer initializer(ConnectionFactory connectionFactory) {
+        ConnectionFactoryInitializer initializer = new ConnectionFactoryInitializer();
+        initializer.setConnectionFactory(connectionFactory);
+        initializer.setDatabasePopulator(new ResourceDatabasePopulator(new ByteArrayResource("""
+                CREATE TABLE car
+                (
+                    id BIGINT NOT NULL COMMENT '主键ID',
+                    PRIMARY KEY (id)
+                );
+                insert into car values(1);
+                insert into car values(2);
+                """.getBytes(StandardCharsets.UTF_8))));
+        return initializer;
+    }
+
+    @Repository
+    interface CarDao extends R2dbcRepository<Car, Long> {
+        @Query
+        Flux<Car> list(Long id);
+    }
+
+    @Data
+    static class Car {
+        @Id
+        private Long id;
+    }
+
+    @Getter
+    @Setter
+    static class StringTemplateStatement extends TemplateStatement {
+        private String template;
+
+        public StringTemplateStatement(String id, String labelType, String template) {
+            super(id, labelType);
+            this.template = template;
+        }
+    }
+}

--- a/spring-data-r2dbc/src/test/resources/r2dbc/MetaUserDO.xml
+++ b/spring-data-r2dbc/src/test/resources/r2dbc/MetaUserDO.xml
@@ -1,0 +1,8 @@
+<mapper namespace="org.springframework.data.r2dbc.repository.query.template.DynamicTemplateQueryUnitTests$CarDao">
+    <select id="list">
+        select * from car
+        #if root[0]
+            where
+                id = :#{[0]}
+    </select>
+</mapper>

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/query/template/AbstractDynamicTemplateProvider.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/query/template/AbstractDynamicTemplateProvider.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.data.relational.core.query.template;
 
 import org.apache.commons.logging.Log;
@@ -53,6 +68,11 @@ public abstract class AbstractDynamicTemplateProvider<TS extends TemplateStateme
     @Override
     public void setResourceLoader(ResourceLoader resourceLoader) {
         this.resourcePatternResolver = ResourcePatternUtils.getResourcePatternResolver(resourceLoader);
+    }
+
+    @Override
+    public void setTemplatePath(List<String> paths) {
+        this.paths = paths;
     }
 
     @Override

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/query/template/AbstractDynamicTemplateProvider.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/query/template/AbstractDynamicTemplateProvider.java
@@ -1,0 +1,124 @@
+package org.springframework.data.relational.core.query.template;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ResourceLoaderAware;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.core.io.support.ResourcePatternResolver;
+import org.springframework.core.io.support.ResourcePatternUtils;
+import org.springframework.util.ResourceUtils;
+import org.springframework.util.StringUtils;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+/**
+ * Basic Implementation of Dynamic Template SQL Provider
+ *
+ * @author kfyty725
+ * @date 2023/10/21 18:31
+ * @email kfyty725@hotmail.com
+ */
+public abstract class AbstractDynamicTemplateProvider<TS extends TemplateStatement> implements DynamicTemplateProvider<TS>, ResourceLoaderAware, InitializingBean {
+    private static final Log LOG = LogFactory.getLog(DynamicTemplateProvider.class);
+
+    /**
+     * Resolve the dynamic SQL template set based on the given path
+     */
+    protected List<String> paths;
+
+    /**
+     * Resource scanner
+     */
+    protected ResourcePatternResolver resourcePatternResolver;
+
+    /**
+     * Parsed dynamic template statement
+     */
+    protected Map<String, TS> templateStatements = new ConcurrentHashMap<>();
+
+    @Override
+    public void setResourceLoader(ResourceLoader resourceLoader) {
+        this.resourcePatternResolver = ResourcePatternUtils.getResourcePatternResolver(resourceLoader);
+    }
+
+    @Override
+    public List<TS> resolve(List<String> paths) {
+        try {
+            List<TS> templateStatements = new ArrayList<>();
+            for (String path : paths) {
+                for (Resource resource : this.resourcePatternResolver.getResources(ResourceUtils.CLASSPATH_URL_PREFIX + path)) {
+                    Element rootElement = createElement(resource.getInputStream());
+                    String namespace = resolveAttribute(rootElement, TemplateStatement.TEMPLATE_NAMESPACE, () -> new IllegalArgumentException("namespace can't empty"));
+                    NodeList select = rootElement.getElementsByTagName(TemplateStatement.SELECT_LABEL);
+                    NodeList execute = rootElement.getElementsByTagName(TemplateStatement.EXECUTE_LABEL);
+                    templateStatements.addAll(this.resolveInternal(namespace, TemplateStatement.SELECT_LABEL, select));
+                    templateStatements.addAll(this.resolveInternal(namespace, TemplateStatement.EXECUTE_LABEL, execute));
+                    LOG.info("resolved resource: " + resource.getDescription());
+                }
+            }
+            return templateStatements;
+        } catch (IOException e) {
+            throw new IllegalArgumentException("resolve template failed", e);
+        }
+    }
+
+    @Override
+    public String resolveTemplateStatementId(Method method) {
+        String id = method.getDeclaringClass().getName() + "." + method.getName();
+        if (!this.templateStatements.containsKey(id)) {
+            throw new IllegalArgumentException("template statement not exists of id: " + id);
+        }
+        return id;
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        List<TS> resolve = this.resolve(this.paths);
+        resolve.forEach(e -> this.templateStatements.put(e.getId(), e));
+    }
+
+    /**
+     * Internal parsing, implemented by subclasses
+     */
+    protected abstract List<TS> resolveInternal(String namespace, String labelType, NodeList nodeList);
+
+    /**
+     * load xml document from an xml input stream
+     */
+    private static Element createElement(InputStream inputStream) {
+        try {
+            return DocumentBuilderFactoryHolder.INSTANCE.newDocumentBuilder().parse(inputStream).getDocumentElement();
+        } catch (ParserConfigurationException | SAXException | IOException e) {
+            throw new IllegalArgumentException("load dynamic template failed", e);
+        }
+    }
+
+    /**
+     * resolve xml attribute from xml element
+     */
+    private static String resolveAttribute(Element element, String name, Supplier<RuntimeException> emptyException) {
+        String attribute = element.getAttribute(name);
+        if (emptyException != null && !StringUtils.hasText(attribute)) {
+            throw emptyException.get();
+        }
+        return attribute;
+    }
+
+    private static final class DocumentBuilderFactoryHolder {
+        static final DocumentBuilderFactory INSTANCE = DocumentBuilderFactory.newInstance();
+    }
+}

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/query/template/DynamicTemplateProvider.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/query/template/DynamicTemplateProvider.java
@@ -1,0 +1,39 @@
+package org.springframework.data.relational.core.query.template;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Dynamic sql template provider
+ *
+ * @author kfyty725
+ * @date 2023/10/21 18:31
+ * @email kfyty725@hotmail.com
+ */
+public interface DynamicTemplateProvider<TS extends TemplateStatement> {
+    /**
+     * Resolve the dynamic SQL template set based on the given path
+     *
+     * @param paths xml template path
+     * @return TemplateStatement
+     */
+    List<TS> resolve(List<String> paths);
+
+    /**
+     * Resolve dynamic SQL id based on given interface method
+     *
+     * @param method DAO interface method
+     * @return id
+     */
+    String resolveTemplateStatementId(Method method);
+
+    /**
+     * Renders the given dynamic SQL template
+     *
+     * @param statementId template statement id
+     * @param params      template parameters
+     * @return Rendered SQL
+     */
+    String renderTemplate(String statementId, Map<String, Object> params);
+}

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/query/template/DynamicTemplateProvider.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/query/template/DynamicTemplateProvider.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.data.relational.core.query.template;
 
 import java.lang.reflect.Method;
@@ -12,6 +27,13 @@ import java.util.Map;
  * @email kfyty725@hotmail.com
  */
 public interface DynamicTemplateProvider<TS extends TemplateStatement> {
+    /**
+     * set template paths
+     *
+     * @param paths template paths
+     */
+    void setTemplatePath(List<String> paths);
+
     /**
      * Resolve the dynamic SQL template set based on the given path
      *

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/query/template/TemplateStatement.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/query/template/TemplateStatement.java
@@ -1,0 +1,65 @@
+package org.springframework.data.relational.core.query.template;
+
+/**
+ * Dynamic sql template statement
+ *
+ * @author kfyty725
+ * @date 2023/10/21 18:06
+ * @email kfyty725@hotmail.com
+ */
+public abstract class TemplateStatement {
+    /**
+     * name of dynamic template namespace in xml attribute
+     */
+    public static final String TEMPLATE_NAMESPACE = "namespace";
+
+    /**
+     * name of dynamic template statement id in xml attribute
+     */
+    public static final String TEMPLATE_STATEMENT_ID = "id";
+
+    /**
+     * template statement type: select
+     */
+    public static final String SELECT_LABEL = "select";
+
+    /**
+     * template statement type: execute
+     */
+    public static final String EXECUTE_LABEL = "execute";
+
+    /**
+     * dynamic template statement id.
+     * namespace and id is unique identifier of dynamic sql template statement.
+     */
+    private String id;
+
+    /**
+     * template statement type
+     *
+     * @see TemplateStatement#SELECT_LABEL
+     * @see TemplateStatement#EXECUTE_LABEL
+     */
+    private String labelType;
+
+    public TemplateStatement(String id, String labelType) {
+        this.id = id;
+        this.labelType = labelType;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getLabelType() {
+        return labelType;
+    }
+
+    public void setLabelType(String labelType) {
+        this.labelType = labelType;
+    }
+}

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/query/template/TemplateStatement.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/query/template/TemplateStatement.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.data.relational.core.query.template;
 
 /**


### PR DESCRIPTION
I want to add dynamic SQL support for r2dbc, just like mybatis. Added the DynamicTemplateProvider interface, although it does not provide a default implementation, it provides a basic implementation. Users can fully implement this function using any third-party template framework, such as enjoy, freemarker, st, and so on.

@schauder do you have chance to take a look ?
