### PR TITLE
Add Stream support to JdbcAggregateOperations

### DIFF
--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/JdbcAggregateOperations.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/JdbcAggregateOperations.java
@@ -17,6 +17,7 @@ package org.springframework.data.jdbc.core;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.springframework.dao.IncorrectUpdateSemanticsDataAccessException;
 import org.springframework.data.domain.Example;
@@ -35,6 +36,7 @@ import org.springframework.lang.Nullable;
  * @author Chirag Tailor
  * @author Diego Krupitza
  * @author Myeonghyeon Lee
+ * @author Sergey Korotaev
  */
 public interface JdbcAggregateOperations {
 
@@ -166,6 +168,17 @@ public interface JdbcAggregateOperations {
 	<T> List<T> findAllById(Iterable<?> ids, Class<T> domainType);
 
 	/**
+	 * Loads all entities that match one of the ids passed as an argument to a {@link Stream}.
+	 * It is not guaranteed that the number of ids passed in matches the number of entities returned.
+	 *
+	 * @param ids the Ids of the entities to load. Must not be {@code null}.
+	 * @param domainType the type of entities to load. Must not be {@code null}.
+	 * @param <T> type of entities to load.
+	 * @return the loaded entities. Guaranteed to be not {@code null}.
+	 */
+	<T> Stream<T> streamAllByIds(Iterable<?> ids, Class<T> domainType);
+
+	/**
 	 * Load all aggregates of a given type.
 	 *
 	 * @param domainType the type of the aggregate roots. Must not be {@code null}.
@@ -173,6 +186,15 @@ public interface JdbcAggregateOperations {
 	 * @return Guaranteed to be not {@code null}.
 	 */
 	<T> List<T> findAll(Class<T> domainType);
+
+	/**
+	 * Load all aggregates of a given type to a {@link Stream}.
+	 *
+	 * @param domainType the type of the aggregate roots. Must not be {@code null}.
+	 * @param <T> the type of the aggregate roots. Must not be {@code null}.
+	 * @return Guaranteed to be not {@code null}.
+	 */
+	<T> Stream<T> streamAll(Class<T> domainType);
 
 	/**
 	 * Load all aggregates of a given type, sorted.
@@ -184,6 +206,17 @@ public interface JdbcAggregateOperations {
 	 * @since 2.0
 	 */
 	<T> List<T> findAll(Class<T> domainType, Sort sort);
+
+	/**
+	 * Loads all entities of the given type to a {@link Stream}, sorted.
+	 *
+	 * @param domainType the type of entities to load. Must not be {@code null}.
+	 * @param <T> the type of entities to load.
+	 * @param sort the sorting information. Must not be {@code null}.
+	 * @return Guaranteed to be not {@code null}.
+	 * @since 2.0
+	 */
+	<T> Stream<T> streamAll(Class<T> domainType, Sort sort);
 
 	/**
 	 * Load a page of (potentially sorted) aggregates of a given type.
@@ -217,6 +250,17 @@ public interface JdbcAggregateOperations {
 	 * @since 3.0
 	 */
 	<T> List<T> findAll(Query query, Class<T> domainType);
+
+	/**
+	 * Execute a {@code SELECT} query and convert the resulting items to a {@link Stream}.
+	 *
+	 * @param query must not be {@literal null}.
+	 * @param domainType the type of entities. Must not be {@code null}.
+	 * @return a non-null list with all the matching results.
+	 * @throws org.springframework.dao.IncorrectResultSizeDataAccessException if more than one match found.
+	 * @since 3.0
+	 */
+	<T> Stream<T> streamAll(Query query, Class<T> domainType);
 
 	/**
 	 * Returns a {@link Page} of entities matching the given {@link Query}. In case no match could be found, an empty

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/CascadingDataAccessStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/CascadingDataAccessStrategy.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -42,6 +43,7 @@ import org.springframework.data.relational.core.sql.LockMode;
  * @author Myeonghyeon Lee
  * @author Chirag Tailor
  * @author Diego Krupitza
+ * @author Sergey Korotaev
  * @since 1.1
  */
 public class CascadingDataAccessStrategy implements DataAccessStrategy {
@@ -133,8 +135,18 @@ public class CascadingDataAccessStrategy implements DataAccessStrategy {
 	}
 
 	@Override
+	public <T> Stream<T> streamAll(Class<T> domainType) {
+		return collect(das -> das.streamAll(domainType));
+	}
+
+	@Override
 	public <T> Iterable<T> findAllById(Iterable<?> ids, Class<T> domainType) {
 		return collect(das -> das.findAllById(ids, domainType));
+	}
+
+	@Override
+	public <T> Stream<T> streamAllByIds(Iterable<?> ids, Class<T> domainType) {
+		return collect(das -> das.streamAllByIds(ids, domainType));
 	}
 
 	@Override
@@ -154,6 +166,11 @@ public class CascadingDataAccessStrategy implements DataAccessStrategy {
 	}
 
 	@Override
+	public <T> Stream<T> streamAll(Class<T> domainType, Sort sort) {
+		return collect(das -> das.streamAll(domainType, sort));
+	}
+
+	@Override
 	public <T> Iterable<T> findAll(Class<T> domainType, Pageable pageable) {
 		return collect(das -> das.findAll(domainType, pageable));
 	}
@@ -166,6 +183,11 @@ public class CascadingDataAccessStrategy implements DataAccessStrategy {
 	@Override
 	public <T> Iterable<T> findAll(Query query, Class<T> domainType) {
 		return collect(das -> das.findAll(query, domainType));
+	}
+
+	@Override
+	public <T> Stream<T> streamAll(Query query, Class<T> domainType) {
+		return collect(das -> das.streamAll(query, domainType));
 	}
 
 	@Override

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DataAccessStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DataAccessStrategy.java
@@ -18,6 +18,7 @@ package org.springframework.data.jdbc.core.convert;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.data.domain.Pageable;
@@ -41,6 +42,7 @@ import org.springframework.lang.Nullable;
  * @author Myeonghyeon Lee
  * @author Chirag Tailor
  * @author Diego Krupitza
+ * @author Sergey Korotaev
  */
 public interface DataAccessStrategy extends ReadingDataAccessStrategy, RelationResolver {
 
@@ -253,6 +255,16 @@ public interface DataAccessStrategy extends ReadingDataAccessStrategy, RelationR
 	<T> Iterable<T> findAll(Class<T> domainType);
 
 	/**
+	 * Loads all entities of the given type to a {@link Stream}.
+	 *
+	 * @param domainType the type of entities to load. Must not be {@code null}.
+	 * @param <T> the type of entities to load.
+	 * @return Guaranteed to be not {@code null}.
+	 */
+	@Override
+	<T> Stream<T> streamAll(Class<T> domainType);
+
+	/**
 	 * Loads all entities that match one of the ids passed as an argument. It is not guaranteed that the number of ids
 	 * passed in matches the number of entities returned.
 	 *
@@ -263,6 +275,18 @@ public interface DataAccessStrategy extends ReadingDataAccessStrategy, RelationR
 	 */
 	@Override
 	<T> Iterable<T> findAllById(Iterable<?> ids, Class<T> domainType);
+
+	/**
+	 * Loads all entities that match one of the ids passed as an argument to a {@link Stream}.
+	 * It is not guaranteed that the number of ids passed in matches the number of entities returned.
+	 *
+	 * @param ids the Ids of the entities to load. Must not be {@code null}.
+	 * @param domainType the type of entities to load. Must not be {@code null}.
+	 * @param <T> type of entities to load.
+	 * @return the loaded entities. Guaranteed to be not {@code null}.
+	 */
+	@Override
+	<T> Stream<T> streamAllByIds(Iterable<?> ids, Class<T> domainType);
 
 	@Override
 	Iterable<Object> findAllByPath(Identifier identifier,
@@ -279,6 +303,18 @@ public interface DataAccessStrategy extends ReadingDataAccessStrategy, RelationR
 	 */
 	@Override
 	<T> Iterable<T> findAll(Class<T> domainType, Sort sort);
+
+	/**
+	 * Loads all entities of the given type to a {@link Stream}, sorted.
+	 *
+	 * @param domainType the type of entities to load. Must not be {@code null}.
+	 * @param <T> the type of entities to load.
+	 * @param sort the sorting information. Must not be {@code null}.
+	 * @return Guaranteed to be not {@code null}.
+	 * @since 2.0
+	 */
+	@Override
+	<T> Stream<T> streamAll(Class<T> domainType, Sort sort);
 
 	/**
 	 * Loads all entities of the given type, paged and sorted.
@@ -315,6 +351,18 @@ public interface DataAccessStrategy extends ReadingDataAccessStrategy, RelationR
 	 */
 	@Override
 	<T> Iterable<T> findAll(Query query, Class<T> domainType);
+
+	/**
+	 * Execute a {@code SELECT} query and convert the resulting items to a {@link Stream}.
+	 *
+	 * @param query must not be {@literal null}.
+	 * @param domainType the type of entities. Must not be {@code null}.
+	 * @return a non-null list with all the matching results.
+	 * @throws org.springframework.dao.IncorrectResultSizeDataAccessException if more than one match found.
+	 * @since 3.0
+	 */
+	@Override
+	<T> Stream<T> streamAll(Query query, Class<T> domainType);
 
 	/**
 	 * Execute a {@code SELECT} query and convert the resulting items to a {@link Iterable}. Applies the {@link Pageable}

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DelegatingDataAccessStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DelegatingDataAccessStrategy.java
@@ -17,6 +17,7 @@ package org.springframework.data.jdbc.core.convert;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -37,6 +38,7 @@ import org.springframework.util.Assert;
  * @author Myeonghyeon Lee
  * @author Chirag Tailor
  * @author Diego Krupitza
+ * @author Sergey Korotaev
  * @since 1.1
  */
 public class DelegatingDataAccessStrategy implements DataAccessStrategy {
@@ -136,8 +138,18 @@ public class DelegatingDataAccessStrategy implements DataAccessStrategy {
 	}
 
 	@Override
+	public <T> Stream<T> streamAll(Class<T> domainType) {
+		return delegate.streamAll(domainType);
+	}
+
+	@Override
 	public <T> Iterable<T> findAllById(Iterable<?> ids, Class<T> domainType) {
 		return delegate.findAllById(ids, domainType);
+	}
+
+	@Override
+	public <T> Stream<T> streamAllByIds(Iterable<?> ids, Class<T> domainType) {
+		return delegate.streamAllByIds(ids, domainType);
 	}
 
 	@Override
@@ -157,6 +169,11 @@ public class DelegatingDataAccessStrategy implements DataAccessStrategy {
 	}
 
 	@Override
+	public <T> Stream<T> streamAll(Class<T> domainType, Sort sort) {
+		return delegate.streamAll(domainType, sort);
+	}
+
+	@Override
 	public <T> Iterable<T> findAll(Class<T> domainType, Pageable pageable) {
 		return delegate.findAll(domainType, pageable);
 	}
@@ -169,6 +186,11 @@ public class DelegatingDataAccessStrategy implements DataAccessStrategy {
 	@Override
 	public <T> Iterable<T> findAll(Query query, Class<T> domainType) {
 		return delegate.findAll(query, domainType);
+	}
+
+	@Override
+	public <T> Stream<T> streamAll(Query query, Class<T> domainType) {
+		return delegate.streamAll(query, domainType);
 	}
 
 	@Override

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/ReadingDataAccessStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/ReadingDataAccessStrategy.java
@@ -17,6 +17,7 @@
 package org.springframework.data.jdbc.core.convert;
 
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -27,6 +28,7 @@ import org.springframework.lang.Nullable;
  * The finding methods of a {@link DataAccessStrategy}.
  *
  * @author Jens Schauder
+ * @author Sergey Korotaev
  * @since 3.2
  */
 interface ReadingDataAccessStrategy {
@@ -52,6 +54,15 @@ interface ReadingDataAccessStrategy {
 	<T> Iterable<T> findAll(Class<T> domainType);
 
 	/**
+	 * Loads all entities of the given type to a {@link Stream}.
+	 *
+	 * @param domainType the type of entities to load. Must not be {@code null}.
+	 * @param <T> the type of entities to load.
+	 * @return Guaranteed to be not {@code null}.
+	 */
+	<T> Stream<T> streamAll(Class<T> domainType);
+
+	/**
 	 * Loads all entities that match one of the ids passed as an argument. It is not guaranteed that the number of ids
 	 * passed in matches the number of entities returned.
 	 *
@@ -63,6 +74,17 @@ interface ReadingDataAccessStrategy {
 	<T> Iterable<T> findAllById(Iterable<?> ids, Class<T> domainType);
 
 	/**
+	 * Loads all entities that match one of the ids passed as an argument to a {@link Stream}.
+	 * It is not guaranteed that the number of ids passed in matches the number of entities returned.
+	 *
+	 * @param ids the Ids of the entities to load. Must not be {@code null}.
+	 * @param domainType the type of entities to load. Must not be {@code null}.
+	 * @param <T> type of entities to load.
+	 * @return the loaded entities. Guaranteed to be not {@code null}.
+	 */
+	<T> Stream<T> streamAllByIds(Iterable<?> ids, Class<T> domainType);
+
+	/**
 	 * Loads all entities of the given type, sorted.
 	 *
 	 * @param domainType the type of entities to load. Must not be {@code null}.
@@ -72,6 +94,17 @@ interface ReadingDataAccessStrategy {
 	 * @since 2.0
 	 */
 	<T> Iterable<T> findAll(Class<T> domainType, Sort sort);
+
+	/**
+	 * Loads all entities of the given type to a {@link Stream}, sorted.
+	 *
+	 * @param domainType the type of entities to load. Must not be {@code null}.
+	 * @param <T> the type of entities to load.
+	 * @param sort the sorting information. Must not be {@code null}.
+	 * @return Guaranteed to be not {@code null}.
+	 * @since 2.0
+	 */
+	<T> Stream<T> streamAll(Class<T> domainType, Sort sort);
 
 	/**
 	 * Loads all entities of the given type, paged and sorted.
@@ -105,6 +138,17 @@ interface ReadingDataAccessStrategy {
 	 * @since 3.0
 	 */
 	<T> Iterable<T> findAll(Query query, Class<T> domainType);
+
+	/**
+	 * Execute a {@code SELECT} query and convert the resulting items to a {@link Stream}.
+	 *
+	 * @param query must not be {@literal null}.
+	 * @param domainType the type of entities. Must not be {@code null}.
+	 * @return a non-null list with all the matching results.
+	 * @throws org.springframework.dao.IncorrectResultSizeDataAccessException if more than one match found.
+	 * @since 3.0
+	 */
+	<T> Stream<T> streamAll(Query query, Class<T> domainType);
 
 	/**
 	 * Execute a {@code SELECT} query and convert the resulting items to a {@link Iterable}. Applies the {@link Pageable}

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SingleQueryDataAccessStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SingleQueryDataAccessStrategy.java
@@ -18,6 +18,7 @@ package org.springframework.data.jdbc.core.convert;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -32,6 +33,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
  *
  * @author Jens Schauder
  * @author Mark Paluch
+ * @author Sergey Korotaev
  * @since 3.2
  */
 class SingleQueryDataAccessStrategy implements ReadingDataAccessStrategy {
@@ -57,12 +59,27 @@ class SingleQueryDataAccessStrategy implements ReadingDataAccessStrategy {
 	}
 
 	@Override
+	public <T> Stream<T> streamAll(Class<T> domainType) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
 	public <T> List<T> findAllById(Iterable<?> ids, Class<T> domainType) {
 		return aggregateReader.findAllById(ids, getPersistentEntity(domainType));
 	}
 
 	@Override
+	public <T> Stream<T> streamAllByIds(Iterable<?> ids, Class<T> domainType) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
 	public <T> List<T> findAll(Class<T> domainType, Sort sort) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public <T> Stream<T> streamAll(Class<T> domainType, Sort sort) {
 		throw new UnsupportedOperationException();
 	}
 
@@ -79,6 +96,11 @@ class SingleQueryDataAccessStrategy implements ReadingDataAccessStrategy {
 	@Override
 	public <T> List<T> findAll(Query query, Class<T> domainType) {
 		return aggregateReader.findAll(query, getPersistentEntity(domainType));
+	}
+
+	@Override
+	public <T> Stream<T> streamAll(Query query, Class<T> domainType) {
+		throw new UnsupportedOperationException();
 	}
 
 	@Override


### PR DESCRIPTION
Hi, everyone! 
I wanted to contribute for you and started with this PR :)
I have added Stream support to JdbcAggregateOperations. These methods use other methods at the db level with the return value type stream (or cursor for MyBatis).
I also read that findAll** is a reserved naming convention, for the sake of similarity I added findAllStreamable or something like that.
Added tests for these methods.


Closes #1714
