### PR TITLE
Support Composite IDs in R2DBC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-relational-parent</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.0.0-2011-embedded-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Relational Parent</name>

--- a/spring-data-jdbc-distribution/pom.xml
+++ b/spring-data-jdbc-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.0.0-2011-embedded-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-jdbc</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.0.0-2011-embedded-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.0.0-2011-embedded-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-r2dbc/pom.xml
+++ b/spring-data-r2dbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-r2dbc</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.0.0-2011-embedded-SNAPSHOT</version>
 
 	<name>Spring Data R2DBC</name>
 	<description>Spring Data module for R2DBC</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.0.0-2011-embedded-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/core/DefaultStatementMapper.java
+++ b/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/core/DefaultStatementMapper.java
@@ -143,7 +143,7 @@ class DefaultStatementMapper implements StatementMapper {
 		List<Expression> mapped = new ArrayList<>(selectList.size());
 
 		for (Expression expression : selectList) {
-			mapped.add(updateMapper.getMappedObject(expression, entity));
+			mapped.addAll(updateMapper.getMappedObjects(expression, entity));
 		}
 
 		return mapped;

--- a/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/query/QueryMapper.java
+++ b/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/query/QueryMapper.java
@@ -24,6 +24,8 @@ import java.util.regex.Pattern;
 
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mapping.MappingException;
+import org.springframework.data.mapping.PersistentProperty;
+import org.springframework.data.mapping.PersistentPropertyAccessor;
 import org.springframework.data.mapping.PersistentPropertyPath;
 import org.springframework.data.mapping.PropertyPath;
 import org.springframework.data.mapping.PropertyReferenceException;
@@ -112,22 +114,42 @@ public class QueryMapper {
 
 			SqlSort.validate(order);
 
-			OrderByField simpleOrderByField = createSimpleOrderByField(table, entity, order);
-			OrderByField orderBy = simpleOrderByField.withNullHandling(order.getNullHandling());
-			mappedOrder.add(order.isAscending() ? orderBy.asc() : orderBy.desc());
+			List<OrderByField> simpleOrderByFields = createSimpleOrderByFields(table, entity, order);
+
+			simpleOrderByFields.forEach(field -> {
+
+				OrderByField orderBy = field.withNullHandling(order.getNullHandling());
+				mappedOrder.add(order.isAscending() ? orderBy.asc() : orderBy.desc());
+			});
 		}
 
 		return mappedOrder;
 	}
 
-	private OrderByField createSimpleOrderByField(Table table, RelationalPersistentEntity<?> entity, Sort.Order order) {
+	private List<OrderByField> createSimpleOrderByFields(Table table, @Nullable RelationalPersistentEntity<?> entity,
+			Sort.Order order) {
 
 		if (order instanceof SqlSort.SqlOrder sqlOrder && sqlOrder.isUnsafe()) {
-			return OrderByField.from(Expressions.just(sqlOrder.getProperty()));
+			return List.of(OrderByField.from(Expressions.just(sqlOrder.getProperty())));
 		}
 
 		Field field = createPropertyField(entity, SqlIdentifier.unquoted(order.getProperty()), this.mappingContext);
-		return OrderByField.from(table.column(field.getMappedColumnName()));
+
+		if (field.isEmbedded() && entity != null) {
+
+			RelationalPersistentEntity<?> embeddedEntity = getMappingContext()
+					.getRequiredPersistentEntity(field.getRequiredProperty());
+
+			List<OrderByField> fields = new ArrayList<>();
+
+			for (RelationalPersistentProperty embeddedProperty : embeddedEntity) {
+				fields.addAll(createSimpleOrderByFields(table, embeddedEntity, order.withProperty(embeddedProperty.getName())));
+			}
+
+			return fields;
+		}
+
+		return List.of(OrderByField.from(table.column(field.getMappedColumnName())));
 	}
 
 	/**
@@ -140,9 +162,28 @@ public class QueryMapper {
 	 */
 	public Expression getMappedObject(Expression expression, @Nullable RelationalPersistentEntity<?> entity) {
 
+		List<Expression> mappedObjects = getMappedObjects(expression, entity);
+
+		if (mappedObjects.isEmpty()) {
+			throw new IllegalArgumentException(String.format("Cannot map %s", expression));
+		}
+
+		return mappedObjects.get(0);
+	}
+
+	/**
+	 * Map the {@link Expression} object to apply field name mapping using {@link Class the type to read}.
+	 *
+	 * @param expression must not be {@literal null}.
+	 * @param entity related {@link RelationalPersistentEntity}, can be {@literal null}.
+	 * @return the mapped {@link Expression}s.
+	 * @since 4.0
+	 */
+	public List<Expression> getMappedObjects(Expression expression, @Nullable RelationalPersistentEntity<?> entity) {
+
 		if (entity == null || expression instanceof AsteriskFromTable
 				|| expression instanceof Expressions.SimpleExpression) {
-			return expression;
+			return List.of(expression);
 		}
 
 		if (expression instanceof Column column) {
@@ -150,8 +191,22 @@ public class QueryMapper {
 			Field field = createPropertyField(entity, column.getName());
 			TableLike table = column.getTable();
 
+			if (field.isEmbedded()) {
+
+				RelationalPersistentEntity<?> embeddedEntity = getMappingContext()
+						.getRequiredPersistentEntity(field.getRequiredProperty());
+
+				List<Expression> expressions = new ArrayList<>();
+
+				for (RelationalPersistentProperty embeddedProperty : embeddedEntity) {
+					expressions.addAll(getMappedObjects(Column.create(embeddedProperty.getName(), table), embeddedEntity));
+				}
+
+				return expressions;
+			}
+
 			Column columnFromTable = table.column(field.getMappedColumnName());
-			return column instanceof Aliased ? columnFromTable.as(((Aliased) column).getAlias()) : columnFromTable;
+			return List.of(column instanceof Aliased ? columnFromTable.as(((Aliased) column).getAlias()) : columnFromTable);
 		}
 
 		if (expression instanceof SimpleFunction function) {
@@ -160,12 +215,12 @@ public class QueryMapper {
 			List<Expression> mappedArguments = new ArrayList<>(arguments.size());
 
 			for (Expression argument : arguments) {
-				mappedArguments.add(getMappedObject(argument, entity));
+				mappedArguments.addAll(getMappedObjects(argument, entity));
 			}
 
 			SimpleFunction mappedFunction = SimpleFunction.create(function.getFunctionName(), mappedArguments);
 
-			return function instanceof Aliased ? mappedFunction.as(((Aliased) function).getAlias()) : mappedFunction;
+			return List.of(function instanceof Aliased ? mappedFunction.as(((Aliased) function).getAlias()) : mappedFunction);
 		}
 
 		throw new IllegalArgumentException(String.format("Cannot map %s", expression));
@@ -297,6 +352,43 @@ public class QueryMapper {
 			@Nullable RelationalPersistentEntity<?> entity) {
 
 		Field propertyField = createPropertyField(entity, criteria.getColumn(), this.mappingContext);
+
+		if (propertyField.isEmbedded() && entity != null) {
+
+			Object value = criteria.getValue();
+
+			RelationalPersistentEntity<?> embeddedEntity = mappingContext
+					.getRequiredPersistentEntity(propertyField.getRequiredProperty());
+			PersistentPropertyAccessor<Object> propertyAccessor = getEmbeddedPropertyAccessor(value, embeddedEntity,
+					propertyField);
+
+			Condition condition = Conditions.unrestricted();
+
+			for (RelationalPersistentProperty embeddedProperty : embeddedEntity) {
+
+				Object propertyValue = propertyAccessor.getProperty(embeddedProperty);
+
+				CriteriaWrapper cw = new CriteriaWrapper(criteria) {
+
+					@Override
+					public SqlIdentifier getColumn() {
+						return SqlIdentifier.unquoted(embeddedProperty.getName());
+					}
+
+					@Nullable
+					@Override
+					public Object getValue() {
+						return propertyValue;
+					}
+				};
+
+				Condition mapped = mapCondition(cw, bindings, table, embeddedEntity);
+				condition = condition.and(mapped);
+			}
+
+			return condition;
+		}
+
 		Column column = table.column(propertyField.getMappedColumnName());
 		TypeInformation<?> actualType = propertyField.getTypeHint().getRequiredActualType();
 
@@ -321,6 +413,39 @@ public class QueryMapper {
 		}
 
 		return createCondition(column, mappedValue, typeHint, bindings, comparator, criteria.isIgnoreCase());
+
+	}
+
+	static PersistentPropertyAccessor<Object> getEmbeddedPropertyAccessor(@Nullable Object value,
+			RelationalPersistentEntity<?> embeddedEntity, Field propertyField) {
+
+		if (value != null) {
+
+			Class<?> propertyType = embeddedEntity.getType();
+			if (!propertyType.isInstance(value)) {
+				throw new IllegalArgumentException("Value of property " + propertyField.getRequiredProperty().getName()
+						+ " is not an instance of " + embeddedEntity.getType().getName() + " but " + value.getClass().getName());
+			}
+
+			return embeddedEntity.getPropertyAccessor(value);
+		}
+
+		return new PersistentPropertyAccessor<>() {
+			@Override
+			public void setProperty(PersistentProperty<?> property, @org.jspecify.annotations.Nullable Object value) {
+
+			}
+
+			@Override
+			public @org.jspecify.annotations.Nullable Object getProperty(PersistentProperty<?> property) {
+				return null;
+			}
+
+			@Override
+			public Object getBean() {
+				return null;
+			}
+		};
 	}
 
 	private Escaper getEscaper(Comparator comparator) {
@@ -587,6 +712,25 @@ public class QueryMapper {
 		public TypeInformation<?> getTypeHint() {
 			return TypeInformation.OBJECT;
 		}
+
+		public boolean isEmbedded() {
+			return false;
+		}
+
+		public @org.jspecify.annotations.Nullable RelationalPersistentProperty getProperty() {
+			return null;
+		}
+
+		public RelationalPersistentProperty getRequiredProperty() {
+
+			RelationalPersistentProperty property = getProperty();
+
+			if (property == null) {
+				throw new IllegalStateException("No property found for field: " + this.name);
+			}
+
+			return property;
+		}
 	}
 
 	/**
@@ -633,13 +777,34 @@ public class QueryMapper {
 			this.mappingContext = context;
 
 			this.path = getPath(name.getReference());
-			this.property = this.path == null ? property : this.path.getLeafProperty();
+
+			RelationalPersistentProperty persistentProperty = null;
+			if (this.path != null) {
+
+				RelationalPersistentEntity<?> currentEntity = entity;
+				RelationalPersistentProperty currentProperty = null;
+				for (RelationalPersistentProperty p : path) {
+
+					currentProperty = currentEntity.getPersistentProperty(p.getName());
+
+					if (currentProperty == null) {
+						break;
+					}
+
+					if (currentProperty.isEntity()) {
+						currentEntity = mappingContext.getRequiredPersistentEntity(currentProperty);
+					}
+				}
+
+				persistentProperty = currentProperty;
+			}
+
+			this.property = persistentProperty;
 		}
 
 		@Override
 		public SqlIdentifier getMappedColumnName() {
-			return this.path == null || this.path.getLeafProperty() == null ? super.getMappedColumnName()
-					: this.path.getLeafProperty().getColumnName();
+			return this.property == null ? super.getMappedColumnName() : this.property.getColumnName();
 		}
 
 		/**
@@ -699,6 +864,92 @@ public class QueryMapper {
 			}
 
 			return this.property.getTypeInformation();
+		}
+
+		@Override
+		public boolean isEmbedded() {
+			return this.property != null && this.property.isEmbedded();
+		}
+
+		@Override
+		public @org.jspecify.annotations.Nullable RelationalPersistentProperty getProperty() {
+			return this.property;
+		}
+	}
+
+	abstract static class CriteriaWrapper extends AbstractCriteria {
+
+		private final CriteriaDefinition delegate;
+
+		public CriteriaWrapper(CriteriaDefinition delegate) {
+			this.delegate = delegate;
+		}
+
+		@Nullable
+		@Override
+		public Comparator getComparator() {
+			return delegate.getComparator();
+		}
+
+		@Override
+		public boolean isIgnoreCase() {
+			return delegate.isIgnoreCase();
+		}
+	}
+
+	abstract static class AbstractCriteria implements CriteriaDefinition {
+		@Override
+		public boolean isGroup() {
+			return false;
+		}
+
+		@Override
+		public List<CriteriaDefinition> getGroup() {
+			return List.of();
+		}
+
+		@Nullable
+		@Override
+		public SqlIdentifier getColumn() {
+			return null;
+		}
+
+		@Nullable
+		@Override
+		public Comparator getComparator() {
+			return null;
+		}
+
+		@Nullable
+		@Override
+		public Object getValue() {
+			return null;
+		}
+
+		@Override
+		public boolean isIgnoreCase() {
+			return false;
+		}
+
+		@Nullable
+		@Override
+		public CriteriaDefinition getPrevious() {
+			return null;
+		}
+
+		@Override
+		public boolean hasPrevious() {
+			return false;
+		}
+
+		@Override
+		public boolean isEmpty() {
+			return false;
+		}
+
+		@Override
+		public Combinator getCombinator() {
+			return null;
 		}
 	}
 }

--- a/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/core/DefaultReactiveDataAccessStrategyUnitTests.java
+++ b/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/core/DefaultReactiveDataAccessStrategyUnitTests.java
@@ -1,0 +1,54 @@
+package org.springframework.data.r2dbc.core;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.r2dbc.dialect.H2Dialect;
+import org.springframework.data.relational.core.mapping.Embedded;
+import org.springframework.data.relational.core.sql.SqlIdentifier;
+
+/**
+ * Unit tests for {@link DefaultReactiveDataAccessStrategy}.
+ *
+ * @author Jens Schauder
+ */
+class DefaultReactiveDataAccessStrategyUnitTests {
+
+	DefaultReactiveDataAccessStrategy dataAccessStrategy = new DefaultReactiveDataAccessStrategy(H2Dialect.INSTANCE);
+
+	@Test
+	void getAllColumns() {
+
+		SoftAssertions.assertSoftly(softly -> {
+			check(softly, SimpleEntity.class, "ID", "NAME");
+			check(softly, WithEmbedded.class, "ID", "L1_NAME", "L1_L2_NAME", "L1_L2_NUMBER");
+			check(softly, WithEmbeddedId.class, "ID_NAME", "ID_NUMBER", "NAME");
+		});
+	}
+
+	private void check(SoftAssertions softly, Class<?> entityType, String... columnNames) {
+
+		List<SqlIdentifier> sqlIdentifiers = Arrays.stream(columnNames).map(SqlIdentifier::quoted).toList();
+		softly.assertThat(dataAccessStrategy.getAllColumns(entityType)).describedAs(entityType.getName())
+				.containsExactlyInAnyOrder(sqlIdentifiers.toArray(new SqlIdentifier[0]));
+	}
+
+	record SimpleEntity(int id, String name) {
+	}
+
+	record WithEmbedded(int id, @Embedded.Empty(prefix = "L1_") Level1 level1) {
+	}
+
+	record Level1(String name, @Embedded.Empty(prefix = "L2_") Level2 l2) {
+	}
+
+	record Level2(String name, Integer number) {
+	}
+
+	record WithEmbeddedId(@Id @Embedded.Empty(prefix = "ID_") Level2 id, String name) {
+	}
+
+}

--- a/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/core/DefaultReactiveDataAccessStrategyUnitTests.java
+++ b/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/core/DefaultReactiveDataAccessStrategyUnitTests.java
@@ -1,10 +1,14 @@
 package org.springframework.data.r2dbc.core;
 
+import static org.assertj.core.api.Assertions.*;
+
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Stream;
 
-import org.assertj.core.api.SoftAssertions;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
 import org.springframework.data.annotation.Id;
 import org.springframework.data.r2dbc.dialect.H2Dialect;
 import org.springframework.data.relational.core.mapping.Embedded;
@@ -19,21 +23,28 @@ class DefaultReactiveDataAccessStrategyUnitTests {
 
 	DefaultReactiveDataAccessStrategy dataAccessStrategy = new DefaultReactiveDataAccessStrategy(H2Dialect.INSTANCE);
 
-	@Test
-	void getAllColumns() {
+	@ParameterizedTest
+	@MethodSource("fixtures")
+	void shouldReportAllColumns(Fixture fixture) {
 
-		SoftAssertions.assertSoftly(softly -> {
-			check(softly, SimpleEntity.class, "ID", "NAME");
-			check(softly, WithEmbedded.class, "ID", "L1_NAME", "L1_L2_NAME", "L1_L2_NUMBER");
-			check(softly, WithEmbeddedId.class, "ID_NAME", "ID_NUMBER", "NAME");
-		});
+		List<SqlIdentifier> sqlIdentifiers = Arrays.stream(fixture.allColumns()).map(SqlIdentifier::quoted).toList();
+
+		assertThat(dataAccessStrategy.getAllColumns(fixture.entityType()))
+				.containsExactlyInAnyOrder(sqlIdentifiers.toArray(new SqlIdentifier[0]));
 	}
 
-	private void check(SoftAssertions softly, Class<?> entityType, String... columnNames) {
+	static Stream<Fixture> fixtures() {
+		return Stream.of(new Fixture(SimpleEntity.class, "ID", "NAME"),
+				new Fixture(WithEmbedded.class, "ID", "L1_NAME", "L1_L2_NAME", "L1_L2_NUMBER"),
+				new Fixture(WithEmbeddedId.class, "ID_NAME", "ID_NUMBER", "NAME"));
+	}
 
-		List<SqlIdentifier> sqlIdentifiers = Arrays.stream(columnNames).map(SqlIdentifier::quoted).toList();
-		softly.assertThat(dataAccessStrategy.getAllColumns(entityType)).describedAs(entityType.getName())
-				.containsExactlyInAnyOrder(sqlIdentifiers.toArray(new SqlIdentifier[0]));
+	record Fixture(Class<?> entityType, String... allColumns) {
+
+		@Override
+		public String toString() {
+			return entityType.getSimpleName();
+		}
 	}
 
 	record SimpleEntity(int id, String name) {

--- a/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/query/QueryMapperUnitTests.java
+++ b/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/query/QueryMapperUnitTests.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Objects;
 
 import org.junit.jupiter.api.Test;
+
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.r2dbc.convert.MappingR2dbcConverter;
@@ -36,6 +37,7 @@ import org.springframework.data.r2dbc.dialect.PostgresDialect;
 import org.springframework.data.r2dbc.dialect.R2dbcDialect;
 import org.springframework.data.r2dbc.mapping.R2dbcMappingContext;
 import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Embedded;
 import org.springframework.data.relational.core.query.Criteria;
 import org.springframework.data.relational.core.sql.Expression;
 import org.springframework.data.relational.core.sql.Functions;
@@ -45,6 +47,7 @@ import org.springframework.data.relational.domain.SqlSort;
 import org.springframework.r2dbc.core.Parameter;
 import org.springframework.r2dbc.core.binding.BindMarkersFactory;
 import org.springframework.r2dbc.core.binding.BindTarget;
+
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.JsonNode;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.node.TextNode;
 
@@ -541,12 +544,94 @@ class QueryMapperUnitTests {
 		assertThat(bindings.getBindings().iterator().next().getValue()).isEqualTo("foo");
 	}
 
+	@Test // GH-2096
+	void shouldMapPathToEmbeddable() {
+
+		Criteria criteria = Criteria.where("home").is(new Address(new Country("DE")));
+
+		BoundCondition bindings = map(criteria, WithEmbeddable.class);
+
+		assertThat(bindings.getCondition())
+				.hasToString("withembeddable.home_country_name = ?[$1] AND withembeddable.home_street = ?[$2]");
+	}
+
+	@Test // GH-2096
+	void shouldMapPathToNestedEmbeddable() {
+
+		Criteria criteria = Criteria.where("home.country").is(new Country("DE"));
+
+		BoundCondition bindings = map(criteria, WithEmbeddable.class);
+
+		assertThat(bindings.getCondition()).hasToString("withembeddable.home_country_name = ?[$1]");
+	}
+
+	@Test // GH-2096
+	void shouldMapPathIntoEmbeddable() {
+
+		Criteria criteria = Criteria.where("home.country.name").is("DE");
+
+		BoundCondition bindings = map(criteria, WithEmbeddable.class);
+
+		assertThat(bindings.getCondition()).hasToString("withembeddable.home_country_name = ?[$1]");
+	}
+
+	@Test // GH-2096
+	void shouldMapSortPathForEmbeddable() {
+
+		List<OrderByField> orderByFields = map(Sort.by("home"), WithEmbeddable.class);
+
+		Table table = Table.create("withembeddable");
+		assertThat(orderByFields).contains(OrderByField.from(table.column("home_country_name"), Sort.Direction.ASC))
+				.contains(OrderByField.from(table.column("home_street"), Sort.Direction.ASC));
+	}
+
+	@Test // GH-2096
+	void shouldMapSortPathIntoNestedEmbeddable() {
+
+		List<OrderByField> orderByFields = map(Sort.by("home.country"), WithEmbeddable.class);
+
+		Table table = Table.create("withembeddable");
+		assertThat(orderByFields).contains(OrderByField.from(table.column("home_country_name"), Sort.Direction.ASC));
+	}
+
+	@Test // GH-2096
+	void shouldMapSortPathIntoEmbeddable() {
+
+		List<OrderByField> orderByFields = map(Sort.by("home.country.name"), WithEmbeddable.class);
+
+		Table table = Table.create("withembeddable");
+		assertThat(orderByFields).contains(OrderByField.from(table.column("home_country_name"), Sort.Direction.ASC));
+	}
+
+	@Test // GH-2096
+	void shouldMapSelectionForEmbeddable() {
+
+		Table table = Table.create("my_table").as("my_aliased_table");
+
+		List<Expression> mappedObject = mapper.getMappedObjects(table.column("home"),
+				mapper.getMappingContext().getRequiredPersistentEntity(WithEmbeddable.class));
+
+		assertThat(mappedObject).extracting(Expression::toString) //
+				.hasSize(2) //
+				.contains("my_aliased_table.home_street", "my_aliased_table.home_country_name");
+	}
+
 	private BoundCondition map(Criteria criteria) {
+		return map(criteria, Person.class);
+	}
+
+	private BoundCondition map(Criteria criteria, Class<?> entityType) {
 
 		BindMarkersFactory markers = BindMarkersFactory.indexed("$", 1);
 
-		return mapper.getMappedObject(markers.create(), criteria, Table.create("person"),
-				mapper.getMappingContext().getRequiredPersistentEntity(Person.class));
+		return mapper.getMappedObject(markers.create(), criteria, Table.create(entityType.getSimpleName().toLowerCase()),
+				mapper.getMappingContext().getRequiredPersistentEntity(entityType));
+	}
+
+	private List<OrderByField> map(Sort sort, Class<?> entityType) {
+
+		return mapper.getMappedSort(Table.create(entityType.getSimpleName().toLowerCase()), sort,
+				mapper.getMappingContext().getRequiredPersistentEntity(entityType));
 	}
 
 	static class Person {
@@ -558,6 +643,32 @@ class QueryMapperUnitTests {
 		boolean state;
 
 		JsonNode jsonNode;
+	}
+
+	static class WithEmbeddable {
+
+		@Embedded.Nullable(prefix = "home_") Address home;
+
+		@Embedded.Nullable(prefix = "work_") Address work;
+	}
+
+	static class Address {
+
+		@Embedded.Nullable(prefix = "country_") Country country;
+		String street;
+
+		public Address(Country country) {
+			this.country = country;
+		}
+	}
+
+	static class Country {
+
+		String name;
+
+		public Country(String name) {
+			this.name = name;
+		}
 	}
 
 	enum MyEnum {

--- a/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/query/UpdateMapperUnitTests.java
+++ b/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/query/UpdateMapperUnitTests.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
-
 import org.springframework.data.r2dbc.convert.MappingR2dbcConverter;
 import org.springframework.data.r2dbc.convert.R2dbcConverter;
 import org.springframework.data.r2dbc.dialect.PostgresDialect;
@@ -102,7 +101,8 @@ public class UpdateMapperUnitTests {
 
 		BoundAssignments mapped = map(update);
 
-		Map<SqlIdentifier, Expression> assignments = mapped.getAssignments().stream().map(it -> (AssignValue) it)
+		Map<SqlIdentifier, Expression> assignments = mapped.getAssignments().stream() //
+				.map(it -> (AssignValue) it) //
 				.collect(Collectors.toMap(k -> k.getColumn().getName(), AssignValue::getValue));
 
 		assertThat(update.getAssignments()).hasSize(3);
@@ -117,11 +117,15 @@ public class UpdateMapperUnitTests {
 
 		BoundAssignments mapped = map(update, WithEmbeddable.class);
 
-		Map<SqlIdentifier, Expression> assignments = mapped.getAssignments().stream().map(it -> (AssignValue) it)
+		Map<SqlIdentifier, Expression> assignments = mapped.getAssignments().stream() //
+				.map(it -> (AssignValue) it) //
 				.collect(Collectors.toMap(k -> k.getColumn().getName(), AssignValue::getValue));
 
-		assertThat(assignments).hasSize(2).containsEntry(SqlIdentifier.unquoted("home_country_name"), SQL.bindMarker("$1"))
-				.containsEntry(SqlIdentifier.unquoted("home_street"), SQL.bindMarker("$2"));
+		assertThat(assignments).containsExactlyInAnyOrderEntriesOf( //
+				Map.of( //
+						SqlIdentifier.unquoted("home_country_name"), SQL.bindMarker("$1"), //
+						SqlIdentifier.unquoted("home_street"), SQL.bindMarker("$2")//
+				));
 
 		mapped.getBindings().forEach(it -> {
 			assertThat(it.getValue()).isIn("DE", "foo");
@@ -135,10 +139,14 @@ public class UpdateMapperUnitTests {
 
 		BoundAssignments mapped = map(update, WithEmbeddable.class);
 
-		Map<SqlIdentifier, Expression> assignments = mapped.getAssignments().stream().map(it -> (AssignValue) it)
+		Map<SqlIdentifier, Expression> assignments = mapped.getAssignments().stream() //
+				.map(it -> (AssignValue) it) //
 				.collect(Collectors.toMap(k -> k.getColumn().getName(), AssignValue::getValue));
 
-		assertThat(assignments).hasSize(1).containsEntry(SqlIdentifier.unquoted("home_country_name"), SQL.bindMarker("$1"));
+		assertThat(assignments) //
+				.hasSize(1) //
+				.containsEntry(SqlIdentifier.unquoted("home_country_name"), SQL.bindMarker("$1"));
+
 		mapped.getBindings().forEach(it -> {
 			assertThat(it.getValue()).isEqualTo("DE");
 		});
@@ -151,10 +159,14 @@ public class UpdateMapperUnitTests {
 
 		BoundAssignments mapped = map(update, WithEmbeddable.class);
 
-		Map<SqlIdentifier, Expression> assignments = mapped.getAssignments().stream().map(it -> (AssignValue) it)
+		Map<SqlIdentifier, Expression> assignments = mapped.getAssignments().stream()//
+				.map(it -> (AssignValue) it) //
 				.collect(Collectors.toMap(k -> k.getColumn().getName(), AssignValue::getValue));
 
-		assertThat(assignments).hasSize(1).containsEntry(SqlIdentifier.unquoted("home_country_name"), SQL.bindMarker("$1"));
+		assertThat(assignments) //
+				.hasSize(1) //
+				.containsEntry(SqlIdentifier.unquoted("home_country_name"), SQL.bindMarker("$1"));
+
 		mapped.getBindings().forEach(it -> {
 			assertThat(it.getValue()).isEqualTo("DE");
 		});

--- a/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/repository/H2R2dbcRepositoryEmbeddedIntegrationTests.java
+++ b/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/repository/H2R2dbcRepositoryEmbeddedIntegrationTests.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2018-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.r2dbc.repository;
+
+import io.r2dbc.spi.ConnectionFactory;
+import reactor.core.publisher.Hooks;
+import reactor.test.StepVerifier;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.r2dbc.config.AbstractR2dbcConfiguration;
+import org.springframework.data.r2dbc.convert.R2dbcCustomConversions;
+import org.springframework.data.r2dbc.mapping.R2dbcMappingContext;
+import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories;
+import org.springframework.data.r2dbc.testing.H2TestSupport;
+import org.springframework.data.r2dbc.testing.R2dbcIntegrationTestSupport;
+import org.springframework.data.relational.RelationalManagedTypes;
+import org.springframework.data.relational.core.mapping.Embedded;
+import org.springframework.data.relational.core.mapping.NamingStrategy;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * Tests for support of embedded entities.
+ *
+ * @author Jens Schauder
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration
+class H2R2dbcRepositoryEmbeddedIntegrationTests extends R2dbcIntegrationTestSupport {
+
+	static {
+		Hooks.onOperatorDebug();
+	}
+
+	@Autowired private PersonRepository repository;
+	@Autowired private ConnectionFactory connectionFactory;
+	protected JdbcTemplate jdbc;
+
+	@Configuration
+	@EnableR2dbcRepositories(considerNestedRepositories = true,
+			includeFilters = @ComponentScan.Filter(classes = PersonRepository.class, type = FilterType.ASSIGNABLE_TYPE))
+	static class IntegrationTestConfiguration extends AbstractR2dbcConfiguration {
+
+		@Bean
+		@Override
+		public ConnectionFactory connectionFactory() {
+			return H2TestSupport.createConnectionFactory();
+		}
+
+		@Override
+		public R2dbcMappingContext r2dbcMappingContext(Optional<NamingStrategy> namingStrategy,
+				R2dbcCustomConversions r2dbcCustomConversions, RelationalManagedTypes r2dbcManagedTypes) {
+
+			R2dbcMappingContext context = super.r2dbcMappingContext(namingStrategy, r2dbcCustomConversions,
+					r2dbcManagedTypes);
+			context.setForceQuote(false);
+
+			return context;
+		}
+
+		@Bean
+		public H2R2dbcRepositoryIntegrationTests.AfterConvertCallbackRecorder afterConvertCallbackRecorder() {
+			return new H2R2dbcRepositoryIntegrationTests.AfterConvertCallbackRecorder();
+		}
+	}
+
+	@BeforeEach
+	void before() {
+
+		this.jdbc = createJdbcTemplate(createDataSource());
+
+		try {
+			this.jdbc.execute("DROP TABLE person");
+		} catch (DataAccessException e) {}
+
+		this.jdbc.execute(getCreateTableStatement());
+	}
+
+	/**
+	 * Creates a {@link DataSource} to be used in this test.
+	 *
+	 * @return the {@link DataSource} to be used in this test.
+	 */
+	DataSource createDataSource() {
+		return H2TestSupport.createDataSource();
+	}
+
+	String getCreateTableStatement() {
+		return "create table person(id integer AUTO_INCREMENT PRIMARY KEY, name_first varchar(50), name_last varchar(50))";
+	}
+
+	@Test // GH-2096
+	void shouldInsertNewItems() {
+
+		Person frodo = new Person(null, new Name("Frodo", "Baggins"));
+		Person sam = new Person(null, new Name("Sam", "Gamgee"));
+
+		repository.saveAll(Arrays.asList(frodo, sam)) //
+				.as(StepVerifier::create) //
+				.expectNextMatches(person -> person.id != null) //
+				.expectNextMatches(person -> person.id != null) //
+				.verifyComplete();
+	}
+
+	@Test // GH-2096
+	void shouldReadNewItems() {
+
+		shouldInsertNewItems();
+
+		Set<String> firstNames = Set.of("Frodo", "Sam");
+
+		repository.findAll() //
+				.as(StepVerifier::create) //
+				.assertNext(p -> firstNames.contains(p.name.first)) //
+				.assertNext(p -> firstNames.contains(p.name.first)) //
+				.verifyComplete();
+	}
+
+	interface PersonRepository extends ReactiveCrudRepository<Person, Integer> {}
+
+	record Person(@Id Integer id, @Embedded.Empty(prefix = "name_") Name name) {
+
+	}
+
+	record Name(String first, String last) {
+
+	}
+
+}

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-relational</artifactId>
-	<version>4.0.0-SNAPSHOT</version>
+	<version>4.0.0-2011-embedded-SNAPSHOT</version>
 
 	<name>Spring Data Relational</name>
 	<description>Spring Data Relational support</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>4.0.0-SNAPSHOT</version>
+		<version>4.0.0-2011-embedded-SNAPSHOT</version>
 	</parent>
 
 	<properties>


### PR DESCRIPTION
R2DBC now has minimal support for embedded entities.
We can read and write them.
And we can use them as ids.

Closes #2012
Closes #2011 