### PR TITLE
Support AggregateReference in a Dto that contains only a single no-args constructor

### DIFF
--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcDtoInstantiatingConverter.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcDtoInstantiatingConverter.java
@@ -1,0 +1,106 @@
+package org.springframework.data.jdbc.core.convert;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.jdbc.core.mapping.AggregateReference;
+import org.springframework.data.mapping.*;
+import org.springframework.data.mapping.context.MappingContext;
+import org.springframework.data.mapping.model.EntityInstantiator;
+import org.springframework.data.mapping.model.EntityInstantiators;
+import org.springframework.data.mapping.model.ParameterValueProvider;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * Spring {@link Converter} to create instances of the given DTO type from the source value handed into the conversion
+ * while also handling Aggregate References
+ *
+ * @author Mark Paluch
+ * @author Oliver Drotbohm
+ * @author Paul Jones
+ * @since 3.3
+ */
+public class JdbcDtoInstantiatingConverter implements Converter<Object, Object> {
+
+    private final Class<?> targetType;
+    private final MappingContext<? extends PersistentEntity<?, ?>, ? extends PersistentProperty<?>> context;
+    private final EntityInstantiator instantiator;
+
+    /**
+     * Create a new {@link Converter} to instantiate DTOs.
+     *
+     * @param dtoType must not be {@literal null}.
+     * @param context must not be {@literal null}.
+     * @param instantiators must not be {@literal null}.
+     */
+    public JdbcDtoInstantiatingConverter(Class<?> dtoType,
+                                     MappingContext<? extends PersistentEntity<?, ?>, ? extends PersistentProperty<?>> context,
+                                     EntityInstantiators instantiators) {
+
+        Assert.notNull(dtoType, "DTO type must not be null");
+        Assert.notNull(context, "MappingContext must not be null");
+        Assert.notNull(instantiators, "EntityInstantiators must not be null");
+
+        this.targetType = dtoType;
+        this.context = context;
+        this.instantiator = instantiators.getInstantiatorFor(context.getRequiredPersistentEntity(dtoType));
+    }
+
+    @NonNull
+    @Override
+    public Object convert(Object source) {
+
+        if (targetType.isInterface()) {
+            return source;
+        }
+
+        PersistentEntity<?, ? extends PersistentProperty<?>> sourceEntity = context
+                .getRequiredPersistentEntity(source.getClass());
+        PersistentPropertyAccessor<Object> sourceAccessor = sourceEntity.getPropertyAccessor(source);
+        PersistentEntity<?, ? extends PersistentProperty<?>> targetEntity = context.getRequiredPersistentEntity(targetType);
+
+        @SuppressWarnings({ "rawtypes", "unchecked" })
+        Object dto = instantiator.createInstance(targetEntity, new ParameterValueProvider() {
+
+            @Override
+            @Nullable
+            public Object getParameterValue(Parameter parameter) {
+
+                String name = parameter.getName();
+
+                if (name == null) {
+                    throw new IllegalArgumentException(String.format("Parameter %s does not have a name", parameter));
+                }
+
+                return sourceAccessor.getProperty(sourceEntity.getRequiredPersistentProperty(name));
+            }
+        });
+
+        PersistentPropertyAccessor<Object> targetAccessor = targetEntity.getPropertyAccessor(dto);
+        InstanceCreatorMetadata<? extends PersistentProperty<?>> creator = targetEntity.getInstanceCreatorMetadata();
+
+        targetEntity.doWithProperties((SimplePropertyHandler) property -> {
+
+            if ((creator != null) && creator.isCreatorParameter(property)) {
+                return;
+            }
+
+            targetAccessor.setProperty(property,
+                    sourceAccessor.getProperty(sourceEntity.getRequiredPersistentProperty(property.getName())));
+        });
+
+        targetEntity.doWithAssociations((SimpleAssociationHandler) property -> {
+            if ((creator != null) && creator.isCreatorParameter(property.getInverse())) {
+                return;
+            }
+
+            if(property.getInverse().getType().equals(AggregateReference.class)) {
+                targetAccessor.setProperty(property.getInverse(),
+                        sourceAccessor.getProperty(sourceEntity.getRequiredPersistentProperty(property.getInverse().getName())));
+
+            }
+        });
+
+        return dto;
+    }
+}

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/JdbcQueryExecution.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/JdbcQueryExecution.java
@@ -16,7 +16,7 @@
 package org.springframework.data.jdbc.repository.query;
 
 import org.springframework.core.convert.converter.Converter;
-import org.springframework.data.convert.DtoInstantiatingConverter;
+import org.springframework.data.jdbc.core.convert.JdbcDtoInstantiatingConverter;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mapping.model.EntityInstantiators;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
@@ -33,6 +33,7 @@ import org.springframework.util.ClassUtils;
  * query and how to process the result in order to get the desired return type.
  *
  * @author Mark Paluch
+ * @author Paul Jones
  * @since 2.0
  */
 @FunctionalInterface
@@ -52,6 +53,7 @@ interface JdbcQueryExecution<T> {
 	 * A {@link Converter} to post-process all source objects using the given {@link ResultProcessor}.
 	 *
 	 * @author Mark Paluch
+	 * @author Paul Jones
 	 * @since 2.3
 	 */
 	class ResultProcessingConverter implements Converter<Object, Object> {
@@ -63,7 +65,7 @@ interface JdbcQueryExecution<T> {
 				MappingContext<? extends RelationalPersistentEntity<?>, ? extends RelationalPersistentProperty> mappingContext,
 				EntityInstantiators instantiators) {
 			this.processor = processor;
-			this.converter = Lazy.of(() -> new DtoInstantiatingConverter(processor.getReturnedType().getReturnedType(),
+			this.converter = Lazy.of(() -> new JdbcDtoInstantiatingConverter(processor.getReturnedType().getReturnedType(),
 					mappingContext, instantiators));
 		}
 


### PR DESCRIPTION
This is a simple fix to populate AggregateReference columns for Class based Dtos which only have a No-args constructor.  At present all other columns are correctly injected, it is just the AggregateReferences that are not transferred to the Dto.

I've added tests to my PR to prove the problem and the fix.  In the following example, the 'productType' column for the ProductDTO will be null using the current main branch, while all other columns will be correctly populated.

Hope this is helpful.   Please let me know your thoughts.  Thanks!

Model
```
@NoArgsConstructor
@Getter
@Setter
@Table
public class Product {
    @Id
    private Long id;
    private String name;
    private AggregateReference<ProductType,Long> productType;
}
```
DTO
```
@NoArgsConstructor
@Getter
@Setter
public class ProductDTO {
        private Long id;
        private String name;
        private AggregateReference<ProductType,Long> productType;
}
```
My Repository
```
public interface ProductRepository extends ListCrudRepository<Product, Long> {
    List<Product> findAll();
    List<ProductDTO> findAllBy();
}
```