### PR TITLE
Consider embedded entities with empty non entity collections empty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-relational-parent</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.4.0-1737-nullable-embedded-with-collection-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Relational Parent</name>

--- a/spring-data-jdbc-distribution/pom.xml
+++ b/spring-data-jdbc-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-1737-nullable-embedded-with-collection-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-jdbc</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.4.0-1737-nullable-embedded-with-collection-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-1737-nullable-embedded-with-collection-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/MappingJdbcConverter.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/MappingJdbcConverter.java
@@ -421,7 +421,7 @@ public class MappingJdbcConverter extends MappingRelationalConverter implements 
 		@Override
 		public boolean hasValue(RelationalPersistentProperty property) {
 
-			if (property.isCollectionLike() || property.isMap()) {
+			if ((property.isCollectionLike() && property.isEntity())|| property.isMap()) {
 				// attempt relation fetch
 				return true;
 			}

--- a/spring-data-r2dbc/pom.xml
+++ b/spring-data-r2dbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-r2dbc</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.4.0-1737-nullable-embedded-with-collection-SNAPSHOT</version>
 
 	<name>Spring Data R2DBC</name>
 	<description>Spring Data module for R2DBC</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-1737-nullable-embedded-with-collection-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-relational</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.4.0-1737-nullable-embedded-with-collection-SNAPSHOT</version>
 
 	<name>Spring Data Relational</name>
 	<description>Spring Data Relational support</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-1737-nullable-embedded-with-collection-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/MappingRelationalConverter.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/MappingRelationalConverter.java
@@ -44,16 +44,7 @@ import org.springframework.data.mapping.PersistentProperty;
 import org.springframework.data.mapping.PersistentPropertyAccessor;
 import org.springframework.data.mapping.PersistentPropertyPathAccessor;
 import org.springframework.data.mapping.context.MappingContext;
-import org.springframework.data.mapping.model.CachingValueExpressionEvaluatorFactory;
-import org.springframework.data.mapping.model.ConvertingPropertyAccessor;
-import org.springframework.data.mapping.model.EntityInstantiator;
-import org.springframework.data.mapping.model.ParameterValueProvider;
-import org.springframework.data.mapping.model.PersistentEntityParameterValueProvider;
-import org.springframework.data.mapping.model.PropertyValueProvider;
-import org.springframework.data.mapping.model.SimpleTypeHolder;
-import org.springframework.data.mapping.model.SpELContext;
-import org.springframework.data.mapping.model.ValueExpressionEvaluator;
-import org.springframework.data.mapping.model.ValueExpressionParameterValueProvider;
+import org.springframework.data.mapping.model.*;
 import org.springframework.data.projection.EntityProjection;
 import org.springframework.data.projection.EntityProjectionIntrospector;
 import org.springframework.data.projection.EntityProjectionIntrospector.ProjectionPredicate;
@@ -1168,7 +1159,43 @@ public class MappingRelationalConverter extends AbstractRelationalConverter
 
 		@Override
 		public boolean hasValue(AggregatePath path) {
-			return document.get(path.getColumnInfo().alias().getReference()) != null;
+			Object value = document.get(path.getColumnInfo().alias().getReference());
+
+			if (value == null) {
+				return false;
+			}
+			if (!path.isCollectionLike()) {
+				return true;
+			}
+
+			if (value instanceof char[] ar) {
+				return ar.length != 0;
+			}
+			if (value instanceof byte[] ar) {
+				return ar.length != 0;
+			}
+			if (value instanceof short[] ar) {
+				return ar.length != 0;
+			}
+			if (value instanceof int[] ar) {
+				return ar.length != 0;
+			}
+			if (value instanceof long[] ar) {
+				return ar.length != 0;
+			}
+			if (value instanceof float[] ar) {
+				return ar.length != 0;
+			}
+			if (value instanceof double[] ar) {
+				return ar.length != 0;
+			}
+			if (value instanceof Object[] ar) {
+				return ar.length != 0;
+			}
+			if (value instanceof Collection<?> col) {
+				return !col.isEmpty();
+			}
+			return true;
 		}
 
 		@Override


### PR DESCRIPTION
Embedded entities which contain a empty collection of values that aren't entities are now considered empty, if this collection is empty.

Closes https://github.com/spring-projects/spring-data-relational/issues/1737