### PR TITLE
JdbcAggregateOperations delete by query

### DIFF
--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/AggregateChangeExecutor.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/AggregateChangeExecutor.java
@@ -30,6 +30,7 @@ import org.springframework.data.relational.core.conversion.MutableAggregateChang
  * @author Myeonghyeon Lee
  * @author Chirag Tailor
  * @author Mikhail Polivakha
+ * @author Jaeyeon Kim
  * @since 2.0
  */
 class AggregateChangeExecutor {
@@ -101,10 +102,16 @@ class AggregateChangeExecutor {
 			executionContext.executeBatchDeleteRoot(batchDeleteRoot);
 		} else if (action instanceof DbAction.DeleteAllRoot<?> deleteAllRoot) {
 			executionContext.executeDeleteAllRoot(deleteAllRoot);
+		} else if (action instanceof DbAction.DeleteRootByQuery<?> deleteRootByQuery) {
+			executionContext.excuteDeleteRootByQuery(deleteRootByQuery);
+		} else if (action instanceof DbAction.DeleteByQuery<?> deleteByQuery) {
+			executionContext.excuteDeleteByQuery(deleteByQuery);
 		} else if (action instanceof DbAction.AcquireLockRoot<?> acquireLockRoot) {
 			executionContext.executeAcquireLock(acquireLockRoot);
 		} else if (action instanceof DbAction.AcquireLockAllRoot<?> acquireLockAllRoot) {
 			executionContext.executeAcquireLockAllRoot(acquireLockAllRoot);
+		} else if (action instanceof DbAction.AcquireLockAllRootByQuery<?> acquireLockAllRootByQuery) {
+			executionContext.executeAcquireLockRootByQuery(acquireLockAllRootByQuery);
 		} else {
 			throw new RuntimeException("unexpected action");
 		}

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/JdbcAggregateChangeExecutionContext.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/JdbcAggregateChangeExecutionContext.java
@@ -51,6 +51,7 @@ import org.springframework.util.Assert;
  * @author Myeonghyeon Lee
  * @author Chirag Tailor
  * @author Mark Paluch
+ * @author Jaeyeon Kim
  */
 @SuppressWarnings("rawtypes")
 class JdbcAggregateChangeExecutionContext {
@@ -160,12 +161,26 @@ class JdbcAggregateChangeExecutionContext {
 		accessStrategy.deleteAll(delete.propertyPath());
 	}
 
+	<T> void excuteDeleteRootByQuery(DbAction.DeleteRootByQuery<T> deleteRootByQuery) {
+
+		accessStrategy.deleteByQuery(deleteRootByQuery.getQuery(), deleteRootByQuery.getEntityType());
+	}
+
+	<T> void excuteDeleteByQuery(DbAction.DeleteByQuery<T> deleteByQuery) {
+
+		accessStrategy.deleteByQuery(deleteByQuery.getQuery(), deleteByQuery.propertyPath());
+	}
+
 	<T> void executeAcquireLock(DbAction.AcquireLockRoot<T> acquireLock) {
 		accessStrategy.acquireLockById(acquireLock.getId(), LockMode.PESSIMISTIC_WRITE, acquireLock.getEntityType());
 	}
 
 	<T> void executeAcquireLockAllRoot(DbAction.AcquireLockAllRoot<T> acquireLock) {
 		accessStrategy.acquireLockAll(LockMode.PESSIMISTIC_WRITE, acquireLock.getEntityType());
+	}
+
+	<T> void executeAcquireLockRootByQuery(DbAction.AcquireLockAllRootByQuery<T> acquireLock) {
+		accessStrategy.acquireLockByQuery(acquireLock.getQuery(), LockMode.PESSIMISTIC_WRITE, acquireLock.getEntityType());
 	}
 
 	private void add(DbActionExecutionResult result) {

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/JdbcAggregateOperations.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/JdbcAggregateOperations.java
@@ -40,6 +40,7 @@ import org.springframework.data.relational.core.query.Query;
  * @author Myeonghyeon Lee
  * @author Sergey Korotaev
  * @author Tomohiko Ozawa
+ * @author Jaeyeon Kim
  */
 public interface JdbcAggregateOperations {
 
@@ -327,6 +328,15 @@ public interface JdbcAggregateOperations {
 	 * @param <T> the type of the aggregate roots.
 	 */
 	<T> void deleteAll(Iterable<? extends T> aggregateRoots);
+
+	/**
+	 * Deletes all aggregates of the given type that match the provided query.
+	 *
+	 * @param query Must not be {@code null}.
+	 * @param domainType the type of the aggregate root. Must not be {@code null}.
+	 * @param <T> the type of the aggregate root.
+	 */
+	<T> void deleteAllByQuery(Query query, Class<T> domainType);
 
 	/**
 	 * Returns the {@link JdbcConverter}.

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/JdbcAggregateTemplate.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/JdbcAggregateTemplate.java
@@ -72,6 +72,7 @@ import org.springframework.util.ClassUtils;
  * @author Diego Krupitza
  * @author Sergey Korotaev
  * @author Mikhail Polivakha
+ * @author Jaeyeon Kim
  */
 public class JdbcAggregateTemplate implements JdbcAggregateOperations, ApplicationContextAware {
 
@@ -485,6 +486,17 @@ public class JdbcAggregateTemplate implements JdbcAggregateOperations, Applicati
 	}
 
 	@Override
+	public <T> void deleteAllByQuery(Query query, Class<T> domainType) {
+
+		Assert.notNull(query, "Query must not be null");
+		Assert.notNull(domainType, "Domain type must not be null");
+
+		MutableAggregateChange<?> change = createDeletingChange(query, domainType);
+
+		executor.executeDelete(change);
+	}
+
+	@Override
 	public DataAccessStrategy getDataAccessStrategy() {
 		return accessStrategy;
 	}
@@ -669,6 +681,13 @@ public class JdbcAggregateTemplate implements JdbcAggregateOperations, Applicati
 
 		MutableAggregateChange<?> aggregateChange = MutableAggregateChange.forDelete(domainType);
 		jdbcEntityDeleteWriter.write(null, aggregateChange);
+		return aggregateChange;
+	}
+
+	private MutableAggregateChange<?> createDeletingChange(Query query, Class<?> domainType) {
+
+		MutableAggregateChange<?> aggregateChange = MutableAggregateChange.forDelete(domainType);
+		jdbcEntityDeleteWriter.writeForQuery(query, aggregateChange);
 		return aggregateChange;
 	}
 

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/CascadingDataAccessStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/CascadingDataAccessStrategy.java
@@ -49,6 +49,7 @@ import org.springframework.util.Assert;
  * @author Chirag Tailor
  * @author Diego Krupitza
  * @author Sergey Korotaev
+ * @author Jaeyeon Kim
  * @since 1.1
  */
 public class CascadingDataAccessStrategy implements DataAccessStrategy {
@@ -133,6 +134,16 @@ public class CascadingDataAccessStrategy implements DataAccessStrategy {
 	}
 
 	@Override
+	public void deleteByQuery(Query query, Class<?> domainType) {
+		collectVoid(das -> das.deleteByQuery(query, domainType));
+	}
+
+	@Override
+	public void deleteByQuery(Query query, PersistentPropertyPath<RelationalPersistentProperty> propertyPath) {
+		collectVoid(das -> das.deleteByQuery(query, propertyPath));
+	}
+
+	@Override
 	public <T> void acquireLockById(Object id, LockMode lockMode, Class<T> domainType) {
 		collectVoid(das -> das.acquireLockById(id, lockMode, domainType));
 	}
@@ -140,6 +151,11 @@ public class CascadingDataAccessStrategy implements DataAccessStrategy {
 	@Override
 	public <T> void acquireLockAll(LockMode lockMode, Class<T> domainType) {
 		collectVoid(das -> das.acquireLockAll(lockMode, domainType));
+	}
+
+	@Override
+	public <T> void acquireLockByQuery(Query query, LockMode lockMode, Class<T> domainType) {
+		collectVoid(das -> das.acquireLockByQuery(query, lockMode, domainType));
 	}
 
 	@Override

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DataAccessStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DataAccessStrategy.java
@@ -45,6 +45,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
  * @author Chirag Tailor
  * @author Diego Krupitza
  * @author Sergey Korotaev
+ * @author Jaeyeon Kim
  */
 public interface DataAccessStrategy extends ReadingDataAccessStrategy, RelationResolver {
 
@@ -192,6 +193,22 @@ public interface DataAccessStrategy extends ReadingDataAccessStrategy, RelationR
 	void deleteAll(PersistentPropertyPath<RelationalPersistentProperty> propertyPath);
 
 	/**
+	 * Deletes all root entities of the given domain type that match the given {@link Query}.
+	 *
+	 * @param query the query specifying which rows to delete. Must not be {@code null}.
+	 * @param domainType the domain type of the entity. Must not be {@code null}.
+	 */
+	void deleteByQuery(Query query, Class<?> domainType);
+
+	/**
+	 * Deletes entities reachable via the given {@link PersistentPropertyPath} from root entities that match the given {@link Query}.
+	 *
+	 * @param query the query specifying which root entities to consider for deleting related entities. Must not be {@code null}.
+	 * @param propertyPath Leading from the root object to the entities to be deleted. Must not be {@code null}.
+	 */
+	void deleteByQuery(Query query, PersistentPropertyPath<RelationalPersistentProperty> propertyPath);
+
+	/**
 	 * Acquire a lock on the aggregate specified by id.
 	 *
 	 * @param id the id of the entity to load. Must not be {@code null}.
@@ -207,6 +224,16 @@ public interface DataAccessStrategy extends ReadingDataAccessStrategy, RelationR
 	 * @param domainType the domain type of the entity. Must not be {@code null}.
 	 */
 	<T> void acquireLockAll(LockMode lockMode, Class<T> domainType);
+
+	/**
+	 * Acquire a lock on all aggregates that match the given {@link Query}.
+	 *
+	 * @param query the query specifying which entities to lock. Must not be {@code null}.
+	 * @param lockMode the lock mode to apply to the query (e.g. {@code FOR UPDATE}). Must not be {@code null}.
+	 * @param domainType the domain type of the entities to be locked. Must not be {@code null}.
+	 * @param <T> the type of the domain entity.
+	 */
+	<T> void acquireLockByQuery(Query query, LockMode lockMode, Class<T> domainType);
 
 	/**
 	 * Counts the rows in the table representing the given domain type.

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DefaultDataAccessStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DefaultDataAccessStrategy.java
@@ -64,6 +64,7 @@ import org.springframework.util.Assert;
  * @author Diego Krupitza
  * @author Sergey Korotaev
  * @author Mikhail Polivakha
+ * @author Jaeyeon Kim
  * @since 1.1
  */
 public class DefaultDataAccessStrategy implements DataAccessStrategy {
@@ -257,6 +258,29 @@ public class DefaultDataAccessStrategy implements DataAccessStrategy {
 	}
 
 	@Override
+	public void deleteByQuery(Query query, Class<?> domainType) {
+
+		MapSqlParameterSource parameterSource = new MapSqlParameterSource();
+		String deleteSql = sql(domainType).createDeleteByQuery(query, parameterSource);
+
+		operations.update(deleteSql, parameterSource);
+	}
+
+	@Override
+	public void deleteByQuery(Query query, PersistentPropertyPath<RelationalPersistentProperty> propertyPath) {
+
+		RelationalPersistentEntity<?> rootEntity = context.getRequiredPersistentEntity(getBaseType(propertyPath));
+
+		RelationalPersistentProperty referencingProperty = propertyPath.getLeafProperty();
+		Assert.notNull(referencingProperty, "No property found matching the PropertyPath " + propertyPath);
+
+		MapSqlParameterSource parameterSource = new MapSqlParameterSource();
+		String deleteSql = sql(rootEntity.getType()).createDeleteInSubselectByPath(query, parameterSource, propertyPath);
+
+		operations.update(deleteSql, parameterSource);
+	}
+
+	@Override
 	public <T> void acquireLockById(Object id, LockMode lockMode, Class<T> domainType) {
 
 		String acquireLockByIdSql = sql(domainType).getAcquireLockById(lockMode);
@@ -270,6 +294,15 @@ public class DefaultDataAccessStrategy implements DataAccessStrategy {
 
 		String acquireLockAllSql = sql(domainType).getAcquireLockAll(lockMode);
 		operations.getJdbcOperations().query(acquireLockAllSql, ResultSet::next);
+	}
+
+	@Override
+	public <T> void acquireLockByQuery(Query query, LockMode lockMode, Class<T> domainType) {
+
+		MapSqlParameterSource parameterSource = new MapSqlParameterSource();
+		String acquireLockByQuerySql = sql(domainType).getAcquireLockByQuery(query, parameterSource, lockMode);
+
+		operations.query(acquireLockByQuerySql, parameterSource, ResultSet::next);
 	}
 
 	@Override

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DelegatingDataAccessStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DelegatingDataAccessStrategy.java
@@ -42,6 +42,7 @@ import org.springframework.util.Assert;
  * @author Chirag Tailor
  * @author Diego Krupitza
  * @author Sergey Korotaev
+ * @author Jaeyeon Kim
  * @since 1.1
  */
 public class DelegatingDataAccessStrategy implements DataAccessStrategy {
@@ -127,6 +128,16 @@ public class DelegatingDataAccessStrategy implements DataAccessStrategy {
 	}
 
 	@Override
+	public void deleteByQuery(Query query, Class<?> domainType) {
+		delegate.deleteByQuery(query, domainType);
+	}
+
+	@Override
+	public void deleteByQuery(Query query, PersistentPropertyPath<RelationalPersistentProperty> propertyPath) {
+		delegate.deleteByQuery(query, propertyPath);
+	}
+
+	@Override
 	public <T> void acquireLockById(Object id, LockMode lockMode, Class<T> domainType) {
 		delegate.acquireLockById(id, lockMode, domainType);
 	}
@@ -134,6 +145,11 @@ public class DelegatingDataAccessStrategy implements DataAccessStrategy {
 	@Override
 	public <T> void acquireLockAll(LockMode lockMode, Class<T> domainType) {
 		delegate.acquireLockAll(lockMode, domainType);
+	}
+
+	@Override
+	public <T> void acquireLockByQuery(Query query, LockMode lockMode, Class<T> domainType) {
+		delegate.acquireLockByQuery(query, lockMode, domainType);
 	}
 
 	@Override

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlGenerator.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlGenerator.java
@@ -61,6 +61,7 @@ import org.springframework.util.Assert;
  * @author Hari Ohm Prasath
  * @author Viktor Ardelean
  * @author Kurt Niemi
+ * @author Jaeyeon Kim
  */
 public class SqlGenerator {
 
@@ -375,6 +376,18 @@ public class SqlGenerator {
 	}
 
 	/**
+	 * Create a {@code SELECT id FROM … WHERE … (LOCK CLAUSE)} statement based on the given query.
+	 *
+	 * @param query the query to base the select on. Must not be null.
+	 * @param parameterSource the source for holding the bindings.
+	 * @param lockMode Lock clause mode.
+	 * @return the SQL statement as a {@link String}. Guaranteed to be not {@literal null}.
+	 */
+	String getAcquireLockByQuery(Query query, MapSqlParameterSource parameterSource, LockMode lockMode) {
+		return this.createAcquireLockByQuery(query, parameterSource, lockMode);
+	}
+
+	/**
 	 * Create a {@code INSERT INTO … (…) VALUES(…)} statement.
 	 *
 	 * @return the statement as a {@link String}. Guaranteed to be not {@literal null}.
@@ -490,6 +503,72 @@ public class SqlGenerator {
 	}
 
 	/**
+	 * Create a {@code DELETE FROM ... WHERE ...} SQL statement based on the given {@link Query}.
+	 *
+	 * @param query the query object defining filter criteria; must not be {@literal null}.
+	 * @param parameterSource the parameter bindings for the query; must not be {@literal null}.
+	 * @return the SQL DELETE statement as a {@link String}; guaranteed to be not {@literal null}.
+	 */
+	public String createDeleteByQuery(Query query, MapSqlParameterSource parameterSource) {
+		Assert.notNull(parameterSource, "parameterSource must not be null");
+
+		Table table = this.getTable();
+
+		DeleteBuilder.DeleteWhere builder = Delete.builder()
+				.from(table);
+
+		query.getCriteria()
+				.filter(criteria -> !criteria.isEmpty())
+				.map(criteria -> queryMapper.getMappedObject(parameterSource, criteria, table, entity))
+				.ifPresent(builder::where);
+
+		return render(builder.build());
+	}
+
+	/**
+	 * Creates a {@code DELETE} SQL query that targets a specific table defined by the given {@link PersistentPropertyPath},
+	 * and applies filtering using a subselect based on the provided {@link Query}.
+	 *
+	 * @param query the query object containing the filtering criteria; must not be {@literal null}.
+	 * @param parameterSource the source for parameter bindings used in the query; must not be {@literal null}.
+	 * @param propertyPath must not be {@literal null}.
+	 * @return the DELETE SQL statement as a {@link String}. Guaranteed to be not {@literal null}.
+	 */
+	public String createDeleteInSubselectByPath(Query query, MapSqlParameterSource parameterSource,
+												PersistentPropertyPath<RelationalPersistentProperty> propertyPath) {
+
+		Assert.notNull(parameterSource, "parameterSource must not be null");
+
+		AggregatePath path = mappingContext.getAggregatePath(propertyPath);
+
+        return createDeleteByPathAndCriteria(path, columnMap -> {
+            Select subSelect = createRootIdSubSelect(query, parameterSource);
+			Collection<Column> columns = columnMap.values();
+            Expression expression = columns.size() == 1 ? columns.iterator().next() : TupleExpression.create(columns);
+            return Conditions.in(expression, subSelect);
+        });
+	}
+
+	/**
+	 * Creates a subselect that retrieves root entity IDs filtered by the given query.
+	 */
+	private Select createRootIdSubSelect(Query query, MapSqlParameterSource parameterSource) {
+
+		Table table = this.getTable();
+
+		SelectBuilder.SelectWhere selectBuilder = StatementBuilder
+				.select(getIdColumns())
+				.from(table);
+
+		query.getCriteria()
+				.filter(criteria -> !criteria.isEmpty())
+				.map(criteria -> queryMapper.getMappedObject(parameterSource, criteria, table, entity))
+				.ifPresent(selectBuilder::where);
+
+		return selectBuilder.build();
+	}
+
+	/**
 	 * Constructs a where condition. The where condition will be of the form {@literal <columns> IN :bind-marker}
 	 */
 	private Condition inCondition(Map<AggregatePath, Column> columnMap) {
@@ -591,6 +670,28 @@ public class SqlGenerator {
 				.select(getSingleNonNullColumn()) //
 				.from(table) //
 				.lock(lockMode) //
+				.build();
+
+		return render(select);
+	}
+
+	private String createAcquireLockByQuery(Query query, MapSqlParameterSource parameterSource, LockMode lockMode) {
+
+		Assert.notNull(parameterSource, "parameterSource must not be null");
+
+		Table table = this.getTable();
+
+		SelectBuilder.SelectWhere selectBuilder = StatementBuilder
+				.select(getSingleNonNullColumn())
+				.from(table);
+
+		query.getCriteria()
+				.filter(criteria -> !criteria.isEmpty())
+				.map(criteria -> queryMapper.getMappedObject(parameterSource, criteria, table, entity))
+				.ifPresent(selectBuilder::where);
+
+		Select select = selectBuilder
+				.lock(lockMode)
 				.build();
 
 		return render(select);

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/mybatis/MyBatisDataAccessStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/mybatis/MyBatisDataAccessStrategy.java
@@ -74,6 +74,7 @@ import org.springframework.util.Assert;
  * @author Christopher Klein
  * @author Mikhail Polivakha
  * @author Sergey Korotaev
+ * @author Jaeyeon Kim
  */
 public class MyBatisDataAccessStrategy implements DataAccessStrategy {
 
@@ -256,6 +257,16 @@ public class MyBatisDataAccessStrategy implements DataAccessStrategy {
 	}
 
 	@Override
+	public void deleteByQuery(Query query, Class<?> domainType) {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	public void deleteByQuery(Query query, PersistentPropertyPath<RelationalPersistentProperty> propertyPath) {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
 	public <T> void acquireLockById(Object id, LockMode lockMode, Class<T> domainType) {
 
 		String statement = namespace(domainType) + ".acquireLockById";
@@ -276,6 +287,11 @@ public class MyBatisDataAccessStrategy implements DataAccessStrategy {
 		MyBatisContext parameter = new MyBatisContext(null, null, domainType, Collections.emptyMap());
 
 		sqlSession().selectOne(statement, parameter);
+	}
+
+	@Override
+	public <T> void acquireLockByQuery(Query query, LockMode lockMode, Class<T> domainType) {
+		throw new UnsupportedOperationException("Not implemented");
 	}
 
 	@Override

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlGeneratorUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlGeneratorUnitTests.java
@@ -73,6 +73,7 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
  * @author Diego Krupitza
  * @author Hari Ohm Prasath
  * @author Viktor Ardelean
+ * @author Jaeyeon Kim
  */
 @SuppressWarnings("Convert2MethodRef")
 class SqlGeneratorUnitTests {
@@ -165,6 +166,16 @@ class SqlGeneratorUnitTests {
 				.doesNotContain("Element AS elements"));
 	}
 
+	@Test // GH-1978
+	void getAcquireLockByQuery(){
+
+		Query query = Query.query(Criteria.where("id").is(23L));
+
+		String sql = sqlGenerator.getAcquireLockByQuery(query, new MapSqlParameterSource(), LockMode.PESSIMISTIC_WRITE);
+
+		assertThat(sql).isEqualTo("SELECT dummy_entity.id1 AS id1 FROM dummy_entity WHERE dummy_entity.id1 = :id1 FOR UPDATE");
+	}
+
 	@Test // DATAJDBC-112
 	void cascadingDeleteFirstLevel() {
 
@@ -238,6 +249,47 @@ class SqlGeneratorUnitTests {
 		String sql = sqlGenerator.createDeleteByPath(getPath("mappedElements", DummyEntity.class));
 
 		assertThat(sql).isEqualTo("DELETE FROM element WHERE element.dummy_entity = :id1");
+	}
+
+	@Test // GH-1978
+	void deleteByQuery() {
+
+		Query query = Query.query(Criteria.where("id").greaterThan(23L));
+		MapSqlParameterSource parameterSource = new MapSqlParameterSource();
+
+		String sql = sqlGenerator.createDeleteByQuery(query, parameterSource);
+
+		assertThat(sql).isEqualTo("DELETE FROM dummy_entity WHERE dummy_entity.id1 > :id1");
+	}
+
+	@Test // GH-1978
+	void cascadingDeleteInSubselectByPathFirstLevel() {
+
+		Query query = Query.query(Criteria.where("id").is(23L));
+		MapSqlParameterSource parameterSource = new MapSqlParameterSource();
+
+		String sql = sqlGenerator.createDeleteInSubselectByPath(query, parameterSource,
+				getPath("ref", DummyEntity.class));
+
+		assertThat(sql).isEqualTo(
+				"DELETE FROM referenced_entity WHERE referenced_entity.dummy_entity IN " +
+						"(SELECT dummy_entity.id1 AS id1 FROM dummy_entity WHERE dummy_entity.id1 = :id1)");
+	}
+
+	@Test // GH-1978
+	void cascadingDeleteInSubselectByPathSecondLevel() {
+
+		Query query = Query.query(Criteria.where("id").is(23L));
+		MapSqlParameterSource parameterSource = new MapSqlParameterSource();
+
+		String sql = sqlGenerator.createDeleteInSubselectByPath(query, parameterSource,
+				getPath("ref.further", DummyEntity.class));
+
+		assertThat(sql).isEqualTo(
+				"DELETE FROM second_level_referenced_entity " +
+						"WHERE second_level_referenced_entity.referenced_entity IN " +
+						"(SELECT referenced_entity.x_l1id FROM referenced_entity WHERE referenced_entity.dummy_entity IN " +
+						"(SELECT dummy_entity.id1 AS id1 FROM dummy_entity WHERE dummy_entity.id1 = :id1))");
 	}
 
 	@Test // DATAJDBC-101

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/DbAction.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/DbAction.java
@@ -26,6 +26,7 @@ import java.util.function.Function;
 import org.jspecify.annotations.Nullable;
 import org.springframework.data.mapping.PersistentPropertyPath;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
+import org.springframework.data.relational.core.query.Query;
 import org.springframework.data.util.Pair;
 import org.springframework.util.Assert;
 
@@ -39,6 +40,7 @@ import org.springframework.util.Assert;
  * @author Tyler Van Gorder
  * @author Myeonghyeon Lee
  * @author Chirag Tailor
+ * @author Jaeyeon Kim
  */
 public interface DbAction<T> {
 
@@ -220,6 +222,67 @@ public interface DbAction<T> {
 		}
 
 	/**
+	 * Represents a delete statement for aggregate root entities matching a given {@link Query}.
+	 *
+	 * @param <T> type of the entity for which this represents a database interaction.
+	 */
+	final class DeleteRootByQuery<T> implements DbAction<T> {
+
+		private final Class<T> entityType;
+
+		private final Query query;
+
+		DeleteRootByQuery(Class<T> entityType, Query query) {
+			this.entityType = entityType;
+			this.query = query;
+		}
+
+		@Override
+		public Class<T> getEntityType() {
+			return this.entityType;
+		}
+
+		public Query getQuery() {
+			return query;
+		}
+
+		public String toString() {
+			return "DbAction.DeleteRootByQuery(entityType=" + this.entityType + ", query=" + this.query + ")";
+		}
+	}
+
+	/**
+	 * Represents a delete statement for all entities that are reachable via a given path from the aggregate root,
+	 * filtered by a {@link Query}.
+	 *
+	 * @param <T> type of the entity for which this represents a database interaction.
+	 */
+	final class DeleteByQuery<T> implements WithPropertyPath<T> {
+
+		private final Query query;
+
+		private final PersistentPropertyPath<RelationalPersistentProperty> propertyPath;
+
+		DeleteByQuery(Query query, PersistentPropertyPath<RelationalPersistentProperty> propertyPath) {
+			this.query = query;
+			this.propertyPath = propertyPath;
+		}
+
+		@Override
+		public PersistentPropertyPath<RelationalPersistentProperty> propertyPath() {
+			return this.propertyPath;
+		}
+
+		public Query getQuery() {
+			return query;
+		}
+
+		public String toString() {
+			return "DbAction.DeleteByQuery(propertyPath=" + this.propertyPath() + ", query=" + this.query + ")";
+		}
+	}
+
+	/**
 	 * Represents an acquire lock statement for a aggregate root when only the ID is known.
 	 *
 	 * @param <T> type of the entity for which this represents a database interaction.
@@ -266,6 +329,37 @@ public interface DbAction<T> {
 
 		public String toString() {
 			return "DbAction.AcquireLockAllRoot(entityType=" + this.getEntityType() + ")";
+		}
+	}
+
+	/**
+	 * Represents a {@code SELECT ... FOR UPDATE} statement on all aggregate roots of a given type,
+	 * filtered by a {@link Query}.
+	 *
+	 * @param <T> type of the root entity for which this represents a database interaction.
+	 */
+	final class AcquireLockAllRootByQuery<T> implements DbAction<T> {
+
+		private final Class<T> entityType;
+
+		private final Query query;
+
+		AcquireLockAllRootByQuery(Class<T> entityType, Query query) {
+			this.entityType = entityType;
+            this.query = query;
+        }
+
+		@Override
+		public Class<T> getEntityType() {
+			return this.entityType;
+		}
+
+		public Query getQuery() {
+			return query;
+		}
+
+		public String toString() {
+			return "DbAction.AcquireLockAllRootByQuery(entityType=" + this.entityType + ", query=" + this.query + ")";
 		}
 	}
 

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/RelationalEntityDeleteWriter.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/RelationalEntityDeleteWriter.java
@@ -26,6 +26,8 @@ import org.springframework.data.mapping.PersistentPropertyPath;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
 import org.springframework.data.relational.core.mapping.RelationalPredicates;
+import org.springframework.data.relational.core.query.CriteriaDefinition;
+import org.springframework.data.relational.core.query.Query;
 import org.springframework.util.Assert;
 
 /**
@@ -40,6 +42,7 @@ import org.springframework.util.Assert;
  * @author Tyler Van Gorder
  * @author Myeonghyeon Lee
  * @author Chirag Tailor
+ * @author Jaeyeon Kim
  */
 public class RelationalEntityDeleteWriter implements EntityWriter<Object, MutableAggregateChange<?>> {
 
@@ -68,6 +71,42 @@ public class RelationalEntityDeleteWriter implements EntityWriter<Object, Mutabl
 		} else {
 			deleteRoot(id, aggregateChange).forEach(aggregateChange::addAction);
 		}
+	}
+
+	/**
+	 * Fills the provided {@link MutableAggregateChange} with the necessary {@link DbAction}s
+	 * to delete all aggregate roots matching the given {@link Query}.
+	 * This includes acquiring locks, deleting referenced entities, and deleting the root entities themselves.
+	 *
+	 * @param query the query used to select aggregate root IDs to delete. Must not be {@code null}.
+	 * @param aggregateChange The change object to which delete actions will be added. Must not be {@code null}.
+	 */
+	public void writeForQuery(Query query, MutableAggregateChange<?> aggregateChange) {
+
+		Class<?> entityType = aggregateChange.getEntityType();
+
+		CriteriaDefinition criteria = query.getCriteria().orElse(null);
+		if (criteria == null || criteria.isEmpty()) {
+			deleteAll(entityType).forEach(aggregateChange::addAction);
+			return;
+		}
+
+		List<DbAction<?>> deleteReferencedActions = new ArrayList<>();
+
+		forAllTableRepresentingPaths(entityType, p -> deleteReferencedActions.add(new DbAction.DeleteByQuery<>(query, p)));
+
+		Collections.reverse(deleteReferencedActions);
+
+		List<DbAction<?>> actions = new ArrayList<>();
+		if (!deleteReferencedActions.isEmpty()) {
+			actions.add(new DbAction.AcquireLockAllRootByQuery<>(entityType, query));
+		}
+		actions.addAll(deleteReferencedActions);
+
+		DbAction.DeleteRootByQuery<?> deleteRootByQuery = new DbAction.DeleteRootByQuery<>(entityType, query);
+		actions.add(deleteRootByQuery);
+
+		actions.forEach(aggregateChange::addAction);
 	}
 
 	private List<DbAction<?>> deleteAll(Class<?> entityType) {


### PR DESCRIPTION
Issue link: #1978

Add deleteAllByQuery method to JdbcAggregateOperations

This method enables deleting aggregates based on a query by performing the following steps:
1. Select root IDs matching the query with a SELECT ... FOR UPDATE to lock the rows.
2. Delete all sub-entities associated with the selected root IDs.
3. Delete the root entities identified by the selected IDs.

see
#1978
