### PR TITLE
Avoid double-conversion of values considered simple.

### DIFF
--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/MappingJdbcConverter.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/MappingJdbcConverter.java
@@ -243,15 +243,14 @@ public class MappingJdbcConverter extends MappingRelationalConverter implements 
 	@Override
 	public JdbcValue writeJdbcValue(@Nullable Object value, TypeInformation<?> columnType, SQLType sqlType) {
 
-		JdbcValue jdbcValue = tryToConvertToJdbcValue(value);
-		if (jdbcValue != null) {
-			return jdbcValue;
+		TypeInformation<?> targetType = canWriteAsJdbcValue(value) ? TypeInformation.of(JdbcValue.class) : columnType;
+		Object convertedValue = writeValue(value, targetType);
+
+		if (convertedValue instanceof JdbcValue result) {
+			return result;
 		}
 
-		Object convertedValue = writeValue(value, columnType);
-
 		if (convertedValue == null || !convertedValue.getClass().isArray()) {
-
 			return JdbcValue.of(convertedValue, sqlType);
 		}
 
@@ -267,20 +266,6 @@ public class MappingJdbcConverter extends MappingRelationalConverter implements 
 		}
 
 		return JdbcValue.of(convertedValue, JDBCType.BINARY);
-	}
-
-	@Nullable
-	private JdbcValue tryToConvertToJdbcValue(@Nullable Object value) {
-
-		if (canWriteAsJdbcValue(value)) {
-
-			Object converted = writeValue(value, TypeInformation.of(JdbcValue.class));
-			if (converted instanceof JdbcValue) {
-				return (JdbcValue) converted;
-			}
-		}
-
-		return null;
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
`MappingJdbcConverter` previously tried to create a `JdbcValue` for simple values via the `ConversionService`, only to drop the conversion result if the conversion did not result in a `JdbcValue` eventually. In that case, it triggered an additional (same) conversion to then handle the wrapping of the conversion result into a `JdbcValue` manually.

This commit alters the flow so that it only triggers the conversion once and manually applies the `JdbcValue` wrapping only if the result of the original conversion is not a `JdbcValue` yet.