### PR TITLE
Align AOT metadata query rendering for IgnoreCase

### DIFF
--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/QueryMapper.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/QueryMapper.java
@@ -57,6 +57,7 @@ import org.springframework.util.ClassUtils;
  * @author Yan Qiang
  * @author Mikhail Fedorov
  * @author Christoph Strobl
+ * @author wonderfulrosemari
  * @since 3.0
  */
 public class QueryMapper {
@@ -692,18 +693,16 @@ public class QueryMapper {
 		}
 
 		Object settableValueValue = settableValue.getValue();
+		@Nullable
+		SQLType jdbcType = settableValue.getJdbcType();
 
 		Assert.state(settableValueValue != null, "Settable value must not be null");
 
 		if (mappedValue.getClass().equals(settableValueValue.getClass())) {
-			return JdbcUtil.TYPE_UNKNOWN;
+			return jdbcType != null ? jdbcType : JdbcUtil.TYPE_UNKNOWN;
 		}
 
-		SQLType jdbcType = settableValue.getJdbcType();
-
-		Assert.state(jdbcType != null, "JDBC type must not be null");
-
-		return jdbcType;
+		return jdbcType != null ? jdbcType : JdbcUtil.TYPE_UNKNOWN;
 	}
 
 	private Expression bind(@Nullable Object mappedValue, SQLType sqlType, MapSqlParameterSource parameterSource,

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/aot/PlaceholderAccessor.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/aot/PlaceholderAccessor.java
@@ -39,6 +39,7 @@ import org.springframework.util.Assert;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author wonderfulrosemari
  * @since 4.0
  */
 class PlaceholderAccessor {
@@ -81,7 +82,7 @@ class PlaceholderAccessor {
 			return cp;
 		}
 
-		if(value instanceof Collection<?> c && c.iterator().hasNext()) {
+		if (value instanceof Collection<?> c && c.iterator().hasNext()) {
 			return unwrap(c.iterator().next());
 		}
 
@@ -140,11 +141,17 @@ class PlaceholderAccessor {
 					|| partType == Part.Type.NOT_CONTAINING) {
 				return JdbcValue.of(
 						capturingJdbcValue.withBinding(ParameterBinding.like(capturingJdbcValue.getBinding(), partType)),
-						JDBCType.OTHER);
+						parameterSqlType(valueType));
 			}
 
 			return JdbcValue.of(capturingJdbcValue.withValue(super.prepareParameterValue(value, valueType, partType)),
-					JDBCType.OTHER);
+					parameterSqlType(valueType));
+		}
+
+		private static JDBCType parameterSqlType(Class<?> valueType) {
+			return CharSequence.class.isAssignableFrom(valueType) || valueType == Character.class || valueType == char.class
+					? JDBCType.VARCHAR
+					: JDBCType.OTHER;
 		}
 
 	}

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/aot/JdbcRepositoryMetadataIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/aot/JdbcRepositoryMetadataIntegrationTests.java
@@ -51,6 +51,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
  * Integration tests for the {@link UserRepository} JSON metadata via {@link JdbcRepositoryContributor}.
  *
  * @author Mark Paluch
+ * @author wonderfulrosemari
  */
 @SpringJUnitConfig(classes = JdbcRepositoryMetadataIntegrationTests.JdbcRepositoryContributorConfiguration.class)
 class JdbcRepositoryMetadataIntegrationTests {
@@ -125,6 +126,22 @@ class JdbcRepositoryMetadataIntegrationTests {
 		assertThatJson(json).inPath("$.methods[?(@.name == 'findByFirstname')].query").isArray().first().isObject()
 				.hasEntrySatisfying("query", value -> assertThat(value).asString().contains("SELECT \"MY_USER\".\"ID\"",
 						"FROM \"MY_USER\" WHERE \"MY_USER\".\"FIRSTNAME\" = :firstname"));
+	}
+
+	@Test // GH-2239
+	void shouldDocumentDerivedQueryWithIgnoreCase() throws IOException {
+
+		Resource resource = getResource();
+
+		assertThat(resource).isNotNull();
+		assertThat(resource.exists()).isTrue();
+
+		String json = resource.getContentAsString(StandardCharsets.UTF_8);
+
+		assertThatJson(json).inPath("$.methods[?(@.name == 'findByFirstnameIgnoreCase')].query").isArray().first()
+				.isObject()
+				.hasEntrySatisfying("query", value -> assertThat(value).asString().contains("SELECT \"MY_USER\".\"ID\"",
+						"FROM \"MY_USER\" WHERE UPPER(\"MY_USER\".\"FIRSTNAME\") = UPPER(:firstname)"));
 	}
 
 	@Test // GH-2121

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/aot/UserRepository.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/aot/UserRepository.java
@@ -38,6 +38,8 @@ public interface UserRepository extends CrudRepository<User, Integer> {
 
 	User findByFirstname(String name);
 
+	User findByFirstnameIgnoreCase(String name);
+
 	User findByFirstnameLike(String name);
 
 	User findByFirstnameStartingWith(String name);


### PR DESCRIPTION
Closes gh-2239

Align AOT-derived query metadata with runtime SQL rendering for IgnoreCase predicates.

Previously, AOT metadata rendered derived IgnoreCase queries as:
`"column" = UPPER(:param)`

while runtime query execution renders:
`UPPER("column") = UPPER(:param)`

Changes include:
- preserving string SQL type hints in AOT placeholder metadata for captured parameters
- keeping provided `JdbcValue` SQL type hints in `QueryMapper` when mapping criteria values
- adding regression coverage in `JdbcRepositoryMetadataIntegrationTests` for `findByFirstnameIgnoreCase`
- adding `findByFirstnameIgnoreCase` to the AOT test repository interface
