### PR TITLE
Add support for CASE statements

### DIFF
--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/CaseExpression.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/CaseExpression.java
@@ -47,7 +47,7 @@ public class CaseExpression extends AbstractSegment implements Expression {
      */
     public CaseExpression when(When condition) {
         this.whenList.add(condition);
-        return this;
+        return new CaseExpression(whenList, other);
     }
 
     /**

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/CaseExpression.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/CaseExpression.java
@@ -22,15 +22,14 @@ import static java.util.stream.Collectors.joining;
  * @since 3.4
  */
 public class CaseExpression extends AbstractSegment implements Expression {
-    private final List<When> whenList = new ArrayList<>();
-    private final Literal other;
+    private final List<When> whenList;
+    private final Expression elseExpression;
 
-    private CaseExpression(List<When> whenList, Literal other) {
+    private CaseExpression(List<When> whenList, Expression elseExpression) {
 
-        super(children(whenList, other));
-
-        this.whenList.addAll(whenList);
-        this.other = other;
+        super(children(whenList, elseExpression));
+        this.whenList = whenList;
+        this.elseExpression = elseExpression;
     }
 
     /**
@@ -48,17 +47,18 @@ public class CaseExpression extends AbstractSegment implements Expression {
      * @return the {@link CaseExpression}
      */
     public CaseExpression when(When condition) {
-        this.whenList.add(condition);
-        return new CaseExpression(whenList, other);
+        List<When> conditions = new ArrayList<>(this.whenList);
+        conditions.add(condition);
+        return new CaseExpression(conditions, elseExpression);
     }
 
     /**
      * Add ELSE clause
-     * @param other the {@link Literal} else value
+     * @param elseExpression the {@link Expression} else value
      * @return the {@link CaseExpression}
      */
-    public CaseExpression other(Literal other) {
-        return new CaseExpression(whenList, other);
+    public CaseExpression elseExpression(Literal elseExpression) {
+        return new CaseExpression(whenList, elseExpression);
     }
 
     /**
@@ -71,22 +71,22 @@ public class CaseExpression extends AbstractSegment implements Expression {
     /**
      * @return the ELSE {@link Literal} value
      */
-    public Literal getOther() {
-        return other;
+    public Expression getElseExpression() {
+        return elseExpression;
     }
 
     @Override
     public String toString() {
-        return "CASE " + whenList.stream().map(When::toString).collect(joining(" ")) + (other != null ? " ELSE " + other : "") + " END";
+        return "CASE " + whenList.stream().map(When::toString).collect(joining(" ")) + (elseExpression != null ? " ELSE " + elseExpression : "") + " END";
     }
 
-    private static Segment[] children(List<When> whenList, Literal other) {
+    private static Segment[] children(List<When> whenList, Expression elseExpression) {
 
         List<Segment> segments = new ArrayList<>();
         segments.addAll(whenList);
 
-        if (other != null) {
-            segments.add(other);
+        if (elseExpression != null) {
+            segments.add(elseExpression);
         }
 
         return segments.toArray(new Segment[segments.size()]);

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/CaseExpression.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/CaseExpression.java
@@ -26,7 +26,9 @@ public class CaseExpression extends AbstractSegment implements Expression {
     private final Literal other;
 
     private CaseExpression(List<When> whenList, Literal other) {
+
         super(children(whenList, other));
+
         this.whenList.addAll(whenList);
         this.other = other;
     }
@@ -79,9 +81,14 @@ public class CaseExpression extends AbstractSegment implements Expression {
     }
 
     private static Segment[] children(List<When> whenList, Literal other) {
+
         List<Segment> segments = new ArrayList<>();
         segments.addAll(whenList);
-        segments.add(other);
+
+        if (other != null) {
+            segments.add(other);
+        }
+
         return segments.toArray(new Segment[segments.size()]);
     }
 }

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/CaseExpression.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/CaseExpression.java
@@ -19,6 +19,7 @@ import static java.util.stream.Collectors.joining;
  * </p>
  *
  * @author Sven Rienstra
+ * @since 3.4
  */
 public class CaseExpression extends AbstractSegment implements Expression {
     private final List<When> whenList = new ArrayList<>();

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/CaseExpression.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/CaseExpression.java
@@ -1,0 +1,86 @@
+package org.springframework.data.relational.core.sql;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.stream.Collectors.joining;
+
+/**
+ * Case with one or more conditions expression.
+ * <p>
+ * Results in a rendered condition:
+ * <pre>
+ *   CASE
+ *     WHEN condition1 THEN result1
+ *     WHEN condition2 THEN result2
+ *     ELSE result
+ *   END
+ * </pre>
+ * </p>
+ *
+ * @author Sven Rienstra
+ */
+public class CaseExpression extends AbstractSegment implements Expression {
+    private final List<When> whenList = new ArrayList<>();
+    private final Literal other;
+
+    private CaseExpression(List<When> whenList, Literal other) {
+        super(children(whenList, other));
+        this.whenList.addAll(whenList);
+        this.other = other;
+    }
+
+    /**
+     * Create CASE {@link Expression} with initial {@link When} condition.
+     * @param condition initial {@link When} condition
+     * @return the {@link CaseExpression}
+     */
+    public static CaseExpression create(When condition) {
+        return new CaseExpression(List.of(condition), null);
+    }
+
+    /**
+     * Add additional {@link When} condition
+     * @param condition the {@link When} condition
+     * @return the {@link CaseExpression}
+     */
+    public CaseExpression when(When condition) {
+        this.whenList.add(condition);
+        return this;
+    }
+
+    /**
+     * Add ELSE clause
+     * @param other the {@link Literal} else value
+     * @return the {@link CaseExpression}
+     */
+    public CaseExpression other(Literal other) {
+        return new CaseExpression(whenList, other);
+    }
+
+    /**
+     * @return the {@link When} conditions
+     */
+    public List<When> getWhenList() {
+        return whenList;
+    }
+
+    /**
+     * @return the ELSE {@link Literal} value
+     */
+    public Literal getOther() {
+        return other;
+    }
+
+    @Override
+    public String toString() {
+        return "CASE " + whenList.stream().map(When::toString).collect(joining(" ")) + (other != null ? " ELSE " + other : "") + " END";
+    }
+
+    private static Segment[] children(List<When> whenList, Literal other) {
+        List<Segment> segments = new ArrayList<>();
+        segments.addAll(whenList);
+        segments.add(other);
+        return segments.toArray(new Segment[segments.size()]);
+    }
+}

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/When.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/When.java
@@ -10,10 +10,10 @@ package org.springframework.data.relational.core.sql;
  * @since 3.4
  */
 public class When extends AbstractSegment {
-    private final Expression condition;
-    private final Literal value;
+    private final Condition condition;
+    private final Expression value;
 
-    private When(Expression condition, Literal value) {
+    private When(Condition condition, Expression value) {
 
         super(condition, value);
 
@@ -28,21 +28,21 @@ public class When extends AbstractSegment {
      * @param value     the {@link Literal} value.
      * @return the {@link When}.
      */
-    public static When when(Expression condition, Literal value) {
+    public static When when(Condition condition, Expression value) {
         return new When(condition, value);
     }
 
     /**
      * @return the condition
      */
-    public Expression getCondition() {
+    public Condition getCondition() {
         return condition;
     }
 
     /**
      * @return the value
      */
-    public Literal getValue() {
+    public Expression getValue() {
         return value;
     }
 

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/When.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/When.java
@@ -1,0 +1,48 @@
+package org.springframework.data.relational.core.sql;
+
+/**
+ * When segment for Case statement.
+ * <p>
+ * Results in a rendered condition: {@code WHEN <condition> THEN <value>}.
+ * </p>
+ */
+public class When extends AbstractSegment {
+    private final Expression condition;
+    private final Literal value;
+
+    private When(Expression condition, Literal value) {
+        super(condition, value);
+        this.condition = condition;
+        this.value = value;
+    }
+
+    /**
+     * Creates a new {@link When} given two {@link Expression} condition and {@link Literal} value.
+     *
+     * @param condition the condition {@link Expression}.
+     * @param value     the {@link Literal} value.
+     * @return the {@link When}.
+     */
+    public static When when(Expression condition, Literal value) {
+        return new When(condition, value);
+    }
+
+    /**
+     * @return the condition
+     */
+    public Expression getCondition() {
+        return condition;
+    }
+
+    /**
+     * @return the value
+     */
+    public Literal getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return "WHEN " + condition + " THEN " + value;
+    }
+}

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/When.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/When.java
@@ -14,7 +14,9 @@ public class When extends AbstractSegment {
     private final Literal value;
 
     private When(Expression condition, Literal value) {
+
         super(condition, value);
+
         this.condition = condition;
         this.value = value;
     }

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/When.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/When.java
@@ -5,6 +5,9 @@ package org.springframework.data.relational.core.sql;
  * <p>
  * Results in a rendered condition: {@code WHEN <condition> THEN <value>}.
  * </p>
+ *
+ * @author Sven Rienstra
+ * @since 3.4
  */
 public class When extends AbstractSegment {
     private final Expression condition;

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/CaseExpressionVisitor.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/CaseExpressionVisitor.java
@@ -5,6 +5,12 @@ import org.springframework.data.relational.core.sql.Literal;
 import org.springframework.data.relational.core.sql.Visitable;
 import org.springframework.data.relational.core.sql.When;
 
+/**
+ * Renderer for {@link CaseExpression}.
+ *
+ * @author Sven Rienstra
+ * @since 3.4
+ */
 public class CaseExpressionVisitor extends TypedSingleConditionRenderSupport<CaseExpression> implements PartRenderer {
     private final StringBuilder part = new StringBuilder();
 

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/CaseExpressionVisitor.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/CaseExpressionVisitor.java
@@ -1,0 +1,51 @@
+package org.springframework.data.relational.core.sql.render;
+
+import org.springframework.data.relational.core.sql.CaseExpression;
+import org.springframework.data.relational.core.sql.Literal;
+import org.springframework.data.relational.core.sql.Visitable;
+import org.springframework.data.relational.core.sql.When;
+
+public class CaseExpressionVisitor extends TypedSingleConditionRenderSupport<CaseExpression> implements PartRenderer {
+    private final StringBuilder part = new StringBuilder();
+
+    CaseExpressionVisitor(RenderContext context) {
+        super(context);
+    }
+
+    @Override
+    Delegation leaveNested(Visitable segment) {
+
+        if (hasDelegatedRendering()) {
+            CharSequence renderedPart = consumeRenderedPart();
+
+            if (segment instanceof When) {
+                part.append(renderedPart);
+            } else if (segment instanceof Literal<?>) {
+                part.append(" ELSE ");
+                part.append(renderedPart);
+            }
+        }
+
+        return super.leaveNested(segment);
+    }
+
+    @Override
+    Delegation enterMatched(CaseExpression segment) {
+        part.append("CASE ");
+
+        return super.enterMatched(segment);
+    }
+
+    @Override
+    Delegation leaveMatched(CaseExpression segment) {
+
+        part.append(" END");
+
+        return super.leaveMatched(segment);
+    }
+
+    @Override
+    public CharSequence getRenderedPart() {
+        return part;
+    }
+}

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/CaseExpressionVisitor.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/CaseExpressionVisitor.java
@@ -25,6 +25,7 @@ public class CaseExpressionVisitor extends TypedSingleConditionRenderSupport<Cas
             CharSequence renderedPart = consumeRenderedPart();
 
             if (segment instanceof When) {
+                part.append(" ");
                 part.append(renderedPart);
             } else if (segment instanceof Literal<?>) {
                 part.append(" ELSE ");
@@ -37,7 +38,8 @@ public class CaseExpressionVisitor extends TypedSingleConditionRenderSupport<Cas
 
     @Override
     Delegation enterMatched(CaseExpression segment) {
-        part.append("CASE ");
+
+        part.append("CASE");
 
         return super.enterMatched(segment);
     }

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/ExpressionVisitor.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/ExpressionVisitor.java
@@ -108,6 +108,10 @@ class ExpressionVisitor extends TypedSubtreeVisitor<Expression> implements PartR
 			CastVisitor visitor = new CastVisitor(context);
 			partRenderer = visitor;
 			return Delegation.delegateTo(visitor);
+		} else if (segment instanceof CaseExpression) {
+			CaseExpressionVisitor visitor = new CaseExpressionVisitor(context);
+			partRenderer = visitor;
+			return Delegation.delegateTo(visitor);
 		} else {
 			// works for literals and just and possibly more
 			value = segment.toString();

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/OrderByClauseVisitor.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/OrderByClauseVisitor.java
@@ -15,7 +15,13 @@
  */
 package org.springframework.data.relational.core.sql.render;
 
-import org.springframework.data.relational.core.sql.*;
+
+import org.springframework.data.relational.core.sql.Column;
+import org.springframework.data.relational.core.sql.CaseExpression;
+import org.springframework.data.relational.core.sql.Expressions;
+import org.springframework.data.relational.core.sql.OrderByField;
+import org.springframework.data.relational.core.sql.SimpleFunction;
+import org.springframework.data.relational.core.sql.Visitable;
 import org.springframework.lang.Nullable;
 
 /**

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/OrderByClauseVisitor.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/OrderByClauseVisitor.java
@@ -15,11 +15,7 @@
  */
 package org.springframework.data.relational.core.sql.render;
 
-import org.springframework.data.relational.core.sql.Column;
-import org.springframework.data.relational.core.sql.Expressions;
-import org.springframework.data.relational.core.sql.OrderByField;
-import org.springframework.data.relational.core.sql.SimpleFunction;
-import org.springframework.data.relational.core.sql.Visitable;
+import org.springframework.data.relational.core.sql.*;
 import org.springframework.lang.Nullable;
 
 /**
@@ -83,7 +79,7 @@ class OrderByClauseVisitor extends TypedSubtreeVisitor<OrderByField> implements 
 			return Delegation.delegateTo((SimpleFunctionVisitor)delegate);
 		}
 
-		if (segment instanceof Expressions.SimpleExpression) {
+		if (segment instanceof Expressions.SimpleExpression || segment instanceof CaseExpression) {
 			delegate = new ExpressionVisitor(context);
 			return Delegation.delegateTo((ExpressionVisitor)delegate);
 		}

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/TypedSingleConditionRenderSupport.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/TypedSingleConditionRenderSupport.java
@@ -18,6 +18,7 @@ package org.springframework.data.relational.core.sql.render;
 import org.springframework.data.relational.core.sql.Condition;
 import org.springframework.data.relational.core.sql.Expression;
 import org.springframework.data.relational.core.sql.Visitable;
+import org.springframework.data.relational.core.sql.When;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
@@ -40,14 +41,20 @@ abstract class TypedSingleConditionRenderSupport<T extends Visitable> extends Ty
 	@Override
 	Delegation enterNested(Visitable segment) {
 
-		if (segment instanceof Expression) {
-			ExpressionVisitor visitor = new ExpressionVisitor(context);
+		if (segment instanceof When) {
+			WhenVisitor visitor = new WhenVisitor(context);
 			current = visitor;
 			return Delegation.delegateTo(visitor);
 		}
 
 		if (segment instanceof Condition) {
 			ConditionVisitor visitor = new ConditionVisitor(context);
+			current = visitor;
+			return Delegation.delegateTo(visitor);
+		}
+
+		if (segment instanceof Expression) {
+			ExpressionVisitor visitor = new ExpressionVisitor(context);
 			current = visitor;
 			return Delegation.delegateTo(visitor);
 		}

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/TypedSingleConditionRenderSupport.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/TypedSingleConditionRenderSupport.java
@@ -27,6 +27,7 @@ import org.springframework.util.Assert;
  * delegate nested {@link Expression} and {@link Condition} rendering.
  *
  * @author Mark Paluch
+ * @author Sven Rienstra
  * @since 1.1
  */
 abstract class TypedSingleConditionRenderSupport<T extends Visitable> extends TypedSubtreeVisitor<T> {

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/WhenVisitor.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/WhenVisitor.java
@@ -1,0 +1,42 @@
+package org.springframework.data.relational.core.sql.render;
+
+import org.springframework.data.relational.core.sql.Visitable;
+import org.springframework.data.relational.core.sql.When;
+
+public class WhenVisitor extends TypedSingleConditionRenderSupport<When> implements PartRenderer {
+    private final StringBuilder part = new StringBuilder();
+    private boolean conditionRendeder;
+
+    WhenVisitor(RenderContext context) {
+        super(context);
+    }
+
+    @Override
+    Delegation leaveNested(Visitable segment) {
+
+        if (hasDelegatedRendering()) {
+
+            if (conditionRendeder) {
+                part.append(" THEN ");
+            }
+
+            part.append(consumeRenderedPart());
+            conditionRendeder = true;
+        }
+
+        return super.leaveNested(segment);
+    }
+
+    @Override
+    Delegation enterMatched(When segment) {
+
+        part.append("WHEN ");
+
+        return super.enterMatched(segment);
+    }
+
+    @Override
+    public CharSequence getRenderedPart() {
+        return part;
+    }
+}

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/WhenVisitor.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/WhenVisitor.java
@@ -11,7 +11,7 @@ import org.springframework.data.relational.core.sql.When;
  */
 public class WhenVisitor extends TypedSingleConditionRenderSupport<When> implements PartRenderer {
     private final StringBuilder part = new StringBuilder();
-    private boolean conditionRendeder;
+    private boolean conditionRendered;
 
     WhenVisitor(RenderContext context) {
         super(context);
@@ -22,12 +22,12 @@ public class WhenVisitor extends TypedSingleConditionRenderSupport<When> impleme
 
         if (hasDelegatedRendering()) {
 
-            if (conditionRendeder) {
+            if (conditionRendered) {
                 part.append(" THEN ");
             }
 
             part.append(consumeRenderedPart());
-            conditionRendeder = true;
+            conditionRendered = true;
         }
 
         return super.leaveNested(segment);

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/WhenVisitor.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/WhenVisitor.java
@@ -3,6 +3,12 @@ package org.springframework.data.relational.core.sql.render;
 import org.springframework.data.relational.core.sql.Visitable;
 import org.springframework.data.relational.core.sql.When;
 
+/**
+ * Renderer for {@link When} segments.
+ *
+ * @author Sven Rienstra
+ * @since 3.4
+ */
 public class WhenVisitor extends TypedSingleConditionRenderSupport<When> implements PartRenderer {
     private final StringBuilder part = new StringBuilder();
     private boolean conditionRendeder;

--- a/spring-data-relational/src/test/java/org/springframework/data/relational/core/sql/render/OrderByClauseVisitorUnitTests.java
+++ b/spring-data-relational/src/test/java/org/springframework/data/relational/core/sql/render/OrderByClauseVisitorUnitTests.java
@@ -18,14 +18,7 @@ package org.springframework.data.relational.core.sql.render;
 import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.data.relational.core.sql.Column;
-import org.springframework.data.relational.core.sql.Expression;
-import org.springframework.data.relational.core.sql.Expressions;
-import org.springframework.data.relational.core.sql.OrderByField;
-import org.springframework.data.relational.core.sql.SQL;
-import org.springframework.data.relational.core.sql.Select;
-import org.springframework.data.relational.core.sql.SimpleFunction;
-import org.springframework.data.relational.core.sql.Table;
+import org.springframework.data.relational.core.sql.*;
 
 import java.util.Arrays;
 import java.util.List;
@@ -128,5 +121,19 @@ class OrderByClauseVisitorUnitTests {
 		select.visit(visitor);
 
 		assertThat(visitor.getRenderedPart().toString()).isEqualTo("1 ASC");
+	}
+
+	@Test
+	void shouldRenderOrderByCase() {
+		Table employee = SQL.table("employee").as("emp");
+		Column column = employee.column("name");
+
+		CaseExpression caseExpression = CaseExpression.create(When.when(column.isNull(), SQL.literalOf(1))).other(SQL.literalOf(2));
+		Select select = Select.builder().select(column).from(employee).orderBy(OrderByField.from(caseExpression).asc()).build();
+
+		OrderByClauseVisitor visitor = new OrderByClauseVisitor(new SimpleRenderContext(NamingStrategies.asIs()));
+		select.visit(visitor);
+
+		assertThat(visitor.getRenderedPart().toString()).isEqualTo("CASE WHEN emp.name IS NULL THEN 1 ELSE 2 END ASC");
 	}
 }

--- a/spring-data-relational/src/test/java/org/springframework/data/relational/core/sql/render/OrderByClauseVisitorUnitTests.java
+++ b/spring-data-relational/src/test/java/org/springframework/data/relational/core/sql/render/OrderByClauseVisitorUnitTests.java
@@ -128,7 +128,7 @@ class OrderByClauseVisitorUnitTests {
 		Table employee = SQL.table("employee").as("emp");
 		Column column = employee.column("name");
 
-		CaseExpression caseExpression = CaseExpression.create(When.when(column.isNull(), SQL.literalOf(1))).other(SQL.literalOf(2));
+		CaseExpression caseExpression = CaseExpression.create(When.when(column.isNull(), SQL.literalOf(1))).elseExpression(SQL.literalOf(2));
 		Select select = Select.builder().select(column).from(employee).orderBy(OrderByField.from(caseExpression).asc()).build();
 
 		OrderByClauseVisitor visitor = new OrderByClauseVisitor(new SimpleRenderContext(NamingStrategies.asIs()));

--- a/spring-data-relational/src/test/java/org/springframework/data/relational/core/sql/render/SelectRendererUnitTests.java
+++ b/spring-data-relational/src/test/java/org/springframework/data/relational/core/sql/render/SelectRendererUnitTests.java
@@ -688,6 +688,20 @@ class SelectRendererUnitTests {
 		assertThat(rendered).isEqualTo("SELECT e.*, e.id FROM employee e");
 	}
 
+	@Test
+	void rendersCaseExpression() {
+		Table table = SQL.table("table");
+		Column column = table.column("name");
+
+		CaseExpression caseExpression = CaseExpression.create(When.when(column.isNull(), SQL.literalOf(1))).other(SQL.literalOf(2));
+		Select select = StatementBuilder.select(caseExpression) //
+				.from(table) //
+				.build();
+
+		String rendered = SqlRenderer.toString(select);
+		assertThat(rendered).isEqualTo("SELECT CASE WHEN table.name IS NULL THEN 1 ELSE 2 END FROM table");
+	}
+
 	/**
 	 * Tests the rendering of analytic functions.
 	 */

--- a/spring-data-relational/src/test/java/org/springframework/data/relational/core/sql/render/SelectRendererUnitTests.java
+++ b/spring-data-relational/src/test/java/org/springframework/data/relational/core/sql/render/SelectRendererUnitTests.java
@@ -693,13 +693,16 @@ class SelectRendererUnitTests {
 		Table table = SQL.table("table");
 		Column column = table.column("name");
 
-		CaseExpression caseExpression = CaseExpression.create(When.when(column.isNull(), SQL.literalOf(1))).other(SQL.literalOf(2));
+		CaseExpression caseExpression = CaseExpression.create(When.when(column.isNull(), SQL.literalOf(1))) //
+				.when(When.when(column.isNotNull(), SQL.literalOf(2))) //
+				.other(SQL.literalOf(3));
+
 		Select select = StatementBuilder.select(caseExpression) //
 				.from(table) //
 				.build();
 
 		String rendered = SqlRenderer.toString(select);
-		assertThat(rendered).isEqualTo("SELECT CASE WHEN table.name IS NULL THEN 1 ELSE 2 END FROM table");
+		assertThat(rendered).isEqualTo("SELECT CASE WHEN table.name IS NULL THEN 1 WHEN table.name IS NOT NULL THEN 2 ELSE 3 END FROM table");
 	}
 
 	/**

--- a/spring-data-relational/src/test/java/org/springframework/data/relational/core/sql/render/SelectRendererUnitTests.java
+++ b/spring-data-relational/src/test/java/org/springframework/data/relational/core/sql/render/SelectRendererUnitTests.java
@@ -695,7 +695,7 @@ class SelectRendererUnitTests {
 
 		CaseExpression caseExpression = CaseExpression.create(When.when(column.isNull(), SQL.literalOf(1))) //
 				.when(When.when(column.isNotNull(), SQL.literalOf(2))) //
-				.other(SQL.literalOf(3));
+				.elseExpression(SQL.literalOf(3));
 
 		Select select = StatementBuilder.select(caseExpression) //
 				.from(table) //


### PR DESCRIPTION
This PR add supports for CASE statements. Added 4 new types: `CaseExpression` and `When` plus their respective visitors.

Also I changed the order of visitors in `TypedSingleConditionRenderSupport`. Because `Condition` extends `Expression` the `ExpressionVisitor` was used for `Condition`s.

Question: Should I add support for any `Expression` in the THEN and OTHER clause (versus `Literal` now)? 