### PR TITLE
Create one connection pool for Oracle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
 		<!-- note that these currently do not control the versions of databases used via Testcontainers for testing -->
 		<db2.version>11.5.8.0</db2.version>
 		<h2.version>2.1.214</h2.version>
+		<hikari.version>5.1.0</hikari.version>
 		<hsqldb.version>2.7.1</hsqldb.version>
 		<mariadb-java-client.version>3.1.3</mariadb-java-client.version>
 		<mssql.version>12.2.0.jre11</mssql.version>
@@ -40,7 +41,7 @@
 		<postgresql.version>42.6.0</postgresql.version>
 		<oracle.version>23.4.0.24.05</oracle.version>
 
-		<!-- test utilities-->
+		<!-- test dependencies -->
 		<awaitility.version>4.2.0</awaitility.version>
 		<archunit.version>1.0.1</archunit.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-relational-parent</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.4.0-1815-tns-error-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Relational Parent</name>

--- a/spring-data-jdbc-distribution/pom.xml
+++ b/spring-data-jdbc-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-1815-tns-error-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -233,6 +233,12 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>com.zaxxer</groupId>
+			<artifactId>HikariCP</artifactId>
+			<version>${hikari.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-jdbc</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.4.0-1815-tns-error-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-1815-tns-error-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/DataSourceConfiguration.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/DataSourceConfiguration.java
@@ -24,6 +24,8 @@ import java.util.concurrent.TimeUnit;
 
 import javax.sql.DataSource;
 
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.awaitility.Awaitility;

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/OracleDataSourceConfiguration.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/OracleDataSourceConfiguration.java
@@ -27,12 +27,13 @@ import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.testcontainers.oracle.OracleContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+
 /**
  * {@link DataSource} setup for Oracle Database 23ai FREE. Starts a docker container with an Oracle database.
  *
- * @see <a href=
- *      "https://github.com/gvenzl/oci-oracle-free">Oracle
- *      Docker Image</a>
+ * @see <a href= "https://github.com/gvenzl/oci-oracle-free">Oracle Docker Image</a>
  * @see <a href="https://www.testcontainers.org/modules/databases/oraclexe/">Testcontainers Oracle</a>
  * @author Thomas Lang
  * @author Jens Schauder
@@ -44,16 +45,16 @@ public class OracleDataSourceConfiguration extends DataSourceConfiguration {
 
 	private static final Log LOG = LogFactory.getLog(OracleDataSourceConfiguration.class);
 
-	private static OracleContainer ORACLE_CONTAINER;
+	private static DataSource DATA_SOURCE;
 
 	public OracleDataSourceConfiguration(TestClass testClass, Environment environment) {
 		super(testClass, environment);
 	}
 
 	@Override
-	protected DataSource createDataSource() {
+	protected synchronized DataSource createDataSource() {
 
-		if (ORACLE_CONTAINER == null) {
+		if (DATA_SOURCE == null) {
 
 			LOG.info("Oracle starting...");
 			DockerImageName dockerImageName = DockerImageName.parse("gvenzl/oracle-free:23-slim");
@@ -63,21 +64,33 @@ public class OracleDataSourceConfiguration extends DataSourceConfiguration {
 			container.start();
 			LOG.info("Oracle started");
 
-			ORACLE_CONTAINER = container;
+			initDb(container.getJdbcUrl(),container.getUsername(), container.getPassword());
+
+			DATA_SOURCE = poolDataSource(new DriverManagerDataSource(container.getJdbcUrl(),
+					container.getUsername(), container.getPassword()));
 		}
-
-		initDb();
-
-		return new DriverManagerDataSource(ORACLE_CONTAINER.getJdbcUrl(), ORACLE_CONTAINER.getUsername(),
-				ORACLE_CONTAINER.getPassword());
+		return DATA_SOURCE;
 	}
 
-	private void initDb() {
+	private DataSource poolDataSource(DataSource dataSource) {
 
-		final DriverManagerDataSource dataSource = new DriverManagerDataSource(ORACLE_CONTAINER.getJdbcUrl(), "system",
-				ORACLE_CONTAINER.getPassword());
+		HikariConfig config = new HikariConfig();
+		config.setDataSource(dataSource);
+
+		config.setMaximumPoolSize(10);
+		config.setIdleTimeout(30000);
+		config.setMaxLifetime(600000);
+		config.setConnectionTimeout(30000);
+
+		return new HikariDataSource(config);
+	}
+
+	private void initDb(String jdbcUrl, String username, String password) {
+
+		final DriverManagerDataSource dataSource = new DriverManagerDataSource(jdbcUrl, "system",
+				password);
 		final JdbcTemplate jdbc = new JdbcTemplate(dataSource);
-		jdbc.execute("GRANT ALL PRIVILEGES TO " + ORACLE_CONTAINER.getUsername());
+		jdbc.execute("GRANT ALL PRIVILEGES TO " + username);
 	}
 
 	@Override

--- a/spring-data-r2dbc/pom.xml
+++ b/spring-data-r2dbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-r2dbc</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.4.0-1815-tns-error-SNAPSHOT</version>
 
 	<name>Spring Data R2DBC</name>
 	<description>Spring Data module for R2DBC</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-1815-tns-error-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-relational</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.4.0-1815-tns-error-SNAPSHOT</version>
 
 	<name>Spring Data Relational</name>
 	<description>Spring Data Relational support</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-1815-tns-error-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -104,7 +104,6 @@
 			<version>${jsqlparser}</version>
 			<scope>test</scope>
 		</dependency>
-
 	</dependencies>
 
 </project>


### PR DESCRIPTION
We now use one pooled `DataSource` for Oracle.

This should avoid problems with the TNS-Listener, which seems to have a problem with constantly opening and closing connections.

Closes https://github.com/spring-projects/spring-data-relational/issues/1815