### PR TITLE
1804 - Upgrade Oracle Database version to the latest 23ai version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,12 +38,7 @@
 		<mssql.version>12.2.0.jre11</mssql.version>
 		<mysql-connector-java.version>8.0.32</mysql-connector-java.version>
 		<postgresql.version>42.6.0</postgresql.version>
-		<!--
-			The Oracle driver 23.3.0.23.09 is not considered production ready by Oracle, but it fixes two important problems for Spring Data JDBC:
-		 	https://stackoverflow.com/q/72717261/66686
-		 	https://stackoverflow.com/q/62263576/66686
-		 -->
-		<oracle.version>23.3.0.23.09</oracle.version>
+		<oracle.version>23.4.0.24.05</oracle.version>
 
 		<!-- test utilities-->
 		<awaitility.version>4.2.0</awaitility.version>

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/OracleDataSourceConfiguration.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/OracleDataSourceConfiguration.java
@@ -36,6 +36,7 @@ import org.testcontainers.utility.DockerImageName;
  * @see <a href="https://www.testcontainers.org/modules/databases/oraclexe/">Testcontainers Oracle</a>
  * @author Thomas Lang
  * @author Jens Schauder
+ * @author Loïc Lefèvre
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnDatabase(DatabaseType.ORACLE)

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/OracleDataSourceConfiguration.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/OracleDataSourceConfiguration.java
@@ -28,10 +28,10 @@ import org.testcontainers.oracle.OracleContainer;
 import org.testcontainers.utility.DockerImageName;
 
 /**
- * {@link DataSource} setup for Oracle Database XE. Starts a docker container with an Oracle database.
+ * {@link DataSource} setup for Oracle Database 23ai FREE. Starts a docker container with an Oracle database.
  *
  * @see <a href=
- *      "https://blogs.oracle.com/oraclemagazine/deliver-oracle-database-18c-express-edition-in-containers">Oracle
+ *      "https://github.com/gvenzl/oci-oracle-free">Oracle
  *      Docker Image</a>
  * @see <a href="https://www.testcontainers.org/modules/databases/oraclexe/">Testcontainers Oracle</a>
  * @author Thomas Lang
@@ -55,7 +55,7 @@ public class OracleDataSourceConfiguration extends DataSourceConfiguration {
 		if (ORACLE_CONTAINER == null) {
 
 			LOG.info("Oracle starting...");
-			DockerImageName dockerImageName = DockerImageName.parse("gvenzl/oracle-free:23.3-slim");
+			DockerImageName dockerImageName = DockerImageName.parse("gvenzl/oracle-free:23-slim");
 			OracleContainer container = new OracleContainer(dockerImageName) //
 					.withStartupTimeoutSeconds(200) //
 					.withReuse(true);
@@ -73,7 +73,7 @@ public class OracleDataSourceConfiguration extends DataSourceConfiguration {
 
 	private void initDb() {
 
-		final DriverManagerDataSource dataSource = new DriverManagerDataSource(ORACLE_CONTAINER.getJdbcUrl(), "SYSTEM",
+		final DriverManagerDataSource dataSource = new DriverManagerDataSource(ORACLE_CONTAINER.getJdbcUrl(), "test",
 				ORACLE_CONTAINER.getPassword());
 		final JdbcTemplate jdbc = new JdbcTemplate(dataSource);
 		jdbc.execute("GRANT ALL PRIVILEGES TO " + ORACLE_CONTAINER.getUsername());

--- a/spring-data-r2dbc/pom.xml
+++ b/spring-data-r2dbc/pom.xml
@@ -31,7 +31,7 @@
 		<r2dbc-mariadb.version>1.1.4</r2dbc-mariadb.version>
 		<r2dbc-mssql.version>1.0.2.RELEASE</r2dbc-mssql.version>
 		<r2dbc-mysql.version>1.0.2</r2dbc-mysql.version>
-		<oracle-r2dbc.version>1.1.1</oracle-r2dbc.version>
+		<oracle-r2dbc.version>1.2.0</oracle-r2dbc.version>
 		<r2dbc-spi.version>1.0.0.RELEASE</r2dbc-spi.version>
 		<reactive-streams.version>1.0.4</reactive-streams.version>
 		<netty>4.1.107.Final</netty>
@@ -190,7 +190,7 @@
 		<dependency>
 			<groupId>com.oracle.database.jdbc</groupId>
 			<artifactId>ojdbc11</artifactId>
-			<version>21.5.0.0</version>
+			<version>23.4.0.24.05</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/testing/OracleTestSupport.java
+++ b/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/testing/OracleTestSupport.java
@@ -113,10 +113,10 @@ public class OracleTestSupport {
 		return ProvidedDatabase.builder() //
 				.hostname("localhost") //
 				.port(1521) //
-				.database("XEPDB1") //
-				.username("system") //
-				.password("oracle") //
-				.jdbcUrl("jdbc:oracle:thin:system/oracle@localhost:1521:XEPDB1") //
+				.database("freepdb1") //
+				.username("test") //
+				.password("test") //
+				.jdbcUrl("jdbc:oracle:thin:test/test@localhost:1521/freepdb1") //
 				.build();
 	}
 
@@ -128,7 +128,7 @@ public class OracleTestSupport {
 		if (testContainerDatabase == null) {
 
 			try {
-				OracleContainer container = new OracleContainer("23.3-slim") //
+				OracleContainer container = new OracleContainer("gvenzl/oracle-free:23-slim") //
 						.withReuse(true) //
 						.withStartupTimeoutSeconds(200); // the default of 60s isn't sufficient
 				container.start();
@@ -167,7 +167,7 @@ public class OracleTestSupport {
 
 		DriverManagerDataSource dataSource = new DriverManagerDataSource();
 
-		dataSource.setUrl(database.getJdbcUrl().replace(":xe", "/XEPDB1"));
+		dataSource.setUrl(database.getJdbcUrl().replace(":freepdb1", "/freepdb1"));
 		dataSource.setUsername(database.getUsername());
 		dataSource.setPassword(database.getPassword());
 

--- a/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/testing/OracleTestSupport.java
+++ b/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/testing/OracleTestSupport.java
@@ -36,6 +36,7 @@ import org.testcontainers.oracle.OracleContainer;
  *
  * @author Mark Paluch
  * @author Jens Schauder
+ * @author Loïc Lefèvre
  */
 public class OracleTestSupport {
 


### PR DESCRIPTION
- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

This PR provides the support for Oracle Database 23ai:
- Uses the latest JDBC driver 23.4.0.24.05
- Uses the latest RD2BC version 1.2.0
- Uses the latest Oracle Database 23ai Free Docker image
- Uses the `freepdb1` database moving forward along default `test` user (from Testcontainers `OracleContainer`)