### PR TITLE
Consider JTS geometry types as simple types.

### DIFF
--- a/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/dialect/PostgresDialect.java
+++ b/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/dialect/PostgresDialect.java
@@ -58,6 +58,18 @@ public class PostgresDialect extends org.springframework.data.relational.core.di
 				"io.r2dbc.postgresql.codec.Polygon") //
 				.forEach(s -> ifClassPresent(s, simpleTypes::add));
 
+		// support the native JTS types supported by r2dbc-postgresql
+		Stream.of("org.locationtech.jts.geom.Geometry", //
+				"org.locationtech.jts.geom.Point", //
+				"org.locationtech.jts.geom.MultiPoint", //
+				"org.locationtech.jts.geom.LineString", //
+				"org.locationtech.jts.geom.LinearRing", //
+				"org.locationtech.jts.geom.MultiLineString", //
+				"org.locationtech.jts.geom.Polygon", //
+				"org.locationtech.jts.geom.MultiPolygon", //
+				"org.locationtech.jts.geom.GeometryCollection") //
+				.forEach(s -> ifClassPresent(s, simpleTypes::add));
+
 		// conditional Postgres JSON support.
 		ifClassPresent("io.r2dbc.postgresql.codec.Json", simpleTypes::add);
 


### PR DESCRIPTION
Here's a quick PR that makes spring-data-r2dbc work with the native JTS types useful for work with PostGIS. These are natively supported in the r2dbc-postgresql driver and should be picked up automatically now if the JTS dependencies are installed.

See: https://github.com/spring-projects/spring-data-relational/issues/1711

I've tested this locally and found that it removes the need for at custom postgres dialect. No additional dependency on JTS is necessary.