### PR TITLE
Add `jdbcAggregateOperationsRef` to `@EnableJdbcRepositories`

### DIFF
--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/JdbcAggregateOperations.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/JdbcAggregateOperations.java
@@ -22,6 +22,8 @@ import org.springframework.data.domain.Example;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.jdbc.core.convert.DataAccessStrategy;
+import org.springframework.data.jdbc.core.convert.JdbcConverter;
 import org.springframework.data.relational.core.query.Query;
 import org.springframework.lang.Nullable;
 
@@ -34,6 +36,7 @@ import org.springframework.lang.Nullable;
  * @author Chirag Tailor
  * @author Diego Krupitza
  * @author Myeonghyeon Lee
+ * @author Tomohiko Ozawa
  */
 public interface JdbcAggregateOperations {
 
@@ -312,4 +315,18 @@ public interface JdbcAggregateOperations {
 	default <T> void deleteAll(Iterable<? extends T> aggregateRoots, Class<T> domainType) {
 		deleteAll(aggregateRoots);
 	}
+
+	/**
+	 * Returns the {@link JdbcConverter}.
+	 *
+	 * @return the {@link JdbcConverter}.
+	 */
+	JdbcConverter getConverter();
+
+	/**
+	 * Return the {@link DataAccessStrategy}
+	 *
+	 * @return the {@link DataAccessStrategy}
+	 */
+	DataAccessStrategy getDataAccessStrategy();
 }

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/JdbcAggregateTemplate.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/JdbcAggregateTemplate.java
@@ -88,7 +88,7 @@ public class JdbcAggregateTemplate implements JdbcAggregateOperations {
 	 *
 	 * @param publisher must not be {@literal null}.
 	 * @param dataAccessStrategy must not be {@literal null}.
-	 * @since 1.1
+	 * @since 3.3
 	 */
 	public JdbcAggregateTemplate(ApplicationContext publisher, JdbcConverter converter,
 			DataAccessStrategy dataAccessStrategy) {
@@ -115,6 +115,7 @@ public class JdbcAggregateTemplate implements JdbcAggregateOperations {
 	 *
 	 * @param publisher must not be {@literal null}.
 	 * @param dataAccessStrategy must not be {@literal null}.
+	 * @since 3.3
 	 */
 	public JdbcAggregateTemplate(ApplicationEventPublisher publisher, JdbcConverter converter,
 			DataAccessStrategy dataAccessStrategy) {
@@ -127,6 +128,66 @@ public class JdbcAggregateTemplate implements JdbcAggregateOperations {
 		this.converter = converter;
 		this.accessStrategy = dataAccessStrategy;
 		this.context = converter.getMappingContext();
+
+		this.jdbcEntityDeleteWriter = new RelationalEntityDeleteWriter(context);
+		this.executor = new AggregateChangeExecutor(converter, accessStrategy);
+	}
+
+	/**
+	 * Creates a new {@link JdbcAggregateTemplate} given {@link ApplicationContext}, {@link RelationalMappingContext} and
+	 * {@link DataAccessStrategy}.
+	 *
+	 * @param publisher must not be {@literal null}.
+	 * @param context must not be {@literal null}.
+	 * @param dataAccessStrategy must not be {@literal null}.
+	 * @since 1.1
+	 * @deprecated since 3.3, use {@link JdbcAggregateTemplate(ApplicationContext, JdbcConverter, DataAccessStrategy)}
+	 *             instead.
+	 */
+	@Deprecated(since = "3.3")
+	public JdbcAggregateTemplate(ApplicationContext publisher, RelationalMappingContext context, JdbcConverter converter,
+			DataAccessStrategy dataAccessStrategy) {
+
+		Assert.notNull(publisher, "ApplicationContext must not be null");
+		Assert.notNull(context, "RelationalMappingContext must not be null");
+		Assert.notNull(converter, "RelationalConverter must not be null");
+		Assert.notNull(dataAccessStrategy, "DataAccessStrategy must not be null");
+
+		this.eventDelegate.setPublisher(publisher);
+		this.context = context;
+		this.accessStrategy = dataAccessStrategy;
+		this.converter = converter;
+
+		this.jdbcEntityDeleteWriter = new RelationalEntityDeleteWriter(context);
+
+		this.executor = new AggregateChangeExecutor(converter, accessStrategy);
+
+		setEntityCallbacks(EntityCallbacks.create(publisher));
+	}
+
+	/**
+	 * Creates a new {@link JdbcAggregateTemplate} given {@link ApplicationEventPublisher},
+	 * {@link RelationalMappingContext} and {@link DataAccessStrategy}.
+	 *
+	 * @param publisher must not be {@literal null}.
+	 * @param context must not be {@literal null}.
+	 * @param dataAccessStrategy must not be {@literal null}.
+	 * @deprecated since 3.3, use {@link JdbcAggregateTemplate(ApplicationEventPublisher, JdbcConverter,
+	 *             DataAccessStrategy)} instead.
+	 */
+	@Deprecated(since = "3.3")
+	public JdbcAggregateTemplate(ApplicationEventPublisher publisher, RelationalMappingContext context,
+			JdbcConverter converter, DataAccessStrategy dataAccessStrategy) {
+
+		Assert.notNull(publisher, "ApplicationEventPublisher must not be null");
+		Assert.notNull(context, "RelationalMappingContext must not be null");
+		Assert.notNull(converter, "RelationalConverter must not be null");
+		Assert.notNull(dataAccessStrategy, "DataAccessStrategy must not be null");
+
+		this.eventDelegate.setPublisher(publisher);
+		this.context = context;
+		this.accessStrategy = dataAccessStrategy;
+		this.converter = converter;
 
 		this.jdbcEntityDeleteWriter = new RelationalEntityDeleteWriter(context);
 		this.executor = new AggregateChangeExecutor(converter, accessStrategy);

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/dialect/DialectResolver.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/dialect/DialectResolver.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.jdbc.repository.config;
+package org.springframework.data.jdbc.dialect;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/config/EnableJdbcRepositories.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/config/EnableJdbcRepositories.java
@@ -122,7 +122,9 @@ public @interface EnableJdbcRepositories {
 	/**
 	 * Configures the name of the {@link org.springframework.data.jdbc.core.convert.DataAccessStrategy} bean definition to
 	 * be used to create repositories discovered through this annotation. Defaults to {@code defaultDataAccessStrategy}.
+	 * @deprecated since 3.3 use {@link #jdbcAggregateOperationsRef()} instead
 	 */
+	@Deprecated(since = "3.3")
 	String dataAccessStrategyRef() default "";
 
 	/**
@@ -132,6 +134,12 @@ public @interface EnableJdbcRepositories {
 	 * @since 2.1
 	 */
 	String transactionManagerRef() default "transactionManager";
+
+	/**
+	 * Configure the name of the {@link org.springframework.data.jdbc.core.JdbcAggregateOperations} bean definition to be
+	 * used to create repositories discovered through this annotation.
+	 */
+	String jdbcAggregateOperationsRef() default "";
 
 	/**
 	 * Returns the key of the {@link QueryLookupStrategy} to be used for lookup queries for query methods. Defaults to

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/config/JdbcRepositoryConfigExtension.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/config/JdbcRepositoryConfigExtension.java
@@ -40,6 +40,7 @@ import org.springframework.util.StringUtils;
  * @author Fei Dong
  * @author Mark Paluch
  * @author Antoine Sauray
+ * @author Tomohiko Ozawa
  */
 public class JdbcRepositoryConfigExtension extends RepositoryConfigurationExtensionSupport {
 
@@ -79,9 +80,15 @@ public class JdbcRepositoryConfigExtension extends RepositoryConfigurationExtens
 		Optional<String> transactionManagerRef = source.getAttribute("transactionManagerRef");
 		builder.addPropertyValue("transactionManager", transactionManagerRef.orElse(DEFAULT_TRANSACTION_MANAGER_BEAN_NAME));
 
-		builder.addPropertyValue("mappingContext", new RuntimeBeanReference(JdbcMappingContext.class));
-		builder.addPropertyValue("dialect", new RuntimeBeanReference(Dialect.class));
-		builder.addPropertyValue("converter", new RuntimeBeanReference(JdbcConverter.class));
+		Optional<String> jdbcAggregateOperationsRef = source.getAttribute("jdbcAggregateOperationsRef");
+
+		if (jdbcAggregateOperationsRef.isPresent()) {
+			builder.addPropertyReference("jdbcAggregateOperations", jdbcAggregateOperationsRef.get());
+		} else {
+			builder.addPropertyValue("mappingContext", new RuntimeBeanReference(JdbcMappingContext.class));
+			builder.addPropertyValue("dialect", new RuntimeBeanReference(Dialect.class));
+			builder.addPropertyValue("converter", new RuntimeBeanReference(JdbcConverter.class));
+		}
 	}
 
 	/**

--- a/spring-data-jdbc/src/main/resources/META-INF/spring.factories
+++ b/spring-data-jdbc/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,2 @@
 org.springframework.data.repository.core.support.RepositoryFactorySupport=org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory
-org.springframework.data.jdbc.repository.config.DialectResolver$JdbcDialectProvider=org.springframework.data.jdbc.repository.config.DialectResolver.DefaultDialectProvider
+org.springframework.data.jdbc.dialect.DialectResolver$JdbcDialectProvider=org.springframework.data.jdbc.dialect.DialectResolver.DefaultDialectProvider

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/AbstractJdbcAggregateTemplateIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/AbstractJdbcAggregateTemplateIntegrationTests.java
@@ -22,22 +22,13 @@ import static org.springframework.data.jdbc.testing.TestConfiguration.*;
 import static org.springframework.data.jdbc.testing.TestDatabaseFeatures.Feature.*;
 
 import java.time.LocalDateTime;
+import java.util.*;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -51,8 +42,6 @@ import org.springframework.data.annotation.Version;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Persistable;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.jdbc.core.convert.DataAccessStrategy;
-import org.springframework.data.jdbc.core.convert.JdbcConverter;
 import org.springframework.data.jdbc.testing.EnabledOnFeature;
 import org.springframework.data.jdbc.testing.IntegrationTest;
 import org.springframework.data.jdbc.testing.TestClass;
@@ -917,9 +906,8 @@ abstract class AbstractJdbcAggregateTemplateIntegrationTests {
 
 		template.save(entity);
 
-		assertThat(
-				jdbcTemplate.queryForObject("SELECT read_only FROM with_read_only", Collections.emptyMap(), String.class))
-						.isEqualTo("from-db");
+		assertThat(jdbcTemplate.queryForObject("SELECT read_only FROM with_read_only", Collections.emptyMap(),
+				String.class)).isEqualTo("from-db");
 	}
 
 	@Test
@@ -1258,7 +1246,8 @@ abstract class AbstractJdbcAggregateTemplateIntegrationTests {
 	@Test // GH-1656
 	void mapWithEnumKey() {
 
-		EnumMapOwner enumMapOwner = template.save(new EnumMapOwner(null, "OwnerName", Map.of(Color.BLUE, new MapElement("Element"))));
+		EnumMapOwner enumMapOwner = template.save(
+				new EnumMapOwner(null, "OwnerName", Map.of(Color.BLUE, new MapElement("Element"))));
 
 		Iterable<EnumMapOwner> enumMapOwners = template.findAll(EnumMapOwner.class);
 
@@ -2086,7 +2075,6 @@ abstract class AbstractJdbcAggregateTemplateIntegrationTests {
 	record EnumMapOwner(@Id Long id, String name, Map<Color, MapElement> map) {
 	}
 
-
 	@Configuration
 	@Import(TestConfiguration.class)
 	static class Config {
@@ -2094,12 +2082,6 @@ abstract class AbstractJdbcAggregateTemplateIntegrationTests {
 		@Bean
 		TestClass testClass() {
 			return TestClass.of(JdbcAggregateTemplateIntegrationTests.class);
-		}
-
-		@Bean
-		JdbcAggregateOperations operations(ApplicationEventPublisher publisher, RelationalMappingContext context,
-				DataAccessStrategy dataAccessStrategy, JdbcConverter converter) {
-			return new JdbcAggregateTemplate(publisher, context, converter, dataAccessStrategy);
 		}
 	}
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/ImmutableAggregateTemplateHsqlIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/ImmutableAggregateTemplateHsqlIntegrationTests.java
@@ -23,18 +23,14 @@ import java.util.Objects;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.jdbc.core.convert.DataAccessStrategy;
-import org.springframework.data.jdbc.core.convert.JdbcConverter;
 import org.springframework.data.jdbc.testing.DatabaseType;
 import org.springframework.data.jdbc.testing.EnabledOnDatabase;
 import org.springframework.data.jdbc.testing.IntegrationTest;
 import org.springframework.data.jdbc.testing.TestConfiguration;
-import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 
 /**
  * Integration tests for {@link JdbcAggregateTemplate} and it's handling of immutable entities.
@@ -601,12 +597,6 @@ public class ImmutableAggregateTemplateHsqlIntegrationTests {
 		@Bean
 		Class<?> testClass() {
 			return ImmutableAggregateTemplateHsqlIntegrationTests.class;
-		}
-
-		@Bean
-		JdbcAggregateOperations operations(ApplicationEventPublisher publisher, RelationalMappingContext context,
-				DataAccessStrategy dataAccessStrategy, JdbcConverter converter) {
-			return new JdbcAggregateTemplate(publisher, context, converter, dataAccessStrategy);
 		}
 	}
 }

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/JdbcAggregateTemplateSchemaIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/JdbcAggregateTemplateSchemaIntegrationTests.java
@@ -16,22 +16,16 @@
 package org.springframework.data.jdbc.core;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.springframework.data.jdbc.testing.TestDatabaseFeatures.Feature.*;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.jdbc.core.convert.DataAccessStrategy;
-import org.springframework.data.jdbc.core.convert.JdbcConverter;
-import org.springframework.data.jdbc.testing.EnabledOnFeature;
 import org.springframework.data.jdbc.testing.IntegrationTest;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.relational.core.mapping.NamingStrategy;
-import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
 
 /**
@@ -84,12 +78,6 @@ public class JdbcAggregateTemplateSchemaIntegrationTests {
 		@Bean
 		Class<?> testClass() {
 			return JdbcAggregateTemplateSchemaIntegrationTests.class;
-		}
-
-		@Bean
-		JdbcAggregateOperations operations(ApplicationEventPublisher publisher, RelationalMappingContext context,
-				DataAccessStrategy dataAccessStrategy, JdbcConverter converter) {
-			return new JdbcAggregateTemplate(publisher, context, converter, dataAccessStrategy);
 		}
 
 		@Bean

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/JdbcAggregateTemplateUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/JdbcAggregateTemplateUnitTests.java
@@ -74,7 +74,7 @@ public class JdbcAggregateTemplateUnitTests {
 		RelationalMappingContext mappingContext = new RelationalMappingContext();
 		JdbcConverter converter = new MappingJdbcConverter(mappingContext, relationResolver);
 
-		template = new JdbcAggregateTemplate(eventPublisher, mappingContext, converter, dataAccessStrategy);
+		template = new JdbcAggregateTemplate(eventPublisher, converter, dataAccessStrategy);
 		template.setEntityCallbacks(callbacks);
 
 	}

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/config/EnableJdbcRepositoriesIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/config/EnableJdbcRepositoriesIntegrationTests.java
@@ -137,7 +137,7 @@ public class EnableJdbcRepositoriesIntegrationTests {
 		assertThat(dataAccessStrategy).isNotSameAs(defaultDataAccessStrategy).isSameAs(qualifierDataAccessStrategy);
 	}
 
-	@Test
+	@Test  // GH-1704
 	public void jdbcAggregateOperationsRef() {
 
 		JdbcAggregateOperations aggregateOperations = (JdbcAggregateOperations) ReflectionUtils.getField(

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/support/JdbcRepositoryFactoryBeanUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/support/JdbcRepositoryFactoryBeanUnitTests.java
@@ -40,8 +40,11 @@ import org.springframework.data.jdbc.core.convert.MappingJdbcConverter;
 import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
 import org.springframework.data.jdbc.repository.QueryMappingConfiguration;
 import org.springframework.data.relational.core.dialect.Dialect;
+import org.springframework.data.relational.core.dialect.H2Dialect;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.jdbc.core.ConnectionCallback;
+import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -66,6 +69,11 @@ public class JdbcRepositoryFactoryBeanUnitTests {
 	@Mock(answer = Answers.RETURNS_DEEP_STUBS) ListableBeanFactory beanFactory;
 	@Mock Dialect dialect;
 
+	@Mock
+	JdbcOperations operations;
+	@Mock
+	NamedParameterJdbcOperations namedParameterJdbcOperations;
+
 	RelationalMappingContext mappingContext;
 
 	@BeforeEach
@@ -76,7 +84,9 @@ public class JdbcRepositoryFactoryBeanUnitTests {
 		// Setup standard configuration
 		factoryBean = new JdbcRepositoryFactoryBean<>(DummyEntityRepository.class);
 
-		when(beanFactory.getBean(NamedParameterJdbcOperations.class)).thenReturn(mock(NamedParameterJdbcOperations.class));
+		when(operations.execute(any(ConnectionCallback.class))).thenReturn(H2Dialect.INSTANCE);
+		when(namedParameterJdbcOperations.getJdbcOperations()).thenReturn(operations);
+		when(beanFactory.getBean(NamedParameterJdbcOperations.class)).thenReturn(namedParameterJdbcOperations);
 
 		ObjectProvider<DataAccessStrategy> provider = mock(ObjectProvider.class);
 		when(beanFactory.getBeanProvider(DataAccessStrategy.class)).thenReturn(provider);

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/TestConfiguration.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/TestConfiguration.java
@@ -26,6 +26,7 @@ import org.apache.ibatis.session.SqlSessionFactory;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -34,11 +35,13 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.convert.CustomConversions;
+import org.springframework.data.jdbc.core.JdbcAggregateOperations;
+import org.springframework.data.jdbc.core.JdbcAggregateTemplate;
 import org.springframework.data.jdbc.core.convert.*;
 import org.springframework.data.jdbc.core.dialect.JdbcDialect;
 import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
 import org.springframework.data.jdbc.core.mapping.JdbcSimpleTypes;
-import org.springframework.data.jdbc.repository.config.DialectResolver;
+import org.springframework.data.jdbc.dialect.DialectResolver;
 import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
 import org.springframework.data.mapping.model.SimpleTypeHolder;
 import org.springframework.data.relational.core.dialect.Dialect;
@@ -167,6 +170,12 @@ public class TestConfiguration {
 	@Bean
 	Dialect jdbcDialect(NamedParameterJdbcOperations operations) {
 		return DialectResolver.getDialect(operations.getJdbcOperations());
+	}
+
+	@Bean
+	JdbcAggregateOperations jdbcAggregateOperations(ApplicationContext publisher, JdbcConverter converter,
+			@Qualifier("defaultDataAccessStrategy") DataAccessStrategy dataAccessStrategy) {
+		return new JdbcAggregateTemplate(publisher, converter, dataAccessStrategy);
 	}
 
 	@Lazy


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->
fix: #544, #687, #994

This PR adds `jdbcAggregateOperationsRef` to `@EnableJdbcRepositories` that enables to specify  JdbcAggregateOperations bean name to be used for creating repositories, which significantly simplifies the configuration for multiple repositories.
I've also created [a sample project](https://github.com/kota65535/spring-data-jdbc-multi-repos/tree/use-jdbc-aggregate-ref) for testing this feature. Multiple repositories with different dialects can be configured using two configurations ([Db1Config.java](https://github.com/kota65535/spring-data-jdbc-multi-repos/blob/use-jdbc-aggregate-ref/src/main/java/com/kota65535/config/Db1Config.java), [Db2Config.java](https://github.com/kota65535/spring-data-jdbc-multi-repos/blob/use-jdbc-aggregate-ref/src/main/java/com/kota65535/config/Db2Config.java)).
As you can see, creating the JdbcAggregateOperations bean is still a bit messy. It may be better to have some factory class for creating them.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).



