### PR TITLE
Fix performance bug with large number of unnamed parameters

### DIFF
--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/QueryMapper.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/QueryMapper.java
@@ -53,6 +53,7 @@ import org.springframework.util.ClassUtils;
  * @author Mark Paluch
  * @author Jens Schauder
  * @author Yan Qiang
+ * @author Mikhail Fedorov
  * @since 3.0
  */
 public class QueryMapper {

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/QueryMapper.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/QueryMapper.java
@@ -638,6 +638,7 @@ public class QueryMapper {
 		do {
 			uniqueName = name + (counter++);
 		} while (values.containsKey(uniqueName));
+
 		return uniqueName;
 	}
 

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/QueryMapper.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/QueryMapper.java
@@ -625,16 +625,19 @@ public class QueryMapper {
 	}
 
 	private static String getUniqueName(MapSqlParameterSource parameterSource, String name) {
-		Map<String, Object> parameters = parameterSource.getValues();
-		Object existingName = parameters.get(name);
-		if (existingName == null) {
+
+		Map<String, Object> values = parameterSource.getValues();
+
+		if (!values.containsKey(name)) {
 			return name;
 		}
-		int counter = parameters.size();
+
+		int counter = values.size();
 		String uniqueName;
+
 		do {
 			uniqueName = name + (counter++);
-		} while (parameters.containsKey(uniqueName));
+		} while (values.containsKey(uniqueName));
 		return uniqueName;
 	}
 

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/QueryMapper.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/QueryMapper.java
@@ -625,20 +625,16 @@ public class QueryMapper {
 	}
 
 	private static String getUniqueName(MapSqlParameterSource parameterSource, String name) {
-
-		Map<String, Object> values = parameterSource.getValues();
-
-		if (!values.containsKey(name)) {
+		Map<String, Object> parameters = parameterSource.getValues();
+		Object existingName = parameters.get(name);
+		if (existingName == null) {
 			return name;
 		}
-
-		int counter = 1;
+		int counter = parameters.size();
 		String uniqueName;
-
 		do {
 			uniqueName = name + (counter++);
-		} while (values.containsKey(uniqueName));
-
+		} while (parameters.containsKey(uniqueName));
 		return uniqueName;
 	}
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/QueryMapperUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/QueryMapperUnitTests.java
@@ -46,6 +46,7 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
  *
  * @author Mark Paluch
  * @author Jens Schauder
+ * @author Mikhail Fedorov
  */
 public class QueryMapperUnitTests {
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/QueryMapperUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/QueryMapperUnitTests.java
@@ -121,7 +121,7 @@ public class QueryMapperUnitTests {
 		Condition condition = map(criteria);
 
 		assertThat(condition).hasToString(
-				"(person.\"NAME\" = ?[:name]) AND (person.\"NAME\" = ?[:name1] OR person.age < ?[:age] OR (person.\"NAME\" != ?[:name2] AND person.age > ?[:age1]))");
+				"(person.\"NAME\" = ?[:name]) AND (person.\"NAME\" = ?[:name1] OR person.age < ?[:age] OR (person.\"NAME\" != ?[:name3] AND person.age > ?[:age4]))");
 	}
 
 	@Test // DATAJDBC-318


### PR DESCRIPTION
**Preamble:**
Consider the following sql script: `select some from table where id in (:args)`
Where args is a 10k items list
It does not look good, but people do it anyways, or maybe just when the system scales up, and it slowly grows from 100 items to 10k items

**The problem**
In such conditions QueryMapper.getUniqueName needs to figure out the names for each of the elements in the `in (:a1,:a2,:a3, :a10000)` list, it does so by generating a name by counter and tries to lookup the name in the parameters hashmap
But if the argument list is so large it traverses the map over and over again
Ultimately it results in O(N^2) complexity (where operation behind is a hashmap lookup)
The symptom is a very high CPU consumption, and it is really slow

**The fix**
The suggested fix is just to skip most of the counter-hashmap traversal, just make the counter go forward
We still need the loop to guarantee generated names are unique

**More on the problem**
While 10k case is just very obvious to see and detect but also
My guess that likely a lot of code out there, having 50+ of arguments invisibly suffer and the fix should probably help them too

I'm sorry about no tests, the problem here that the nature of the bug is whether it works slow, I'm not sure if there are any load tests or something for this repo
