### PR TITLE
Consider convertible argument types in in JDBC query derivation

### DIFF
--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/JdbcQueryCreator.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/JdbcQueryCreator.java
@@ -48,6 +48,7 @@ import org.springframework.util.Assert;
  * @author Jens Schauder
  * @author Myeonghyeon Lee
  * @author Diego Krupitza
+ * @author wonderfulrosemari
  * @since 2.0
  */
 public class JdbcQueryCreator extends RelationalQueryCreator<ParametrizedQuery> {

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/PartTreeJdbcQuery.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/PartTreeJdbcQuery.java
@@ -61,6 +61,7 @@ import org.springframework.util.Assert;
  * @author Mikhail Polivakha
  * @author Yunyoung LEE
  * @author Nikita Konev
+ * @author wonderfulrosemari
  * @since 2.0
  */
 public class PartTreeJdbcQuery extends AbstractJdbcQuery {

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/query/PartTreeJdbcQueryUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/query/PartTreeJdbcQueryUnitTests.java
@@ -74,6 +74,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
  * @author Jens Schauder
  * @author Myeonghyeon Lee
  * @author Diego Krupitza
+ * @author wonderfulrosemari
  */
 @ExtendWith(MockitoExtension.class)
 public class PartTreeJdbcQueryUnitTests {


### PR DESCRIPTION
Closes #2059

Fix query-derivation validation so value objects with registered
Reading/Writing converters are treated as queryable simple properties.

Previously, repository methods like `findAllByRef(CustomerRef ref)` could fail
with `Cannot query by nested entity: ref` even when a custom write target was
configured.

Changes include:
- passing `JdbcConverter` into `JdbcQueryCreator.validate(...)`
- allowing entity-like leaf properties when a custom write target exists
- adding regression coverage in `PartTreeJdbcQueryUnitTests` for converter-backed value objects
- adding author headers in touched classes

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
