### PR TITLE
StringBasedJdbcQuery no longer requires BeanFactory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-relational-parent</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.4.0-1872-refactor-SBJQ-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Relational Parent</name>

--- a/spring-data-jdbc-distribution/pom.xml
+++ b/spring-data-jdbc-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-1872-refactor-SBJQ-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-jdbc</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.4.0-1872-refactor-SBJQ-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-1872-refactor-SBJQ-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/AbstractJdbcQuery.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/AbstractJdbcQuery.java
@@ -76,7 +76,7 @@ public abstract class AbstractJdbcQuery implements RepositoryQuery {
 	 * Creates a {@link JdbcQueryExecution} given a {@link ResultSetExtractor} or a {@link RowMapper}. Prefers the given
 	 * {@link ResultSetExtractor} over {@link RowMapper}.
 	 *
-	 * @param extractor must not be {@literal null}.
+	 * @param extractor may be {@literal null}.
 	 * @param rowMapper must not be {@literal null}.
 	 * @return a JdbcQueryExecution appropriate for {@literal queryMethod}. Guaranteed to be not {@literal null}.
 	 */

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/AbstractJdbcQuery.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/AbstractJdbcQuery.java
@@ -23,6 +23,7 @@ import java.util.stream.Stream;
 
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.data.jdbc.core.convert.JdbcArrayColumns;
 import org.springframework.data.repository.query.RepositoryQuery;
 import org.springframework.data.repository.query.ResultProcessor;
 import org.springframework.data.repository.query.ReturnedType;
@@ -155,7 +156,34 @@ public abstract class AbstractJdbcQuery implements RepositoryQuery {
 	 * @since 2.3
 	 */
 	public interface RowMapperFactory {
+
+		/**
+		 * Create a {@link RowMapper} based on the expected return type passed in as an argument.
+		 *
+		 * @param result must not be {@code null}.
+		 * @return a {@code RowMapper} producing instances of {@code result}.
+		 */
 		RowMapper<Object> create(Class<?> result);
+
+		/**
+		 * Obtain a {@code RowMapper} from some other source, typically a {@link org.springframework.beans.factory.BeanFactory}.
+		 *
+		 * @param reference must not be {@code null}.
+		 * @since 3.4
+		 */
+		default RowMapper<Object> rowMapperByReference(String reference) {
+			throw new UnsupportedOperationException("rowMapperByReference is not supported");
+		}
+
+		/**
+		 * Obtain a {@code ResultSetExtractor} from some other source, typically a {@link org.springframework.beans.factory.BeanFactory}.
+		 *
+		 * @param reference must not be {@code null}.
+		 * @since 3.4
+		 */
+		default ResultSetExtractor<Object> resultSetExtractorByReference(String reference) {
+			throw new UnsupportedOperationException("resultSetExtractorByReference is not supported");
+		}
 	}
 
 	/**

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/AbstractJdbcQuery.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/AbstractJdbcQuery.java
@@ -23,7 +23,6 @@ import java.util.stream.Stream;
 
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.dao.EmptyResultDataAccessException;
-import org.springframework.data.jdbc.core.convert.JdbcArrayColumns;
 import org.springframework.data.repository.query.RepositoryQuery;
 import org.springframework.data.repository.query.ResultProcessor;
 import org.springframework.data.repository.query.ReturnedType;
@@ -171,8 +170,8 @@ public abstract class AbstractJdbcQuery implements RepositoryQuery {
 		 * @param reference must not be {@code null}.
 		 * @since 3.4
 		 */
-		default RowMapper<Object> rowMapperByReference(String reference) {
-			throw new UnsupportedOperationException("rowMapperByReference is not supported");
+		default RowMapper<Object> getRowMapper(String reference) {
+			throw new UnsupportedOperationException("getRowMapper is not supported");
 		}
 
 		/**
@@ -181,8 +180,8 @@ public abstract class AbstractJdbcQuery implements RepositoryQuery {
 		 * @param reference must not be {@code null}.
 		 * @since 3.4
 		 */
-		default ResultSetExtractor<Object> resultSetExtractorByReference(String reference) {
-			throw new UnsupportedOperationException("resultSetExtractorByReference is not supported");
+		default ResultSetExtractor<Object> getResultSetExtractor(String reference) {
+			throw new UnsupportedOperationException("getResultSetExtractor is not supported");
 		}
 	}
 

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/StringBasedJdbcQuery.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/StringBasedJdbcQuery.java
@@ -77,7 +77,6 @@ public class StringBasedJdbcQuery extends AbstractJdbcQuery {
 	private final SpelEvaluator spelEvaluator;
 	private final boolean containsSpelExpressions;
 	private final String query;
-	private BeanFactory beanFactory;
 
 	private final CachedRowMapperFactory cachedRowMapperFactory;
 	private final CachedResultSetExtractorFactory cachedResultSetExtractorFactory;
@@ -353,10 +352,6 @@ public class StringBasedJdbcQuery extends AbstractJdbcQuery {
 		return configuredClass == null || configuredClass == defaultClass;
 	}
 
-	public void setBeanFactory(BeanFactory beanFactory) {
-		this.beanFactory = beanFactory;
-	}
-
 	class CachedRowMapperFactory {
 
 		private final Lazy<RowMapper<Object>> cachedRowMapper;
@@ -380,10 +375,7 @@ public class StringBasedJdbcQuery extends AbstractJdbcQuery {
 			this.cachedRowMapper = Lazy.of(() -> {
 
 				if (!ObjectUtils.isEmpty(rowMapperRef)) {
-
-					Assert.notNull(beanFactory, "When a RowMapperRef is specified the BeanFactory must not be null");
-
-					return (RowMapper<Object>) beanFactory.getBean(rowMapperRef);
+					return rowMapperFactory.rowMapperByReference(rowMapperRef);
 				}
 
 				if (isUnconfigured(rowMapperClass, RowMapper.class)) {
@@ -434,10 +426,7 @@ public class StringBasedJdbcQuery extends AbstractJdbcQuery {
 			this.resultSetExtractorFactory = rowMapper -> {
 
 				if (!ObjectUtils.isEmpty(resultSetExtractorRef)) {
-
-					Assert.notNull(beanFactory, "When a ResultSetExtractorRef is specified the BeanFactory must not be null");
-
-					return (ResultSetExtractor<Object>) beanFactory.getBean(resultSetExtractorRef);
+					return rowMapperFactory.resultSetExtractorByReference(resultSetExtractorRef);
 				}
 
 				if (isUnconfigured(resultSetExtractorClass, ResultSetExtractor.class)) {

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/StringBasedJdbcQuery.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/StringBasedJdbcQuery.java
@@ -352,6 +352,9 @@ public class StringBasedJdbcQuery extends AbstractJdbcQuery {
 		return configuredClass == null || configuredClass == defaultClass;
 	}
 
+	@Deprecated(since = "3.4")
+	public void setBeanFactory(BeanFactory beanFactory) {}
+
 	class CachedRowMapperFactory {
 
 		private final Lazy<RowMapper<Object>> cachedRowMapper;
@@ -375,7 +378,7 @@ public class StringBasedJdbcQuery extends AbstractJdbcQuery {
 			this.cachedRowMapper = Lazy.of(() -> {
 
 				if (!ObjectUtils.isEmpty(rowMapperRef)) {
-					return rowMapperFactory.rowMapperByReference(rowMapperRef);
+					return rowMapperFactory.getRowMapper(rowMapperRef);
 				}
 
 				if (isUnconfigured(rowMapperClass, RowMapper.class)) {
@@ -426,7 +429,7 @@ public class StringBasedJdbcQuery extends AbstractJdbcQuery {
 			this.resultSetExtractorFactory = rowMapper -> {
 
 				if (!ObjectUtils.isEmpty(resultSetExtractorRef)) {
-					return rowMapperFactory.resultSetExtractorByReference(resultSetExtractorRef);
+					return rowMapperFactory.getResultSetExtractor(resultSetExtractorRef);
 				}
 
 				if (isUnconfigured(resultSetExtractorClass, ResultSetExtractor.class)) {

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/query/StringBasedJdbcQueryUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/query/StringBasedJdbcQueryUnitTests.java
@@ -645,21 +645,21 @@ class StringBasedJdbcQueryUnitTests {
 		}
 
 		@Override
-		public RowMapper<Object> rowMapperByReference(String reference) {
+		public RowMapper<Object> getRowMapper(String reference) {
 
 			if (preparedReference.equals(reference)) {
 				return (RowMapper<Object>) value;
 			}
-			return AbstractJdbcQuery.RowMapperFactory.super.rowMapperByReference(reference);
+			return AbstractJdbcQuery.RowMapperFactory.super.getRowMapper(reference);
 		}
 
 		@Override
-		public ResultSetExtractor<Object> resultSetExtractorByReference(String reference) {
+		public ResultSetExtractor<Object> getResultSetExtractor(String reference) {
 
 			if (preparedReference.equals(reference)) {
 				return (ResultSetExtractor<Object>) value;
 			}
-			return AbstractJdbcQuery.RowMapperFactory.super.resultSetExtractorByReference(reference);
+			return AbstractJdbcQuery.RowMapperFactory.super.getResultSetExtractor(reference);
 		}
 	}
 }

--- a/spring-data-r2dbc/pom.xml
+++ b/spring-data-r2dbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-r2dbc</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.4.0-1872-refactor-SBJQ-SNAPSHOT</version>
 
 	<name>Spring Data R2DBC</name>
 	<description>Spring Data module for R2DBC</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-1872-refactor-SBJQ-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-relational</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.4.0-1872-refactor-SBJQ-SNAPSHOT</version>
 
 	<name>Spring Data Relational</name>
 	<description>Spring Data Relational support</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-1872-refactor-SBJQ-SNAPSHOT</version>
 	</parent>
 
 	<properties>


### PR DESCRIPTION
The lookup is now performed by the `RowMapperFactory`.

Closes https://github.com/spring-projects/spring-data-relational/issues/1872