### PR TITLE
Use JDBCType.NULL for null if possible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-relational-parent</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.0.0-1935-jdbc-sql-type-for-null-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Relational Parent</name>

--- a/spring-data-jdbc-distribution/pom.xml
+++ b/spring-data-jdbc-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.0.0-1935-jdbc-sql-type-for-null-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-jdbc</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.0.0-1935-jdbc-sql-type-for-null-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.0.0-1935-jdbc-sql-type-for-null-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlParametersFactory.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlParametersFactory.java
@@ -189,9 +189,7 @@ public class SqlParametersFactory {
 	private void addConvertedValue(SqlIdentifierParameterSource parameterSource, @Nullable Object value,
 			SqlIdentifier paramName, Class<?> javaType, SQLType sqlType) {
 
-		JdbcValue jdbcValue = value != null
-				? converter.writeJdbcValue(value, javaType, sqlType)
-				: JdbcValue.of(null, JDBCType.NULL);
+		JdbcValue jdbcValue = converter.writeJdbcValue(value, javaType, sqlType);
 
 		parameterSource.addValue( //
 				paramName, //

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlParametersFactory.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlParametersFactory.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.jdbc.core.convert;
 
+import java.sql.JDBCType;
 import java.sql.SQLType;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,6 +42,7 @@ import org.springframework.util.Assert;
  * @author Jens Schauder
  * @author Chirag Tailor
  * @author Mikhail Polivakha
+ * @author Sergey Korotaev
  * @since 2.4
  */
 public class SqlParametersFactory {
@@ -187,11 +189,9 @@ public class SqlParametersFactory {
 	private void addConvertedValue(SqlIdentifierParameterSource parameterSource, @Nullable Object value,
 			SqlIdentifier paramName, Class<?> javaType, SQLType sqlType) {
 
-		JdbcValue jdbcValue = converter.writeJdbcValue( //
-				value, //
-				javaType, //
-				sqlType //
-		);
+		JdbcValue jdbcValue = value != null
+				? converter.writeJdbcValue(value, javaType, sqlType)
+				: JdbcValue.of(null, JDBCType.NULL);
 
 		parameterSource.addValue( //
 				paramName, //

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/dialect/JdbcDb2Dialect.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/dialect/JdbcDb2Dialect.java
@@ -66,4 +66,14 @@ public class JdbcDb2Dialect extends Db2Dialect implements JdbcDialect {
 			return Timestamp.from(source.toInstant());
 		}
 	}
+
+	/**
+	 * DB2 does not support {@link java.sql.JDBCType#NULL}. Therefore it uses {@link NullTypeStrategy#NOOP}.
+	 *
+	 * @since 4.0
+	 */
+	@Override
+	public NullTypeStrategy getNullTypeStrategy() {
+		return NullTypeStrategy.NOOP;
+	}
 }

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/dialect/JdbcDialect.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/dialect/JdbcDialect.java
@@ -37,4 +37,15 @@ public interface JdbcDialect extends Dialect {
 		return JdbcArrayColumns.Unsupported.INSTANCE;
 	}
 
+	/**
+	 * Determines how to handle the  {@link java.sql.JDBCType} of {@literal null} values.
+	 *
+	 * The default is suitable for all databases supporting {@link java.sql.JDBCType#NULL}.
+	 *
+	 * @return a strategy to handle the {@link java.sql.JDBCType} of {@literal null} values. Guaranteed not to be null.
+	 * @since 4.0
+	 */
+	default NullTypeStrategy getNullTypeStrategy() {
+		return NullTypeStrategy.DEFAULT;
+	}
 }

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/dialect/JdbcSqlServerDialect.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/dialect/JdbcSqlServerDialect.java
@@ -70,4 +70,14 @@ public class JdbcSqlServerDialect extends SqlServerDialect implements JdbcDialec
 		}
 	}
 
+
+	/**
+	 * SQL Server does not support {@link java.sql.JDBCType#NULL}. Therefore it uses {@link NullTypeStrategy#NOOP}.
+	 *
+	 * @since 4.0
+	 */
+	@Override
+	public NullTypeStrategy getNullTypeStrategy() {
+		return NullTypeStrategy.NOOP;
+	}
 }

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/dialect/NullTypeStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/dialect/NullTypeStrategy.java
@@ -1,0 +1,33 @@
+package org.springframework.data.jdbc.core.dialect;
+
+import java.sql.JDBCType;
+import java.sql.SQLType;
+
+/**
+ * Interface for defining what to {@link SQLType} to use for {@literal null} values.
+ * 
+ * @author Jens Schauder
+ * @since 4.0
+ */
+public interface NullTypeStrategy {
+
+	/**
+	 * Implementation that always uses {@link JDBCType#NULL}. Suitable for all databases that actually support this
+	 * {@link JDBCType}.
+	 */
+	NullTypeStrategy DEFAULT = sqlType -> JDBCType.NULL;
+
+	/**
+	 * Implementation that uses what ever type was past in as an argument. Suitable for databases that do not support
+	 * {@link JDBCType#NULL}.
+	 */
+	NullTypeStrategy NOOP = sqlType -> sqlType;
+
+	/**
+	 * {@link SQLType} to use for {@literal null} values.
+	 * 
+	 * @param sqlType a fallback value that is considered suitable by the caller.
+	 * @return Guaranteed not to be {@literal null}.
+	 */
+	SQLType getNullType(SQLType sqlType);
+}

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/config/AbstractJdbcConfiguration.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/config/AbstractJdbcConfiguration.java
@@ -147,14 +147,12 @@ public class AbstractJdbcConfiguration implements ApplicationContextAware {
 	 */
 	@Bean
 	public JdbcConverter jdbcConverter(JdbcMappingContext mappingContext, NamedParameterJdbcOperations operations,
-			@Lazy RelationResolver relationResolver, JdbcCustomConversions conversions, Dialect dialect) {
+			@Lazy RelationResolver relationResolver, JdbcCustomConversions conversions, JdbcDialect dialect) {
 
-		org.springframework.data.jdbc.core.dialect.JdbcArrayColumns arrayColumns = dialect instanceof JdbcDialect jd
-				? jd.getArraySupport()
-				: JdbcArrayColumns.DefaultSupport.INSTANCE;
+		org.springframework.data.jdbc.core.dialect.JdbcArrayColumns arrayColumns = dialect.getArraySupport();
 		DefaultJdbcTypeFactory jdbcTypeFactory = new DefaultJdbcTypeFactory(operations.getJdbcOperations(), arrayColumns);
 
-		return new MappingJdbcConverter(mappingContext, relationResolver, conversions, jdbcTypeFactory);
+		return new MappingJdbcConverter(mappingContext, relationResolver, conversions, jdbcTypeFactory, dialect.getNullTypeStrategy());
 	}
 
 	/**
@@ -222,7 +220,7 @@ public class AbstractJdbcConfiguration implements ApplicationContextAware {
 	 */
 	@Bean
 	public DataAccessStrategy dataAccessStrategyBean(NamedParameterJdbcOperations operations, JdbcConverter jdbcConverter,
-			JdbcMappingContext context, Dialect dialect) {
+			JdbcMappingContext context, JdbcDialect dialect) {
 
 		SqlGeneratorSource sqlGeneratorSource = new SqlGeneratorSource(context, jdbcConverter, dialect);
 		DataAccessStrategyFactory factory = new DataAccessStrategyFactory(sqlGeneratorSource, jdbcConverter, operations,
@@ -242,7 +240,7 @@ public class AbstractJdbcConfiguration implements ApplicationContextAware {
 	 *           cannot be determined.
 	 */
 	@Bean
-	public Dialect jdbcDialect(NamedParameterJdbcOperations operations) {
+	public JdbcDialect jdbcDialect(NamedParameterJdbcOperations operations) {
 		return DialectResolver.getDialect(operations.getJdbcOperations());
 	}
 

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/config/MyBatisJdbcConfiguration.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/config/MyBatisJdbcConfiguration.java
@@ -24,9 +24,9 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jdbc.core.convert.DataAccessStrategy;
 import org.springframework.data.jdbc.core.convert.JdbcConverter;
 import org.springframework.data.jdbc.core.convert.QueryMappingConfiguration;
+import org.springframework.data.jdbc.core.dialect.JdbcDialect;
 import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
 import org.springframework.data.jdbc.mybatis.MyBatisDataAccessStrategy;
-import org.springframework.data.relational.core.dialect.Dialect;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
 
 /**
@@ -46,7 +46,7 @@ public class MyBatisJdbcConfiguration extends AbstractJdbcConfiguration {
 	@Bean
 	@Override
 	public DataAccessStrategy dataAccessStrategyBean(NamedParameterJdbcOperations operations, JdbcConverter jdbcConverter,
-			JdbcMappingContext context, Dialect dialect) {
+			JdbcMappingContext context, JdbcDialect dialect) {
 
 		return MyBatisDataAccessStrategy.createCombinedAccessStrategy(context, jdbcConverter, operations, session, dialect,
 				queryMappingConfiguration.orElse(QueryMappingConfiguration.EMPTY));

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlParametersFactoryUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlParametersFactoryUnitTests.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.*;
 import static org.springframework.data.jdbc.core.convert.DefaultDataAccessStrategyUnitTests.*;
 
 import java.sql.JDBCType;
+import java.sql.Types;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -173,7 +174,7 @@ class SqlParametersFactoryUnitTests {
 
 		assertThat(sqlParameterSource.getValue("id")).isEqualTo(23L);
 		assertThat(sqlParameterSource.getValue("dummy_enum")).isEqualTo(DummyEnum.ONE.name());
-		assertThat(sqlParameterSource.getSqlType("dummy_enum")).isEqualTo(1111);
+		assertThat(sqlParameterSource.getSqlType("dummy_enum")).isEqualTo(Types.OTHER);
 	}
 
 	@Test // GH-1935
@@ -187,8 +188,8 @@ class SqlParametersFactoryUnitTests {
 				Identifier.empty(), IdValueSource.PROVIDED);
 
 		assertThat(sqlParameterSource.getValue("id")).isEqualTo(23L);
-		assertThat(sqlParameterSource.getSqlType("dummy_enum")).isEqualTo(JDBCType.NULL.getVendorTypeNumber());
 		assertThat(sqlParameterSource.getValue("dummy_enum")).isNull();
+		assertThat(sqlParameterSource.getSqlType("dummy_enum")).isEqualTo(Types.NULL);
 	}
 
 	@Test // GH-1935
@@ -201,7 +202,7 @@ class SqlParametersFactoryUnitTests {
 
 		assertThat(sqlParameterSource.getValue("id")).isEqualTo(23L);
 		assertThat(sqlParameterSource.getValue("dummy_enum")).isEqualTo(DummyEnum.ONE.name());
-		assertThat(sqlParameterSource.getSqlType("dummy_enum")).isEqualTo(12);
+		assertThat(sqlParameterSource.getSqlType("dummy_enum")).isEqualTo(Types.VARCHAR);
 
 	}
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlParametersFactoryUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlParametersFactoryUnitTests.java
@@ -46,7 +46,7 @@ import org.springframework.jdbc.core.JdbcOperations;
  * @author Chirag Tailor
  * @author Sergey Korotaev
  */
-class SqlParametersFactoryTest {
+class SqlParametersFactoryUnitTests {
 
 	RelationalMappingContext context = new JdbcMappingContext();
 	RelationResolver relationResolver = mock(RelationResolver.class);
@@ -88,8 +88,7 @@ class SqlParametersFactoryTest {
 		assertThat(sqlParameterSource.getValue("DUMMYENTITYROOT")).isEqualTo(rawId);
 	}
 
-	@Test
-	// DATAJDBC-146
+	@Test // DATAJDBC-146
 	void identifiersGetAddedAsParameters() {
 
 		long id = 4711L;
@@ -103,8 +102,7 @@ class SqlParametersFactoryTest {
 		assertThat(sqlParameterSource.getValue("reference")).isEqualTo(reference);
 	}
 
-	@Test
-	// DATAJDBC-146
+	@Test // DATAJDBC-146
 	void additionalIdentifierForIdDoesNotLeadToDuplicateParameters() {
 
 		long id = 4711L;
@@ -116,8 +114,7 @@ class SqlParametersFactoryTest {
 		assertThat(sqlParameterSource.getValue("id")).isEqualTo(id);
 	}
 
-	@Test
-	// DATAJDBC-235
+	@Test // DATAJDBC-235
 	void considersConfiguredWriteConverter() {
 
 		SqlParametersFactory sqlParametersFactory = createSqlParametersFactoryWithConverters(
@@ -131,8 +128,7 @@ class SqlParametersFactoryTest {
 		assertThat(sqlParameterSource.getValue("flag")).isEqualTo("T");
 	}
 
-	@Test
-	// DATAJDBC-412
+	@Test // DATAJDBC-412
 	void considersConfiguredWriteConverterForIdValueObjects_onWrite() {
 
 		SqlParametersFactory sqlParametersFactory = createSqlParametersFactoryWithConverters(
@@ -149,8 +145,7 @@ class SqlParametersFactoryTest {
 		assertThat(sqlParameterSource.getValue("value")).isEqualTo(value);
 	}
 
-	@Test
-	// GH-1405
+	@Test // GH-1405
 	void parameterNamesGetSanitized() {
 
 		WithIllegalCharacters entity = new WithIllegalCharacters(23L, "aValue");
@@ -165,8 +160,7 @@ class SqlParametersFactoryTest {
 		assertThat(sqlParameterSource.getValue("val&ue")).isNull();
 	}
 
-	@Test
-	// GH-1935
+	@Test // GH-1935
 	void enumParameterIsNotNullReturnCorrectSqlTypeFromConverter() {
 
 		WithEnumEntity entity = new WithEnumEntity(23L, DummyEnum.ONE);
@@ -174,38 +168,36 @@ class SqlParametersFactoryTest {
 		SqlParametersFactory sqlParametersFactory = createSqlParametersFactoryWithConverters(
 				singletonList(WritingEnumConverter.INSTANCE));
 
-		SqlIdentifierParameterSource sqlParameterSource = sqlParametersFactory.forInsert(entity,
-				WithEnumEntity.class, Identifier.empty(), IdValueSource.PROVIDED);
+		SqlIdentifierParameterSource sqlParameterSource = sqlParametersFactory.forInsert(entity, WithEnumEntity.class,
+				Identifier.empty(), IdValueSource.PROVIDED);
 
 		assertThat(sqlParameterSource.getValue("id")).isEqualTo(23L);
 		assertThat(sqlParameterSource.getValue("dummy_enum")).isEqualTo(DummyEnum.ONE.name());
 		assertThat(sqlParameterSource.getSqlType("dummy_enum")).isEqualTo(1111);
 	}
 
-	@Test
-	// GH-1935
+	@Test // GH-1935
 	void enumParameterIsNullReturnCorrectSqlTypeFromConverter() {
 		WithEnumEntity entity = new WithEnumEntity(23L, null);
 
 		SqlParametersFactory sqlParametersFactory = createSqlParametersFactoryWithConverters(
 				singletonList(WritingEnumConverter.INSTANCE));
 
-		SqlIdentifierParameterSource sqlParameterSource = sqlParametersFactory.forInsert(entity,
-				WithEnumEntity.class, Identifier.empty(), IdValueSource.PROVIDED);
+		SqlIdentifierParameterSource sqlParameterSource = sqlParametersFactory.forInsert(entity, WithEnumEntity.class,
+				Identifier.empty(), IdValueSource.PROVIDED);
 
 		assertThat(sqlParameterSource.getValue("id")).isEqualTo(23L);
 		assertThat(sqlParameterSource.getSqlType("dummy_enum")).isEqualTo(JDBCType.NULL.getVendorTypeNumber());
 		assertThat(sqlParameterSource.getValue("dummy_enum")).isNull();
 	}
 
-	@Test
-	// GH-1935
+	@Test // GH-1935
 	void enumParameterIsNotNullReturnCorrectSqlTypeWithoutConverter() {
 
 		WithEnumEntity entity = new WithEnumEntity(23L, DummyEnum.ONE);
 
-		SqlIdentifierParameterSource sqlParameterSource = sqlParametersFactory.forInsert(entity,
-				WithEnumEntity.class, Identifier.empty(), IdValueSource.PROVIDED);
+		SqlIdentifierParameterSource sqlParameterSource = sqlParametersFactory.forInsert(entity, WithEnumEntity.class,
+				Identifier.empty(), IdValueSource.PROVIDED);
 
 		assertThat(sqlParameterSource.getValue("id")).isEqualTo(23L);
 		assertThat(sqlParameterSource.getValue("dummy_enum")).isEqualTo(DummyEnum.ONE.name());
@@ -213,14 +205,13 @@ class SqlParametersFactoryTest {
 
 	}
 
-	@Test
-	// GH-1935
+	@Test // GH-1935
 	void enumParameterIsNullReturnCorrectSqlTypeWithoutConverter() {
 
 		WithEnumEntity entity = new WithEnumEntity(23L, null);
 
-		SqlIdentifierParameterSource sqlParameterSource = sqlParametersFactory.forInsert(entity,
-				WithEnumEntity.class, Identifier.empty(), IdValueSource.PROVIDED);
+		SqlIdentifierParameterSource sqlParameterSource = sqlParametersFactory.forInsert(entity, WithEnumEntity.class,
+				Identifier.empty(), IdValueSource.PROVIDED);
 
 		assertThat(sqlParameterSource.getValue("id")).isEqualTo(23L);
 		assertThat(sqlParameterSource.getSqlType("dummy_enum")).isEqualTo(JDBCType.NULL.getVendorTypeNumber());
@@ -291,7 +282,7 @@ class SqlParametersFactoryTest {
 		}
 
 		public String toString() {
-			return "SqlParametersFactoryTest.IdValue(id=" + this.getId() + ")";
+			return "SqlParametersFactoryUnitTests.IdValue(id=" + this.getId() + ")";
 		}
 	}
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/config/AbstractJdbcConfigurationIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/config/AbstractJdbcConfigurationIntegrationTests.java
@@ -36,6 +36,7 @@ import org.springframework.data.jdbc.core.JdbcAggregateTemplate;
 import org.springframework.data.jdbc.core.convert.DataAccessStrategy;
 import org.springframework.data.jdbc.core.convert.JdbcConverter;
 import org.springframework.data.jdbc.core.convert.JdbcCustomConversions;
+import org.springframework.data.jdbc.core.dialect.JdbcDialect;
 import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
 import org.springframework.data.relational.RelationalManagedTypes;
 import org.springframework.data.relational.core.dialect.Dialect;
@@ -142,7 +143,7 @@ class AbstractJdbcConfigurationIntegrationTests {
 
 		@Override
 		@Bean
-		public Dialect jdbcDialect(NamedParameterJdbcOperations operations) {
+		public JdbcDialect jdbcDialect(NamedParameterJdbcOperations operations) {
 			return new DummyDialect();
 		}
 
@@ -165,7 +166,7 @@ class AbstractJdbcConfigurationIntegrationTests {
 
 		private static class Blubb {}
 
-		private static class DummyDialect implements Dialect {
+		private static class DummyDialect implements JdbcDialect {
 			@Override
 			public LimitClause limit() {
 				return null;

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/config/MyBatisJdbcConfigurationIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/config/MyBatisJdbcConfigurationIntegrationTests.java
@@ -26,6 +26,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jdbc.core.convert.CascadingDataAccessStrategy;
 import org.springframework.data.jdbc.core.convert.DataAccessStrategy;
+import org.springframework.data.jdbc.core.dialect.JdbcDialect;
 import org.springframework.data.jdbc.core.dialect.JdbcHsqlDbDialect;
 import org.springframework.data.jdbc.mybatis.MyBatisDataAccessStrategy;
 import org.springframework.data.relational.core.dialect.Dialect;
@@ -70,7 +71,7 @@ public class MyBatisJdbcConfigurationIntegrationTests extends AbstractJdbcConfig
 
 		@Override
 		@Bean
-		public Dialect jdbcDialect(NamedParameterJdbcOperations operations) {
+		public JdbcDialect jdbcDialect(NamedParameterJdbcOperations operations) {
 			return JdbcHsqlDbDialect.INSTANCE;
 		}
 	}

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/TestConfiguration.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/TestConfiguration.java
@@ -36,7 +36,6 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.convert.CustomConversions;
 import org.springframework.data.jdbc.core.convert.*;
-import org.springframework.data.jdbc.core.dialect.JdbcArrayColumns;
 import org.springframework.data.jdbc.core.dialect.JdbcDialect;
 import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
 import org.springframework.data.jdbc.core.mapping.JdbcSimpleTypes;
@@ -162,17 +161,15 @@ public class TestConfiguration {
 	@Bean
 	JdbcConverter relationalConverter(RelationalMappingContext mappingContext, @Lazy RelationResolver relationResolver,
 			CustomConversions conversions, @Qualifier("namedParameterJdbcTemplate") NamedParameterJdbcOperations template,
-			Dialect dialect) {
+			JdbcDialect dialect) {
 
-		org.springframework.data.jdbc.core.dialect.JdbcArrayColumns arrayColumns = dialect instanceof JdbcDialect
-				? ((JdbcDialect) dialect).getArraySupport()
-				: JdbcArrayColumns.DefaultSupport.INSTANCE;
+		org.springframework.data.jdbc.core.dialect.JdbcArrayColumns arrayColumns = dialect.getArraySupport();
 
 		return new MappingJdbcConverter( //
 				mappingContext, //
 				relationResolver, //
 				conversions, //
-				new DefaultJdbcTypeFactory(template.getJdbcOperations(), arrayColumns));
+				new DefaultJdbcTypeFactory(template.getJdbcOperations(), arrayColumns), dialect.getNullTypeStrategy());
 	}
 
 	/**
@@ -188,7 +185,7 @@ public class TestConfiguration {
 	}
 
 	@Bean
-	Dialect jdbcDialect(NamedParameterJdbcOperations operations) {
+	JdbcDialect jdbcDialect(NamedParameterJdbcOperations operations) {
 		return DialectResolver.getDialect(operations.getJdbcOperations());
 	}
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/TestConfiguration.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/TestConfiguration.java
@@ -22,9 +22,7 @@ import java.util.Optional;
 
 import javax.sql.DataSource;
 
-import org.apache.ibatis.session.SqlSessionFactory;
 import org.mockito.Mockito;
-import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationEventPublisher;
@@ -77,9 +75,7 @@ public class TestConfiguration {
 	public static final String PROFILE_NO_SINGLE_QUERY_LOADING = "!" + PROFILE_SINGLE_QUERY_LOADING;
 
 	@Autowired DataSource dataSource;
-	@Autowired BeanFactory beanFactory;
 	@Autowired ApplicationEventPublisher publisher;
-	@Autowired(required = false) SqlSessionFactory sqlSessionFactory;
 
 	@Bean
 	JdbcRepositoryFactory jdbcRepositoryFactory(

--- a/spring-data-r2dbc/pom.xml
+++ b/spring-data-r2dbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-r2dbc</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.0.0-1935-jdbc-sql-type-for-null-SNAPSHOT</version>
 
 	<name>Spring Data R2DBC</name>
 	<description>Spring Data module for R2DBC</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.0.0-1935-jdbc-sql-type-for-null-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-relational</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.0.0-1935-jdbc-sql-type-for-null-SNAPSHOT</version>
 
 	<name>Spring Data Relational</name>
 	<description>Spring Data Relational support</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.0.0-1935-jdbc-sql-type-for-null-SNAPSHOT</version>
 	</parent>
 
 	<properties>


### PR DESCRIPTION
This is based on #2068.

Not all databases support the JDBCSqlType.NULL.
Therefore this handling was made dialect dependent, with SQL Server and DB2 using the old approach, while all others use JDBCSqlType.NULL

In the process modified AbstractJdbcConfiguration to use JdbcDialect instead of Dialect.

Closes #1935