### PR TITLE
`AggregatePath` caching considers the owning Entity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-relational-parent</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-1657-aggregate-path-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Relational Parent</name>

--- a/spring-data-jdbc-distribution/pom.xml
+++ b/spring-data-jdbc-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-1657-aggregate-path-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-jdbc</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-1657-aggregate-path-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-1657-aggregate-path-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-r2dbc/pom.xml
+++ b/spring-data-r2dbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-r2dbc</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-1657-aggregate-path-SNAPSHOT</version>
 
 	<name>Spring Data R2DBC</name>
 	<description>Spring Data module for R2DBC</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-1657-aggregate-path-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-relational</artifactId>
-	<version>3.2.0-SNAPSHOT</version>
+	<version>3.2.0-1657-aggregate-path-SNAPSHOT</version>
 
 	<name>Spring Data Relational</name>
 	<description>Spring Data Relational support</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.2.0-SNAPSHOT</version>
+		<version>3.2.0-1657-aggregate-path-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/DefaultAggregatePath.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/DefaultAggregatePath.java
@@ -52,7 +52,7 @@ class DefaultAggregatePath implements AggregatePath {
 
 		this.context = context;
 		this.path = (PersistentPropertyPath) path;
-		this.rootType = null;
+		this.rootType = path.getBaseProperty().getOwner();
 	}
 
 	DefaultAggregatePath(RelationalMappingContext context, RelationalPersistentEntity<?> rootType) {

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/RelationalMappingContext.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/RelationalMappingContext.java
@@ -186,11 +186,13 @@ public class RelationalMappingContext
 	 */
 	public AggregatePath getAggregatePath(PersistentPropertyPath<? extends RelationalPersistentProperty> path) {
 
-		AggregatePath aggregatePath = aggregatePathCache.get(path);
+		AggregatePathCacheKey cacheKey = AggregatePathCacheKey.of(path);
+
+		AggregatePath aggregatePath = aggregatePathCache.get(cacheKey);
 		if (aggregatePath == null) {
 
 			aggregatePath = new DefaultAggregatePath(this, path);
-			aggregatePathCache.put(path, aggregatePath);
+			aggregatePathCache.put(cacheKey, aggregatePath);
 		}
 
 		return aggregatePath;
@@ -198,13 +200,26 @@ public class RelationalMappingContext
 
 	public AggregatePath getAggregatePath(RelationalPersistentEntity<?> type) {
 
-		AggregatePath aggregatePath = aggregatePathCache.get(type);
+		AggregatePathCacheKey cacheKey = AggregatePathCacheKey.of(type);
+
+		AggregatePath aggregatePath = aggregatePathCache.get(cacheKey);
 		if (aggregatePath == null) {
 
 			aggregatePath = new DefaultAggregatePath(this, type);
-			aggregatePathCache.put(type, aggregatePath);
+			aggregatePathCache.put(cacheKey, aggregatePath);
 		}
 
 		return aggregatePath;
+	}
+
+	private record AggregatePathCacheKey(RelationalPersistentEntity<?> root,@Nullable PersistentPropertyPath<? extends RelationalPersistentProperty> path) {
+		static AggregatePathCacheKey of(RelationalPersistentEntity<?> root) {
+			return new AggregatePathCacheKey(root, null);
+		}
+		static AggregatePathCacheKey of(PersistentPropertyPath<? extends RelationalPersistentProperty> path) {
+
+			RelationalPersistentEntity<?> root = path.getBaseProperty().getOwner();
+			return new AggregatePathCacheKey(root, path);
+		}
 	}
 }

--- a/spring-data-relational/src/test/java/org/springframework/data/relational/core/mapping/RelationalMappingContextUnitTests.java
+++ b/spring-data-relational/src/test/java/org/springframework/data/relational/core/mapping/RelationalMappingContextUnitTests.java
@@ -104,6 +104,20 @@ public class RelationalMappingContextUnitTests {
 		assertThat(name.getColumnName()).isEqualTo(SqlIdentifier.quoted("PRNT_CHLD_NAME"));
 	}
 
+	@Test // GH-1657
+	void aggregatePathsOfBasePropertyForDifferentInheritedEntitiesAreDifferent() {
+
+		PersistentPropertyPath<RelationalPersistentProperty> path1 = context.getPersistentPropertyPath("name",
+				Inherit1.class);
+		PersistentPropertyPath<RelationalPersistentProperty> path2 = context.getPersistentPropertyPath("name",
+				Inherit2.class);
+
+		AggregatePath aggregatePath1 = context.getAggregatePath(path1);
+		AggregatePath aggregatePath2 = context.getAggregatePath(path2);
+
+		assertThat(aggregatePath1).isNotEqualTo(aggregatePath2);
+	}
+
 	static class EntityWithUuid {
 		@Id UUID uuid;
 	}
@@ -120,5 +134,13 @@ public class RelationalMappingContextUnitTests {
 	static class Child {
 		String name;
 	}
+
+	static class Base {
+		String name;
+	}
+
+	static class Inherit1 extends Base {}
+
+	static class Inherit2 extends Base {}
 
 }


### PR DESCRIPTION
Since a PersistencePropertyPath does NOT consider it's owner for equality, this is necessary.
to distinguish different AggregatePath instances based on a inherited property.

Closes https://github.com/spring-projects/spring-data-relational/issues/1657