### PR TITLE
Remove duplicate declaration of `document()` accessor in `RowDocument`

### DIFF
--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/MappingRelationalConverter.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/MappingRelationalConverter.java
@@ -85,6 +85,7 @@ import org.springframework.util.ClassUtils;
  * @author Jens Schauder
  * @author Chirag Tailor
  * @author Vincent Galloy
+ * @author Chanhyeong Cho
  * @see org.springframework.data.mapping.context.MappingContext
  * @see SimpleTypeHolder
  * @see CustomConversions
@@ -346,7 +347,7 @@ public class MappingRelationalConverter extends AbstractRelationalConverter
 		}
 
 		if (RowDocument.class.isAssignableFrom(rawType)) {
-			return (S) documentAccessor.document();
+			return (S) documentAccessor.getDocument();
 		}
 
 		if (typeHint.isMap()) {
@@ -1151,7 +1152,7 @@ public class MappingRelationalConverter extends AbstractRelationalConverter
 		@Override
 		public Object getValue(AggregatePath path) {
 
-			Object value = accessor.document().get(path.getColumnInfo().alias().getReference());
+			Object value = accessor.getDocument().get(path.getColumnInfo().alias().getReference());
 
 			if (value == null) {
 				return null;
@@ -1162,12 +1163,12 @@ public class MappingRelationalConverter extends AbstractRelationalConverter
 
 		@Override
 		public boolean hasValue(AggregatePath path) {
-			return accessor.document().get(path.getColumnInfo().alias().getReference()) != null;
+			return accessor.getDocument().get(path.getColumnInfo().alias().getReference()) != null;
 		}
 
 		@Override
 		public boolean hasValue(SqlIdentifier identifier) {
-			return accessor().document().get(identifier.getReference()) != null;
+			return accessor().getDocument().get(identifier.getReference()) != null;
 		}
 
 		@Override

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/RowDocumentAccessor.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/RowDocumentAccessor.java
@@ -28,6 +28,7 @@ import org.springframework.util.Assert;
  * a {@link RelationalPersistentProperty} might refer to through a path expression in field names.
  *
  * @author Mark Paluch
+ * @author Chanhyeong Cho
  * @since 3.2
  */
 public class RowDocumentAccessor {
@@ -108,10 +109,6 @@ public class RowDocumentAccessor {
 
 	String getColumnName(RelationalPersistentProperty prop) {
 		return prop.getColumnName().getReference();
-	}
-
-	public RowDocument document() {
-		return document;
 	}
 
 	@Override


### PR DESCRIPTION
I found two method declarations of get `RowDocument` and removed the uncommented one.