### PR TITLE
Issue/remove code duplication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-relational-parent</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.4.0-remove-code-duplication-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Relational Parent</name>

--- a/spring-data-jdbc-distribution/pom.xml
+++ b/spring-data-jdbc-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-remove-code-duplication-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-jdbc</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.4.0-remove-code-duplication-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-remove-code-duplication-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-r2dbc/pom.xml
+++ b/spring-data-r2dbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-r2dbc</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.4.0-remove-code-duplication-SNAPSHOT</version>
 
 	<name>Spring Data R2DBC</name>
 	<description>Spring Data module for R2DBC</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-remove-code-duplication-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-relational</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.4.0-remove-code-duplication-SNAPSHOT</version>
 
 	<name>Spring Data Relational</name>
 	<description>Spring Data Relational support</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.4.0-remove-code-duplication-SNAPSHOT</version>
 	</parent>
 
 	<properties>


### PR DESCRIPTION
ONLY MERGE AFTER GA RELEASE

Mainly reimplements the changes undone in https://github.com/spring-projects/spring-data-relational/commit/49e343fe8ac1d0372648cd97b0d5783d852272eb.
The check for presence of the ID property is implemented for all variants for save, as it should.

See https://github.com/spring-projects/spring-data-relational/issues/1924