### PR TITLE
Netty verison bump

### DIFF
--- a/spring-data-r2dbc/pom.xml
+++ b/spring-data-r2dbc/pom.xml
@@ -28,7 +28,7 @@
 		<degraph-check.version>0.1.4</degraph-check.version>
 		<r2dbc-spi.version>1.0.0.RELEASE</r2dbc-spi.version>
 		<reactive-streams.version>1.0.4</reactive-streams.version>
-		<netty>4.1.107.Final</netty>
+		<netty>4.1.118.Final</netty>
 	</properties>
 
 	<inceptionYear>2018</inceptionYear>


### PR DESCRIPTION
When working on #2000 PR, I realized that the build on `main` is failing due to incompatibility of R2DBC driver and `netty`:

```
java.lang.NoClassDefFoundError: io/netty/resolver/dns/DnsNameResolverChannelStrategy
	at reactor.netty.transport.NameResolverProvider$Build.<clinit>(NameResolverProvider.java:682)
	at reactor.netty.transport.NameResolverProvider.builder(NameResolverProvider.java:303)
	at reactor.netty.tcp.TcpResources.<clinit>(TcpResources.java:426)
	at org.mariadb.r2dbc.MariadbConnectionConfiguration.<init>(MariadbConnectionConfiguration.java:142)
	at org.mariadb.r2dbc.MariadbConnectionConfiguration.<init>(MariadbConnectionConfiguration.java:32)
	at org.mariadb.r2dbc.MariadbConnectionConfiguration$Builder.build(MariadbConnectionConfiguration.java:651)
	at org.springframework.data.r2dbc.dialect.DialectResolverUnitTests.shouldResolveDatabaseType(DialectResolverUnitTests.java:41)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
Caused by: java.lang.ClassNotFoundException: io.netty.resolver.dns.DnsNameResolverChannelStrategy
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:520)
```

I've bumped the patch `netty` version to include the missing class. The version that project-reactor `1.2.3` that we're btw are using [requires netty `4.1.118.Final`](https://github.com/reactor/reactor-netty/blob/main/build.gradle#L112)



CC: @mp911de @schauder 