### PR TITLE
Docs: Add Person entity example to JDBC getting started section

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -30,6 +30,17 @@ Here is a quick teaser of an application using Spring Data JDBC Repositories in 
 
 [source,java]
 ----
+@Table("person")
+public class Person {
+
+    @Id
+    private Long id;
+    private String firstname;
+    private String lastname;
+
+    // getters and setters
+}
+
 interface PersonRepository extends CrudRepository<Person, Long> {
 
     @Query("SELECT * FROM person WHERE lastname = :lastname")


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [ x ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ x ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

## Summary
This PR improves the **Getting Started with JDBC** section of the documentation by adding the missing `Person` entity class to the example.  
Previously, the docs showed `PersonRepository`, `MyService`, and `ApplicationConfig` without the corresponding entity, which could confuse new users.  

By including the entity definition, the example is now **self-contained** and easier to follow.  

### Example Change

```java
@Table("person")
public class Person {

    @Id
    private Long id;
    private String firstname;
    private String lastname;

    // getters and setters
}
