### PR TITLE
Consider embedded properties in the QBE queries

### DIFF
--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/BasicRelationalPersistentProperty.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/BasicRelationalPersistentProperty.java
@@ -261,7 +261,11 @@ public class BasicRelationalPersistentProperty extends AnnotationBasedPersistent
 
 	@Override
 	public boolean isEmbedded() {
-		return isEmbedded || (isIdProperty() && isEntity());
+		return isEmbedded || isCompositeId();
+	}
+
+	private boolean isCompositeId() {
+		return isIdProperty() && isEntity();
 	}
 
 	@Override


### PR DESCRIPTION
Closes #2099 
Closes #1986

This PR enhances the `RelationalExampleMapper` by making it consider embedded properties and specifiers for them.

As it turned out during resolution of #1986, the embedded properties were kind of ignored in QBE.

Current algorithm works more a less the same way, it just traverses the `Example` recursively from direct properties defined in the root `probe`, all the way down to the deeply embedded leafs.

Tests are included in the PR.

CC: @mp911de @schauder  
