### PR TITLE
Issue/1953 feat: Add custom operator to Criteria.

### DIFF
--- a/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/query/CriteriaUnitTests.java
+++ b/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/query/CriteriaUnitTests.java
@@ -19,6 +19,8 @@ import static org.assertj.core.api.Assertions.*;
 import static org.springframework.data.relational.core.query.Criteria.*;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
@@ -31,6 +33,7 @@ import org.springframework.data.relational.core.sql.SqlIdentifier;
  *
  * @author Mark Paluch
  * @author Mingyuan Wu
+ * @author Zhengyu Wu
  */
 class CriteriaUnitTests {
 
@@ -290,4 +293,17 @@ class CriteriaUnitTests {
 		assertThat(criteria.getColumn()).isEqualTo(SqlIdentifier.unquoted("foo"));
 		assertThat(criteria.getComparator()).isEqualTo(Comparator.IS_FALSE);
 	}
+
+	@Test
+	void shouldBuildCustomCriteria() {
+		List<String> values = List.of("bar", "baz", "qux");
+		Criteria criteria = where("foo").custom("@>",
+				value -> "ARRAY[" + values.stream().map(s -> "'" + s + "'").collect(Collectors.joining(",")) + "]",
+				List.of("bar", "baz", "qux"));
+
+		assertThat(criteria.getColumn()).isEqualTo(SqlIdentifier.unquoted("foo"));
+		assertThat(criteria.getComparator()).isEqualTo(Comparator.CUSTOM);
+		assertThat(criteria.toString()).isEqualTo("foo @> ARRAY['bar','baz','qux']");
+	}
+
 }

--- a/spring-data-relational/src/test/java/org/springframework/data/relational/core/query/CriteriaUnitTests.java
+++ b/spring-data-relational/src/test/java/org/springframework/data/relational/core/query/CriteriaUnitTests.java
@@ -20,6 +20,8 @@ import static org.assertj.core.api.SoftAssertions.*;
 import static org.springframework.data.relational.core.query.Criteria.*;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
@@ -31,6 +33,7 @@ import org.springframework.data.relational.core.sql.SqlIdentifier;
  * @author Mark Paluch
  * @author Jens Schauder
  * @author Roman Chigvintsev
+ * @author Zhengyu Wu
  */
 class CriteriaUnitTests {
 
@@ -297,4 +300,17 @@ class CriteriaUnitTests {
 		assertThat(criteria.getComparator()).isEqualTo(CriteriaDefinition.Comparator.IS_FALSE);
 		assertThat(criteria.getValue()).isEqualTo(false);
 	}
+
+	@Test
+	void shouldBuildCustomCriteria() {
+		List<String> values = List.of("bar", "baz", "qux");
+		Criteria criteria = where("foo").custom("@>",
+				value -> "ARRAY[" + values.stream().map(s -> "'" + s + "'").collect(Collectors.joining(",")) + "]",
+				List.of("bar", "baz", "qux"));
+
+		assertThat(criteria.getColumn()).isEqualTo(SqlIdentifier.unquoted("foo"));
+		assertThat(criteria.getComparator()).isEqualTo(Comparator.CUSTOM);
+		assertThat(criteria.toString()).isEqualTo("foo @> ARRAY['bar','baz','qux']");
+	}
+
 }


### PR DESCRIPTION
Solving https://github.com/spring-projects/spring-data-relational/issues/1953 issue
This PR introduces support for custom comparators in the Spring Data Relational library, enhancing the flexibility of query building.

Key Changes
1. Enhanced Comparator
        - Added two new fields:
        - customRenderValueFunc: A function to define custom rendering logic for values.
        - customComparator: A string to define the custom comparator operator.
        - Introduced a setCustomComparator method to configure these properties.
        - Moved the render logic from Criteria to Comparator for better encapsulation and extensibility.
2. Added Custom Comparator Support in CriteriaStep
