### PR TITLE
Consider JDBCType in String-based repository queries

### DIFF
--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/StringBasedJdbcQuery.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/StringBasedJdbcQuery.java
@@ -261,10 +261,10 @@ public class StringBasedJdbcQuery extends AbstractJdbcQuery {
 			JdbcValue jdbcValue = JdbcValueBindUtil.getBindValue(converter, value, parameter);
 			SQLType jdbcType = jdbcValue.getJdbcType();
 
-			if (jdbcType == JDBCType.OTHER) {
-				parameters.addValue(parameterName, jdbcValue.getValue());
-			} else {
+			if (jdbcType != null) {
 				parameters.addValue(parameterName, jdbcValue.getValue(), jdbcType.getVendorTypeNumber());
+			} else {
+				parameters.addValue(parameterName, jdbcValue.getValue());
 			}
 		}
 


### PR DESCRIPTION
This PR addresses GH-2188 (Converters with JDBCType.OTHER broken).

### Summary

Custom converters that return `JdbcValue` with `JDBCType.OTHER` stopped working correctly for string-based queries.  
`StringBasedJdbcQuery` treated `JDBCType.OTHER` as a special case and did not register its SQL type when binding parameters, so the JDBC driver did not see `Types.OTHER` anymore.

### Changes

* Update `StringBasedJdbcQuery.bindParameters(…)` to register the SQL type for all non-null `SQLType` values, including `JDBCType.OTHER`, and only fall back to the type-less `addValue(name, value)` overload when the JDBC type is actually `null`.
* Add a regression test to `StringBasedJdbcQueryUnitTests` that:
  * uses a custom `@WritingConverter` returning `JdbcValue.of(…, JDBCType.OTHER)`,
  * executes a string-based query method,
  * and asserts that the resulting `SqlParameterSource` exposes `Types.OTHER` for the bound parameter.

This restores the behavior for PostgreSQL enum/custom types and other use cases that rely on `JDBCType.OTHER` in custom converters.

Closes #2188