### PR TITLE
Remove duplicated "the" in JavaDoc

### DIFF
--- a/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/repository/AbstractR2dbcRepositoryIntegrationTests.java
+++ b/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/repository/AbstractR2dbcRepositoryIntegrationTests.java
@@ -95,7 +95,7 @@ public abstract class AbstractR2dbcRepositoryIntegrationTests extends R2dbcInteg
 	protected abstract ConnectionFactory createConnectionFactory();
 
 	/**
-	 * Returns the the CREATE TABLE statement for table {@code legoset} with the following three columns:
+	 * Returns the CREATE TABLE statement for table {@code legoset} with the following three columns:
 	 * <ul>
 	 * <li>id integer (primary key), not null, auto-increment</li>
 	 * <li>name varchar(255), nullable</li>

--- a/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/repository/AbstractR2dbcRepositoryWithMixedCaseNamesIntegrationTests.java
+++ b/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/repository/AbstractR2dbcRepositoryWithMixedCaseNamesIntegrationTests.java
@@ -88,7 +88,7 @@ public abstract class AbstractR2dbcRepositoryWithMixedCaseNamesIntegrationTests 
 	protected abstract String getCreateTableStatement();
 
 	/**
-	 * Returns the the DROP TABLE statement for table {@code LegoSet}.
+	 * Returns the DROP TABLE statement for table {@code LegoSet}.
 	 *
 	 * @return the DROP TABLE statement for table {@code LegoSet}.
 	 */

--- a/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/repository/support/AbstractSimpleR2dbcRepositoryIntegrationTests.java
+++ b/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/repository/support/AbstractSimpleR2dbcRepositoryIntegrationTests.java
@@ -110,7 +110,7 @@ public abstract class AbstractSimpleR2dbcRepositoryIntegrationTests extends R2db
 	protected abstract DataSource createDataSource();
 
 	/**
-	 * Returns the the CREATE TABLE statement for table {@code legoset} with the following three columns:
+	 * Returns the CREATE TABLE statement for table {@code legoset} with the following three columns:
 	 * <ul>
 	 * <li>id integer (primary key), not null, auto-increment</li>
 	 * <li>name varchar(255), nullable</li>


### PR DESCRIPTION
This PR fixes typos of "the the" to "the".
I didn't add myself to the author of files because it's a simple typos correction.