### PR TITLE
GH-2020 Added SqlTypeResolver abstraction

### DIFF
--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DefaultJdbcTypeFactory.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DefaultJdbcTypeFactory.java
@@ -48,25 +48,6 @@ public class DefaultJdbcTypeFactory implements JdbcTypeFactory {
 	 * Creates a new {@link DefaultJdbcTypeFactory}.
 	 *
 	 * @param operations must not be {@literal null}.
-	 * @since 2.3
-	 * @deprecated use
-	 *             {@link #DefaultJdbcTypeFactory(JdbcOperations, org.springframework.data.jdbc.core.dialect.JdbcArrayColumns)}
-	 *             instead.
-	 */
-	@Deprecated(forRemoval = true, since = "3.5")
-	public DefaultJdbcTypeFactory(JdbcOperations operations, JdbcArrayColumns arrayColumns) {
-
-		Assert.notNull(operations, "JdbcOperations must not be null");
-		Assert.notNull(arrayColumns, "JdbcArrayColumns must not be null");
-
-		this.operations = operations;
-		this.arrayColumns = arrayColumns;
-	}
-
-	/**
-	 * Creates a new {@link DefaultJdbcTypeFactory}.
-	 *
-	 * @param operations must not be {@literal null}.
 	 * @since 3.5
 	 */
 	public DefaultJdbcTypeFactory(JdbcOperations operations,

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DelegatingDataAccessStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DelegatingDataAccessStrategy.java
@@ -45,6 +45,10 @@ public class DelegatingDataAccessStrategy implements DataAccessStrategy {
 
 	private DataAccessStrategy delegate;
 
+	/**
+	 * @deprecated please, use {@link DelegatingDataAccessStrategy#DelegatingDataAccessStrategy(DataAccessStrategy)} instead
+	 */
+	@Deprecated(forRemoval = true, since = "4.0")
 	public DelegatingDataAccessStrategy() {}
 
 	public DelegatingDataAccessStrategy(DataAccessStrategy delegate) {

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/dialect/DefaultSqlTypeResolver.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/dialect/DefaultSqlTypeResolver.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.jdbc.core.dialect;
+
+import java.sql.SQLType;
+
+import org.springframework.data.relational.repository.query.RelationalParameters;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * Default implementation of {@link SqlTypeResolver}. Capable to resolve the {@link SqlType} annotation
+ * on the {@link java.lang.annotation.ElementType#PARAMETER method parameters}, like this:
+ * <p>
+ * <pre class="code">
+ * List<User> findByAge(&#64;SqlType(name = "TINYINT", vendorTypeNumber = Types.TINYINT) byte age);
+ * </pre>
+ *
+ * Qualification of the actual {@link SQLType} (the sql type of the component), then the following needs to be done:
+ * <pre class="code">
+ * List<User> findByAgeIn(&#64;SqlType(name = "TINYINT", vendorTypeNumber = Types.TINYINT) Integer[] age);
+ * </pre>
+ *
+ * @author Mikhail Polivakha
+ */
+public class DefaultSqlTypeResolver implements SqlTypeResolver {
+
+	public static DefaultSqlTypeResolver INSTANCE = new DefaultSqlTypeResolver();
+
+	@Override
+	@Nullable
+	public SQLType resolveSqlType(RelationalParameters.RelationalParameter relationalParameter) {
+		return resolveInternally(relationalParameter);
+	}
+
+	@Override
+	@Nullable
+	public SQLType resolveActualSqlType(RelationalParameters.RelationalParameter relationalParameter) {
+		return resolveInternally(relationalParameter);
+	}
+
+	private static AnnotationBasedSqlType resolveInternally(
+			RelationalParameters.RelationalParameter relationalParameter) {
+		SqlType parameterAnnotation = relationalParameter.getMethodParameter().getParameterAnnotation(SqlType.class);
+
+		if (parameterAnnotation != null) {
+			return new AnnotationBasedSqlType(parameterAnnotation);
+		} else {
+			return null;
+		}
+	}
+
+	/**
+	 * {@link SQLType} determined from the {@link SqlType} annotation.
+	 *
+	 * @author Mikhail Polivakha
+	 */
+	protected static class AnnotationBasedSqlType implements SQLType {
+
+		private final SqlType sqlType;
+
+		public AnnotationBasedSqlType(SqlType sqlType) {
+			Assert.notNull(sqlType, "sqlType must not be null");
+
+			this.sqlType = sqlType;
+		}
+
+		@Override
+		public String getName() {
+			return sqlType.name();
+		}
+
+		@Override
+		public String getVendor() {
+			return "Spring Data JDBC";
+		}
+
+		@Override
+		public Integer getVendorTypeNumber() {
+			return sqlType.vendorTypeNumber();
+		}
+	}
+}

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/dialect/JdbcDialect.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/dialect/JdbcDialect.java
@@ -16,6 +16,8 @@
 package org.springframework.data.jdbc.core.dialect;
 
 import org.springframework.data.relational.core.dialect.Dialect;
+import org.springframework.data.jdbc.core.dialect.SqlTypeResolver;
+import org.springframework.data.jdbc.core.dialect.DefaultSqlTypeResolver;
 
 /**
  * {@link org.springframework.data.relational.core.dialect.ArrayColumns} that offer JDBC specific functionality.
@@ -37,4 +39,12 @@ public interface JdbcDialect extends Dialect {
 		return JdbcArrayColumns.Unsupported.INSTANCE;
 	}
 
+	/**
+	 * Returns a {@link SqlTypeResolver} of this dialect.
+	 *
+	 * @since 4.0
+	 */
+	default SqlTypeResolver getSqlTypeResolver() {
+		return DefaultSqlTypeResolver.INSTANCE;
+	}
 }

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/dialect/SqlType.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/dialect/SqlType.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.jdbc.core.dialect;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.sql.SQLType;
+
+/**
+ * Serves as a hint to the {@link DefaultSqlTypeResolver}, that signals the {@link java.sql.SQLType} to be used.
+ * The arguments of this annotation are identical to the methods on {@link java.sql.SQLType} interface, expect for
+ * the {@link SQLType#getVendor()}, which is absent, because it typically does not matter as such for the underlying
+ * JDBC drivers. The examples of usage, can be found in javadoc of {@link DefaultSqlTypeResolver}.
+ *
+ * @see DefaultSqlTypeResolver
+ * @author Mikhail Polivakha
+ */
+@Documented
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SqlType {
+
+	/**
+	 * Returns the {@code SQLType} name that represents a SQL data type.
+	 *
+	 * @return The name of this {@code SQLType}.
+	 */
+	String name();
+
+	/**
+	 * Returns the vendor specific type number for the data type.
+	 *
+	 * @return An Integer representing the vendor specific data type
+	 */
+	int vendorTypeNumber();
+}

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/dialect/SqlTypeResolver.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/dialect/SqlTypeResolver.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.jdbc.core.dialect;
+
+import java.sql.SQLType;
+
+import org.springframework.data.relational.repository.query.RelationalParameters.RelationalParameter;
+import org.springframework.data.util.TypeInformation;
+import org.springframework.lang.Nullable;
+
+/**
+ * Common interface for all objects capable to resolve the {@link SQLType} to be used for a give method parameter.
+ *
+ * @author Mikhail Polivakha
+ */
+public interface SqlTypeResolver {
+
+	/**
+	 * Resolving the {@link SQLType} from the given {@link RelationalParameter}.
+	 *
+	 * @param relationalParameter the parameter of the query method
+	 * @return {@code null} in case the given {@link SqlTypeResolver} cannot or do not want to determine the
+	 * 				 {@link SQLType} of the given parameter
+	 */
+	@Nullable
+	SQLType resolveSqlType(RelationalParameter relationalParameter);
+
+	/**
+	 * Resolving the {@link SQLType} from the given {@link RelationalParameter}. The definition of "actual"
+	 * type can be looked up in the {@link TypeInformation#getActualType()}.
+	 *
+	 * @param relationalParameter the parameter of the query method
+	 * @return {@code null} in case the given {@link SqlTypeResolver} cannot or do not want to determine the
+	 * 	  		 actual {@link SQLType} of the given parameter
+	 */
+	@Nullable
+	SQLType resolveActualSqlType(RelationalParameter relationalParameter);
+}

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/JdbcQueryMethod.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/JdbcQueryMethod.java
@@ -24,6 +24,8 @@ import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.projection.ProjectionFactory;
+import org.springframework.data.jdbc.core.dialect.DefaultSqlTypeResolver;
+import org.springframework.data.jdbc.core.dialect.SqlTypeResolver;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
 import org.springframework.data.relational.repository.Lock;
@@ -34,6 +36,7 @@ import org.springframework.data.repository.core.RepositoryMetadata;
 import org.springframework.data.repository.query.Parameters;
 import org.springframework.data.repository.query.ParametersSource;
 import org.springframework.data.repository.query.QueryMethod;
+import org.springframework.data.util.Lazy;
 import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.lang.Nullable;
@@ -53,6 +56,7 @@ import org.springframework.util.StringUtils;
  * @author Diego Krupitza
  * @author Mark Paluch
  * @author Daeho Kwon
+ * @author Mikhail Polivakha
  */
 public class JdbcQueryMethod extends QueryMethod {
 
@@ -67,8 +71,15 @@ public class JdbcQueryMethod extends QueryMethod {
 	public JdbcQueryMethod(Method method, RepositoryMetadata metadata, ProjectionFactory factory,
 			NamedQueries namedQueries,
 			MappingContext<? extends RelationalPersistentEntity<?>, ? extends RelationalPersistentProperty> mappingContext) {
+		this(method, metadata, factory, namedQueries, mappingContext, DefaultSqlTypeResolver.INSTANCE);
+	}
 
-		super(method, metadata, factory, JdbcParameters::new);
+	public JdbcQueryMethod(Method method, RepositoryMetadata metadata, ProjectionFactory factory,
+			NamedQueries namedQueries,
+			MappingContext<? extends RelationalPersistentEntity<?>, ? extends RelationalPersistentProperty> mappingContext,
+			SqlTypeResolver sqlTypeResolver) {
+
+		super(method, metadata, factory, parametersSource -> new JdbcParameters(parametersSource, sqlTypeResolver));
 		this.namedQueries = namedQueries;
 		this.method = method;
 		this.mappingContext = mappingContext;

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/StringBasedJdbcQuery.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/StringBasedJdbcQuery.java
@@ -86,13 +86,13 @@ public class StringBasedJdbcQuery extends AbstractJdbcQuery {
 
 	/**
 	 * Creates a new {@link StringBasedJdbcQuery} for the given {@link JdbcQueryMethod}, {@link RelationalMappingContext}
-	 * and {@link org.springframework.data.jdbc.repository.query.RowMapperFactory}.
+	 * and {@link RowMapperFactory}.
 	 *
-	 * @param queryMethod must not be {@literal null}.
-	 * @param operations must not be {@literal null}.
+	 * @param queryMethod      must not be {@literal null}.
+	 * @param operations       must not be {@literal null}.
 	 * @param rowMapperFactory must not be {@literal null}.
-	 * @param converter must not be {@literal null}.
-	 * @param delegate must not be {@literal null}.
+	 * @param converter        must not be {@literal null}.
+	 * @param delegate         must not be {@literal null}.
 	 * @since 3.4
 	 */
 	public StringBasedJdbcQuery(JdbcQueryMethod queryMethod, NamedParameterJdbcOperations operations,
@@ -105,12 +105,12 @@ public class StringBasedJdbcQuery extends AbstractJdbcQuery {
 	 * Creates a new {@link StringBasedJdbcQuery} for the given {@link JdbcQueryMethod}, {@link RelationalMappingContext}
 	 * and {@link org.springframework.data.jdbc.repository.query.RowMapperFactory}.
 	 *
-	 * @param query must not be {@literal null} or empty.
-	 * @param queryMethod must not be {@literal null}.
-	 * @param operations must not be {@literal null}.
+	 * @param query            must not be {@literal null} or empty.
+	 * @param queryMethod      must not be {@literal null}.
+	 * @param operations       must not be {@literal null}.
 	 * @param rowMapperFactory must not be {@literal null}.
-	 * @param converter must not be {@literal null}.
-	 * @param delegate must not be {@literal null}.
+	 * @param converter        must not be {@literal null}.
+	 * @param delegate         must not be {@literal null}.
 	 * @since 3.4
 	 */
 	public StringBasedJdbcQuery(String query, JdbcQueryMethod queryMethod, NamedParameterJdbcOperations operations,
@@ -378,7 +378,8 @@ public class StringBasedJdbcQuery extends AbstractJdbcQuery {
 	}
 
 	@Deprecated(since = "3.4")
-	public void setBeanFactory(BeanFactory beanFactory) {}
+	public void setBeanFactory(BeanFactory beanFactory) {
+	}
 
 	class CachedRowMapperFactory {
 
@@ -437,19 +438,20 @@ public class StringBasedJdbcQuery extends AbstractJdbcQuery {
 			String resultSetExtractorRef = getQueryMethod().getResultSetExtractorRef();
 			Class<? extends ResultSetExtractor> resultSetExtractorClass = getQueryMethod().getResultSetExtractorClass();
 
-			if (!ObjectUtils.isEmpty(resultSetExtractorRef)
-					&& !isUnconfigured(resultSetExtractorClass, ResultSetExtractor.class)) {
+			if (!ObjectUtils.isEmpty(resultSetExtractorRef) && !isUnconfigured(resultSetExtractorClass,
+					ResultSetExtractor.class)) {
 				throw new IllegalArgumentException(
 						"Invalid ResultSetExtractor configuration. Configure either one but not both via @Query(resultSetExtractorRef = …, resultSetExtractorClass = …) for query method "
 								+ getQueryMethod());
 			}
 
-			this.configuredResultSetExtractor = !ObjectUtils.isEmpty(resultSetExtractorRef)
-					|| !isUnconfigured(resultSetExtractorClass, ResultSetExtractor.class);
+			this.configuredResultSetExtractor =
+					!ObjectUtils.isEmpty(resultSetExtractorRef) || !isUnconfigured(resultSetExtractorClass,
+							ResultSetExtractor.class);
 
-			this.rowMapperConstructor = resultSetExtractorClass != null
-					? ClassUtils.getConstructorIfAvailable(resultSetExtractorClass, RowMapper.class)
-					: null;
+			this.rowMapperConstructor = resultSetExtractorClass != null ?
+					ClassUtils.getConstructorIfAvailable(resultSetExtractorClass, RowMapper.class) :
+					null;
 			this.constructor = resultSetExtractorClass != null ? findPrimaryConstructor(resultSetExtractorClass) : null;
 			this.resultSetExtractorFactory = rowMapper -> {
 

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/support/JdbcRepositoryFactory.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/support/JdbcRepositoryFactory.java
@@ -23,6 +23,7 @@ import org.springframework.data.jdbc.core.JdbcAggregateTemplate;
 import org.springframework.data.jdbc.core.convert.DataAccessStrategy;
 import org.springframework.data.jdbc.core.convert.JdbcConverter;
 import org.springframework.data.jdbc.core.convert.QueryMappingConfiguration;
+import org.springframework.data.jdbc.core.dialect.JdbcDialect;
 import org.springframework.data.mapping.callback.EntityCallbacks;
 import org.springframework.data.relational.core.dialect.Dialect;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
@@ -58,7 +59,7 @@ public class JdbcRepositoryFactory extends RepositoryFactorySupport {
 	private final ApplicationEventPublisher publisher;
 	private final DataAccessStrategy accessStrategy;
 	private final NamedParameterJdbcOperations operations;
-	private final Dialect dialect;
+	private final JdbcDialect dialect;
 	private @Nullable BeanFactory beanFactory;
 
 	private QueryMappingConfiguration queryMappingConfiguration = QueryMappingConfiguration.EMPTY;
@@ -75,8 +76,39 @@ public class JdbcRepositoryFactory extends RepositoryFactorySupport {
 	 * @param publisher must not be {@literal null}.
 	 * @param operations must not be {@literal null}.
 	 */
+	@Deprecated(forRemoval = true, since = "4.0")
 	public JdbcRepositoryFactory(DataAccessStrategy dataAccessStrategy, RelationalMappingContext context,
 			JdbcConverter converter, Dialect dialect, ApplicationEventPublisher publisher,
+			NamedParameterJdbcOperations operations) {
+
+		Assert.notNull(dataAccessStrategy, "DataAccessStrategy must not be null");
+		Assert.notNull(context, "RelationalMappingContext must not be null");
+		Assert.notNull(converter, "RelationalConverter must not be null");
+		Assert.notNull(dialect, "Dialect must not be null");
+		Assert.notNull(publisher, "ApplicationEventPublisher must not be null");
+		Assert.state(dialect instanceof JdbcDialect, "Dialect must be an instance of the JdbcDialect");
+
+		this.publisher = publisher;
+		this.context = context;
+		this.converter = converter;
+		this.dialect = (JdbcDialect) dialect;
+		this.accessStrategy = dataAccessStrategy;
+		this.operations = operations;
+	}
+
+	/**
+	 * Creates a new {@link JdbcRepositoryFactory} for the given {@link DataAccessStrategy},
+	 * {@link RelationalMappingContext} and {@link ApplicationEventPublisher}.
+	 *
+	 * @param dataAccessStrategy must not be {@literal null}.
+	 * @param context must not be {@literal null}.
+	 * @param converter must not be {@literal null}.
+	 * @param dialect must not be {@literal null}.
+	 * @param publisher must not be {@literal null}.
+	 * @param operations must not be {@literal null}.
+	 */
+	public JdbcRepositoryFactory(DataAccessStrategy dataAccessStrategy, RelationalMappingContext context,
+			JdbcConverter converter, JdbcDialect dialect, ApplicationEventPublisher publisher,
 			NamedParameterJdbcOperations operations) {
 
 		Assert.notNull(dataAccessStrategy, "DataAccessStrategy must not be null");

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/support/JdbcRepositoryFactoryBean.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/support/JdbcRepositoryFactoryBean.java
@@ -20,6 +20,7 @@ import java.io.Serializable;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.FactoryBean;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.data.jdbc.core.convert.DataAccessStrategy;
@@ -29,6 +30,7 @@ import org.springframework.data.jdbc.core.convert.JdbcConverter;
 import org.springframework.data.jdbc.core.convert.QueryMappingConfiguration;
 import org.springframework.data.jdbc.core.convert.SqlGeneratorSource;
 import org.springframework.data.jdbc.core.convert.SqlParametersFactory;
+import org.springframework.data.jdbc.core.dialect.JdbcDialect;
 import org.springframework.data.mapping.callback.EntityCallbacks;
 import org.springframework.data.relational.core.dialect.Dialect;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
@@ -39,7 +41,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
 import org.springframework.util.Assert;
 
 /**
- * Special adapter for Springs {@link org.springframework.beans.factory.FactoryBean} interface to allow easy setup of
+ * Special adapter for Springs {@link FactoryBean} interface to allow easy setup of
  * repository factories via Spring configuration.
  * <p>
  * A partially populated factory bean can use {@link BeanFactory} to resolve missing dependencies, specifically:
@@ -76,7 +78,7 @@ public class JdbcRepositoryFactoryBean<T extends Repository<S, ID>, S, ID extend
 	private @Nullable QueryMappingConfiguration queryMappingConfiguration;
 	private @Nullable NamedParameterJdbcOperations operations;
 	private EntityCallbacks entityCallbacks = EntityCallbacks.create();
-	private @Nullable Dialect dialect;
+	private @Nullable JdbcDialect dialect;
 
 	/**
 	 * Creates a new {@link JdbcRepositoryFactoryBean} for the given repository interface.
@@ -126,7 +128,19 @@ public class JdbcRepositoryFactoryBean<T extends Repository<S, ID>, S, ID extend
 		this.mappingContext = mappingContext;
 	}
 
+	/**
+	 * @deprecated please, use {@link #setDialect(JdbcDialect)} instead.
+	 */
+	@Deprecated(forRemoval = true, since = "4.0")
 	public void setDialect(Dialect dialect) {
+
+		Assert.notNull(dialect, "Dialect must not be null");
+		Assert.state(dialect instanceof JdbcDialect, "Dialect must be an instance of the JdbcDialect");
+
+		this.setDialect(((JdbcDialect) dialect));
+	}
+
+	public void setDialect(JdbcDialect dialect) {
 
 		Assert.notNull(dialect, "Dialect must not be null");
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/DeclaredQueryRepositoryUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/DeclaredQueryRepositoryUnitTests.java
@@ -31,6 +31,7 @@ import org.springframework.data.jdbc.core.convert.DelegatingDataAccessStrategy;
 import org.springframework.data.jdbc.core.convert.JdbcConverter;
 import org.springframework.data.jdbc.core.convert.JdbcCustomConversions;
 import org.springframework.data.jdbc.core.convert.MappingJdbcConverter;
+import org.springframework.data.jdbc.core.dialect.JdbcDialect;
 import org.springframework.data.jdbc.core.dialect.JdbcHsqlDbDialect;
 import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
 import org.springframework.data.jdbc.repository.query.Query;
@@ -94,15 +95,15 @@ public class DeclaredQueryRepositoryUnitTests {
 
 	private @NotNull <T extends CrudRepository> T repository(Class<T> repositoryInterface) {
 
-		Dialect dialect = JdbcHsqlDbDialect.INSTANCE;
+		JdbcDialect dialect = JdbcHsqlDbDialect.INSTANCE;
 
 		RelationalMappingContext context = JdbcMappingContext.forQuotedIdentifiers();
+		DataAccessStrategy dataAccessStrategy = mock(DataAccessStrategy.class);
 
-		DelegatingDataAccessStrategy delegatingDataAccessStrategy = new DelegatingDataAccessStrategy();
+		DelegatingDataAccessStrategy delegatingDataAccessStrategy = new DelegatingDataAccessStrategy(dataAccessStrategy);
 		JdbcConverter converter = new MappingJdbcConverter(context, delegatingDataAccessStrategy,
 				new JdbcCustomConversions(), new DefaultJdbcTypeFactory(operations.getJdbcOperations()));
 
-		DataAccessStrategy dataAccessStrategy = mock(DataAccessStrategy.class);
 		ApplicationEventPublisher publisher = mock(ApplicationEventPublisher.class);
 
 		JdbcRepositoryFactory factory = new JdbcRepositoryFactory(dataAccessStrategy, context, converter, dialect,

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/SimpleJdbcRepositoryEventsUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/SimpleJdbcRepositoryEventsUnitTests.java
@@ -15,11 +15,16 @@
  */
 package org.springframework.data.jdbc.repository;
 
-import static java.util.Arrays.*;
-import static org.assertj.core.api.Assertions.*;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -33,7 +38,16 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.jdbc.core.convert.*;
+import org.springframework.data.jdbc.core.convert.DefaultDataAccessStrategy;
+import org.springframework.data.jdbc.core.convert.DefaultJdbcTypeFactory;
+import org.springframework.data.jdbc.core.convert.DelegatingDataAccessStrategy;
+import org.springframework.data.jdbc.core.convert.InsertStrategyFactory;
+import org.springframework.data.jdbc.core.convert.JdbcConverter;
+import org.springframework.data.jdbc.core.convert.JdbcCustomConversions;
+import org.springframework.data.jdbc.core.convert.MappingJdbcConverter;
+import org.springframework.data.jdbc.core.convert.QueryMappingConfiguration;
+import org.springframework.data.jdbc.core.convert.SqlGeneratorSource;
+import org.springframework.data.jdbc.core.convert.SqlParametersFactory;
 import org.springframework.data.jdbc.core.dialect.JdbcH2Dialect;
 import org.springframework.data.jdbc.core.dialect.JdbcHsqlDbDialect;
 import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/support/JdbcRepositoryFactoryBeanUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/support/JdbcRepositoryFactoryBeanUnitTests.java
@@ -38,6 +38,7 @@ import org.springframework.data.jdbc.core.convert.DataAccessStrategy;
 import org.springframework.data.jdbc.core.convert.DefaultDataAccessStrategy;
 import org.springframework.data.jdbc.core.convert.MappingJdbcConverter;
 import org.springframework.data.jdbc.core.convert.QueryMappingConfiguration;
+import org.springframework.data.jdbc.core.dialect.JdbcDialect;
 import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
 import org.springframework.data.relational.core.dialect.Dialect;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
@@ -64,7 +65,7 @@ class JdbcRepositoryFactoryBeanUnitTests {
 	@Mock DataAccessStrategy dataAccessStrategy;
 	@Mock ApplicationEventPublisher publisher;
 	@Mock(answer = Answers.RETURNS_DEEP_STUBS) ListableBeanFactory beanFactory;
-	@Mock Dialect dialect;
+	@Mock JdbcDialect dialect;
 
 	private RelationalMappingContext mappingContext;
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/TestConfiguration.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/TestConfiguration.java
@@ -35,12 +35,23 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.convert.CustomConversions;
-import org.springframework.data.jdbc.core.convert.*;
+import org.springframework.data.jdbc.core.convert.DataAccessStrategy;
+import org.springframework.data.jdbc.core.convert.DataAccessStrategyFactory;
+import org.springframework.data.jdbc.core.convert.DefaultJdbcTypeFactory;
+import org.springframework.data.jdbc.core.convert.IdGeneratingEntityCallback;
+import org.springframework.data.jdbc.core.convert.InsertStrategyFactory;
+import org.springframework.data.jdbc.core.convert.JdbcConverter;
+import org.springframework.data.jdbc.core.convert.JdbcCustomConversions;
+import org.springframework.data.jdbc.core.convert.MappingJdbcConverter;
+import org.springframework.data.jdbc.core.convert.QueryMappingConfiguration;
+import org.springframework.data.jdbc.core.convert.RelationResolver;
+import org.springframework.data.jdbc.core.convert.SqlGeneratorSource;
+import org.springframework.data.jdbc.core.convert.SqlParametersFactory;
+import org.springframework.data.jdbc.core.dialect.DialectResolver;
 import org.springframework.data.jdbc.core.dialect.JdbcArrayColumns;
 import org.springframework.data.jdbc.core.dialect.JdbcDialect;
 import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
 import org.springframework.data.jdbc.core.mapping.JdbcSimpleTypes;
-import org.springframework.data.jdbc.repository.config.DialectResolver;
 import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
 import org.springframework.data.mapping.callback.EntityCallback;
 import org.springframework.data.mapping.callback.EntityCallbacks;
@@ -85,7 +96,7 @@ public class TestConfiguration {
 	@Bean
 	JdbcRepositoryFactory jdbcRepositoryFactory(
 			@Qualifier("defaultDataAccessStrategy") DataAccessStrategy dataAccessStrategy, RelationalMappingContext context,
-			Dialect dialect, JdbcConverter converter, Optional<List<NamedQueries>> namedQueries,
+			JdbcDialect dialect, JdbcConverter converter, Optional<List<NamedQueries>> namedQueries,
 			List<EntityCallback<?>> callbacks, List<EvaluationContextExtension> evaulationContextExtensions) {
 
 		JdbcRepositoryFactory factory = new JdbcRepositoryFactory(dataAccessStrategy, context, converter, dialect,
@@ -190,7 +201,7 @@ public class TestConfiguration {
 	}
 
 	@Bean
-	Dialect jdbcDialect(NamedParameterJdbcOperations operations) {
+	JdbcDialect jdbcDialect(NamedParameterJdbcOperations operations) {
 		return DialectResolver.getDialect(operations.getJdbcOperations());
 	}
 

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/repository/query/RelationalParameters.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/repository/query/RelationalParameters.java
@@ -66,6 +66,7 @@ public class RelationalParameters extends Parameters<RelationalParameters, Relat
 	public static class RelationalParameter extends Parameter {
 
 		private final TypeInformation<?> typeInformation;
+		private final MethodParameter methodParameter;
 
 		/**
 		 * Creates a new {@link RelationalParameter}.
@@ -75,7 +76,7 @@ public class RelationalParameters extends Parameters<RelationalParameters, Relat
 		protected RelationalParameter(MethodParameter parameter, TypeInformation<?> domainType) {
 			super(parameter, domainType);
 			this.typeInformation = TypeInformation.fromMethodParameter(parameter);
-
+			this.methodParameter = parameter;
 		}
 
 		public ResolvableType getResolvableType() {
@@ -84,6 +85,10 @@ public class RelationalParameters extends Parameters<RelationalParameters, Relat
 
 		public TypeInformation<?> getTypeInformation() {
 			return typeInformation;
+		}
+
+		public MethodParameter getMethodParameter() {
+			return methodParameter;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #2020 

I've introduced the `SqlTypeResolver` interface, and a default implementation of it - `DefaultSqlTypeResolver`. 

Backward compatibility: I've removed the `@Deprecated` constructors. Apart from that, it seems that we're backward compatible, if I have not overlooked anything. 

Note: I had to wrap the `SqlTypeResolver` with `Lazy` here. The reason is described in the ad-hoc comment and [in this issue](https://github.com/spring-projects/spring-data-commons/issues/3263).

CC: @mp911de @schauder 