### PR TITLE
Mentioning the support of 'IgnoreCase' for String

### DIFF
--- a/src/main/antora/modules/ROOT/pages/jdbc/query-methods.adoc
+++ b/src/main/antora/modules/ROOT/pages/jdbc/query-methods.adoc
@@ -119,6 +119,10 @@ The following table shows the keywords that are supported for query methods:
 | `findByFirstnameNotContaining(String name)`
 | `firstname NOT LIKE '%' + name + '%'`
 
+| `IgnoreCase` on String
+| `findByFirstnameLikeIgnoreCase(String name)`
+| `UPPER(firstname) LIKE '%' + UPPER(name) + '%'`
+
 | `(No keyword)`
 | `findByFirstname(String name)`
 | `firstname = name`


### PR DESCRIPTION
I think it is worth mentioning that Spring Data JDBC supports `IgnoreCase` for String objects. Although, perhaps, the implementation is subject to change (see #2101)