### PR TITLE
Implement logic deletion #1547

### DIFF
--- a/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/core/DefaultQueryWrapper.java
+++ b/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/core/DefaultQueryWrapper.java
@@ -1,0 +1,10 @@
+package org.springframework.data.r2dbc.core;
+
+import org.springframework.data.relational.core.query.Query;
+
+public class DefaultQueryWrapper implements QueryWrapper{
+    @Override
+    public Query wrapper(Query query, Class<?> domainType) {
+        return query;
+    }
+}

--- a/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/core/DefaultQueryWrapper.java
+++ b/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/core/DefaultQueryWrapper.java
@@ -1,10 +1,32 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.data.r2dbc.core;
 
 import org.springframework.data.relational.core.query.Query;
 
-public class DefaultQueryWrapper implements QueryWrapper{
-    @Override
-    public Query wrapper(Query query, Class<?> domainType) {
-        return query;
-    }
+/**
+ * Default implementation of {@link QueryWrapper} that returns the original query unchanged.
+ *
+ * @author Your Name
+ * @since 3.4
+ */
+public class DefaultQueryWrapper implements QueryWrapper {
+
+	@Override
+	public Query wrapper(Query query, Class<?> domainType) {
+		return query;
+	}
 }

--- a/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/core/QueryWrapper.java
+++ b/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/core/QueryWrapper.java
@@ -1,8 +1,36 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.data.r2dbc.core;
 
 import org.springframework.data.relational.core.query.Query;
 
+/**
+ * Interface for query wrapper implementations that allow customization of queries before execution.
+ *
+ * @author Your Name
+ * @since 3.4
+ */
 public interface QueryWrapper {
 
-    Query wrapper(Query query, Class<?> domainType);
+	/**
+	 * Wraps the given query for the specified domain type.
+	 *
+	 * @param query the original query to wrap, must not be {@literal null}.
+	 * @param domainType the domain type for which the query is executed, must not be {@literal null}.
+	 * @return the wrapped query, must not be {@literal null}.
+	 */
+	Query wrapper(Query query, Class<?> domainType);
 }

--- a/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/core/QueryWrapper.java
+++ b/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/core/QueryWrapper.java
@@ -1,0 +1,8 @@
+package org.springframework.data.r2dbc.core;
+
+import org.springframework.data.relational.core.query.Query;
+
+public interface QueryWrapper {
+
+    Query wrapper(Query query, Class<?> domainType);
+}

--- a/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/core/R2dbcEntityTemplate.java
+++ b/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/core/R2dbcEntityTemplate.java
@@ -133,7 +133,7 @@ public class R2dbcEntityTemplate implements R2dbcEntityOperations, BeanFactoryAw
 		this.converter = dataAccessStrategy.getConverter();
 		this.mappingContext = converter.getMappingContext();
 		this.projectionFactory = new SpelAwareProxyProjectionFactory();
-		this.queryWrapper=new DefaultQueryWrapper();
+		this.queryWrapper = new DefaultQueryWrapper();
 	}
 
 	/**
@@ -166,15 +166,17 @@ public class R2dbcEntityTemplate implements R2dbcEntityOperations, BeanFactoryAw
 	 * @since 1.2
 	 */
 	public R2dbcEntityTemplate(DatabaseClient databaseClient, ReactiveDataAccessStrategy strategy) {
-		this(databaseClient,strategy,new DefaultQueryWrapper());
+		this(databaseClient, strategy, new DefaultQueryWrapper());
 	}
 	/**
-	 * Create a new {@link R2dbcEntityTemplate} given {@link DatabaseClient} and {@link ReactiveDataAccessStrategy}.
+	 * Create a new {@link R2dbcEntityTemplate} given {@link DatabaseClient}, {@link ReactiveDataAccessStrategy}, and {@link QueryWrapper}.
 	 *
 	 * @param databaseClient must not be {@literal null}.
-	 * @since 1.2
+	 * @param strategy must not be {@literal null}.
+	 * @param queryWrapper must not be {@literal null}.
+	 * @since 3.4
 	 */
-	public R2dbcEntityTemplate(DatabaseClient databaseClient, ReactiveDataAccessStrategy strategy,QueryWrapper queryWrapper) {
+	public R2dbcEntityTemplate(DatabaseClient databaseClient, ReactiveDataAccessStrategy strategy, QueryWrapper queryWrapper) {
 
 		Assert.notNull(databaseClient, "DatabaseClient must not be null");
 		Assert.notNull(strategy, "ReactiveDataAccessStrategy must not be null");
@@ -285,7 +287,7 @@ public class R2dbcEntityTemplate implements R2dbcEntityOperations, BeanFactoryAw
 	}
 
 	Mono<Long> doCount(Query query, Class<?> entityClass, SqlIdentifier tableName) {
-		query = queryWrapper.wrapper(query,entityClass);
+		query = queryWrapper.wrapper(query, entityClass);
 		StatementMapper statementMapper = dataAccessStrategy.getStatementMapper().forType(entityClass);
 
 		StatementMapper.SelectSpec selectSpec = statementMapper //
@@ -316,7 +318,7 @@ public class R2dbcEntityTemplate implements R2dbcEntityOperations, BeanFactoryAw
 	}
 
 	Mono<Boolean> doExists(Query query, Class<?> entityClass, SqlIdentifier tableName) {
-		query = queryWrapper.wrapper(query,entityClass);
+		query = queryWrapper.wrapper(query, entityClass);
 		StatementMapper statementMapper = dataAccessStrategy.getStatementMapper().forType(entityClass);
 		StatementMapper.SelectSpec selectSpec = statementMapper.createSelect(tableName).limit(1)
 				.withProjection(Expressions.just("1"));
@@ -363,7 +365,7 @@ public class R2dbcEntityTemplate implements R2dbcEntityOperations, BeanFactoryAw
 
 	private <T> RowsFetchSpec<T> doSelect(Query query, Class<?> entityType, SqlIdentifier tableName,
 			Class<T> returnType, Function<? super Statement, ? extends Statement> filterFunction) {
-		query = queryWrapper.wrapper(query,entityType);
+		query = queryWrapper.wrapper(query, entityType);
 		StatementMapper statementMapper = dataAccessStrategy.getStatementMapper().forType(entityType);
 		final Query finalQuery = query;
 		StatementMapper.SelectSpec selectSpec = statementMapper //


### PR DESCRIPTION
I want to implement soft deletion step by step by modifying the methods of `R2dbcEntityTemplate`, while also achieving better scalability.

I plan to achieve this in several steps:
1. Provide a query wrapper, allowing the implementation class for logical deletion to override this wrapper function.
2. Split the doDelete method, separating the construction behavior from the final execution. The construction process can be overridden, and the implementation class for logical deletion is also provided to override it.
      