### PR TITLE
Expand composite id for (not) in queries targeting association properties.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-relational-parent</artifactId>
-	<version>4.1.0-SNAPSHOT</version>
+	<version>4.1.x-GH-2276-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Relational Parent</name>

--- a/spring-data-jdbc-distribution/pom.xml
+++ b/spring-data-jdbc-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.1.x-GH-2276-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-jdbc</artifactId>
-	<version>4.1.0-SNAPSHOT</version>
+	<version>4.1.x-GH-2276-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.1.x-GH-2276-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/QueryMapper.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/QueryMapper.java
@@ -52,6 +52,7 @@ import org.springframework.data.relational.core.sql.Expression;
 import org.springframework.data.relational.core.sql.Expressions;
 import org.springframework.data.relational.core.sql.Functions;
 import org.springframework.data.relational.core.sql.OrderByField;
+import org.springframework.data.relational.core.sql.OrCondition;
 import org.springframework.data.relational.core.sql.SQL;
 import org.springframework.data.relational.core.sql.SimpleFunction;
 import org.springframework.data.relational.core.sql.SqlIdentifier;
@@ -319,7 +320,6 @@ public class QueryMapper {
 		// Single embedded entity
 		if (propertyField.isEmbedded()) {
 
-			// IN/NOT_IN with collection of composite/embedded values: expand to (… AND …) OR (…)
 			if ((Comparator.IN.equals(comparator) || Comparator.NOT_IN.equals(comparator))
 					&& value instanceof Collection<?> collection) {
 
@@ -333,6 +333,9 @@ public class QueryMapper {
 					.getRequiredPersistentEntity(propertyField.getRequiredProperty());
 
 			Condition condition = mapEmbeddedObjectCondition(criteria, parameterSource, table, embeddedEntity, embedded);
+			if (!embedded && condition instanceof OrCondition) {
+				return Conditions.nest(condition);
+			}
 			return embedded || !(condition instanceof AndCondition) ? condition : Conditions.nest(condition);
 		}
 
@@ -396,6 +399,9 @@ public class QueryMapper {
 	/**
 	 * Expands {@link Comparator#IN}/{@link Comparator#NOT_IN} over a collection to a disjunction of nested conditions,
 	 * one per element (used for embedded types and composite association identifiers).
+	 * <p>
+	 * IN: (col = v AND …) OR (…) per element.
+	 * NOT_IN: AND over tuple negations; each negation is (col != v OR …), i.e. NOT (c1 = v1 AND c2 = v2) ≡ (c1 != v1 OR c2 != v2).
 	 */
 	@SuppressWarnings("NullAway")
 	private Condition expandInCollectionComparison(Comparator comparator, Collection<?> collection,
@@ -408,9 +414,8 @@ public class QueryMapper {
 		Condition condition = null;
 		for (Object element : collection) {
 			Condition next = Conditions.nest(nestedConditionFactory.apply(element));
-			condition = condition == null ? next : condition.or(next);
+			condition = condition == null ? next : (Comparator.IN.equals(comparator) ? condition.or(next) : condition.and(next));
 		}
-
 		return condition;
 	}
 
@@ -516,17 +521,22 @@ public class QueryMapper {
 
 		PersistentPropertyAccessor<Object> embeddedAccessor = embeddedEntity.getPropertyAccessor(criteria.getValue());
 
-		Condition condition = Conditions.unrestricted();
+		Comparator tupleComparator = criteria.getComparator();
+		Assert.notNull(tupleComparator, "Comparator must not be null");
+
+		boolean negateTuple = Comparator.NEQ.equals(tupleComparator);
+
+		Condition condition = null;
 		for (RelationalPersistentProperty embeddedProperty : embeddedEntity) {
 
 			Object propertyValue = embeddedAccessor.getProperty(embeddedProperty);
 
 			CriteriaDefinition cw = new EmbeddedPropertyCriteria(criteria, embeddedProperty, propertyValue);
 			Condition mapped = mapCondition(cw, parameterSource, table, embeddedEntity, embedded);
-			condition = condition.and(mapped);
+			condition = condition == null ? mapped : (negateTuple ? condition.or(mapped) : condition.and(mapped));
 		}
 
-		return condition;
+		return condition != null ? condition : Conditions.unrestricted();
 	}
 
 	@Nullable

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/QueryMapper.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/QueryMapper.java
@@ -22,14 +22,15 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.regex.Pattern;
 
 import org.jspecify.annotations.Nullable;
-
 import org.springframework.data.core.PropertyPath;
 import org.springframework.data.core.PropertyReferenceException;
 import org.springframework.data.core.TypeInformation;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.jdbc.core.mapping.AggregateReference;
 import org.springframework.data.jdbc.core.mapping.JdbcValue;
 import org.springframework.data.jdbc.support.JdbcUtil;
 import org.springframework.data.mapping.MappingException;
@@ -41,12 +42,27 @@ import org.springframework.data.relational.core.mapping.RelationalPersistentProp
 import org.springframework.data.relational.core.query.CriteriaDefinition;
 import org.springframework.data.relational.core.query.CriteriaDefinition.Comparator;
 import org.springframework.data.relational.core.query.ValueFunction;
-import org.springframework.data.relational.core.sql.*;
+import org.springframework.data.relational.core.sql.Aliased;
+import org.springframework.data.relational.core.sql.AndCondition;
+import org.springframework.data.relational.core.sql.AsteriskFromTable;
+import org.springframework.data.relational.core.sql.Column;
+import org.springframework.data.relational.core.sql.Condition;
+import org.springframework.data.relational.core.sql.Conditions;
+import org.springframework.data.relational.core.sql.Expression;
+import org.springframework.data.relational.core.sql.Expressions;
+import org.springframework.data.relational.core.sql.Functions;
+import org.springframework.data.relational.core.sql.OrderByField;
+import org.springframework.data.relational.core.sql.SQL;
+import org.springframework.data.relational.core.sql.SimpleFunction;
+import org.springframework.data.relational.core.sql.SqlIdentifier;
+import org.springframework.data.relational.core.sql.Table;
+import org.springframework.data.relational.core.sql.TableLike;
 import org.springframework.data.relational.domain.SqlSort;
 import org.springframework.data.util.Pair;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
+import org.springframework.util.CollectionUtils;
 
 /**
  * Maps {@link CriteriaDefinition} and {@link Sort} objects considering mapping metadata and dialect-specific
@@ -305,40 +321,10 @@ public class QueryMapper {
 
 			// IN/NOT_IN with collection of composite/embedded values: expand to (… AND …) OR (…)
 			if ((Comparator.IN.equals(comparator) || Comparator.NOT_IN.equals(comparator))
-				&& value instanceof Collection<?> collection) {
+					&& value instanceof Collection<?> collection) {
 
-				Condition condition = null;
-
-				for (Object o : collection) {
-
-					CriteriaWrapper cw = new CriteriaWrapper(criteria) {
-
-						@Override
-						public @Nullable Comparator getComparator() {
-							return Comparator.IN.equals(comparator) ? Comparator.EQ : Comparator.NEQ;
-						}
-
-						@Nullable
-						@Override
-						public Object getValue() {
-							return o;
-						}
-
-						@Override
-						public @Nullable SqlIdentifier getColumn() {
-							return criteriaColumn;
-						}
-					};
-
-					Condition c = Conditions.nest(mapCondition(cw, parameterSource, table, entity, true));
-					condition = condition == null ? c : condition.or(c);
-				}
-
-				if (condition == null) {
-					return Comparator.IN.equals(comparator) ? Conditions.unrestricted().not() : Conditions.unrestricted();
-				}
-
-				return condition;
+				return expandInCollectionComparison(comparator, collection,
+						element -> mapCondition(new ListElementCriteria(criteria, element), parameterSource, table, entity, true));
 			}
 
 			PersistentPropertyPath<RelationalPersistentProperty> path = ((MetadataBackedField) propertyField).getPath();
@@ -348,6 +334,29 @@ public class QueryMapper {
 
 			Condition condition = mapEmbeddedObjectCondition(criteria, parameterSource, table, embeddedEntity, embedded);
 			return embedded || !(condition instanceof AndCondition) ? condition : Conditions.nest(condition);
+		}
+
+		// AggregateReference (and similar associations) to a composite identifier: expand IN/NOT_IN like embedded
+		if (propertyField instanceof MetadataBackedField metadataBackedField && metadataBackedField.property != null) {
+
+			RelationalPersistentProperty associationProperty = metadataBackedField.property;
+
+			if (Association.isAssociation(associationProperty)) {
+
+				Association association = Association.from(associationProperty, converter);
+
+				if (association.isComplexIdentifier() //
+						&& (Comparator.IN.equals(comparator) || Comparator.NOT_IN.equals(comparator))
+						&& value instanceof Collection<?> collection) {
+
+					RelationalPersistentEntity<?> identifierEntity = association.getRequiredTargetIdentifierEntity();
+
+					return expandInCollectionComparison(comparator, collection,
+							element -> mapEmbeddedObjectCondition(
+									new ListElementCriteria(criteria, unwrapAssociationCriteriaValue(element)), parameterSource, table,
+									identifierEntity, true));
+				}
+			}
 		}
 
 		TypeInformation<?> actualType = propertyField.getTypeHint().getRequiredActualType();
@@ -382,6 +391,27 @@ public class QueryMapper {
 		}
 
 		return createCondition(column, mappedValue, sqlType, parameterSource, comparator, criteria.isIgnoreCase());
+	}
+
+	/**
+	 * Expands {@link Comparator#IN}/{@link Comparator#NOT_IN} over a collection to a disjunction of nested conditions,
+	 * one per element (used for embedded types and composite association identifiers).
+	 */
+	@SuppressWarnings("NullAway")
+	private Condition expandInCollectionComparison(Comparator comparator, Collection<?> collection,
+			Function<Object, Condition> nestedConditionFactory) {
+
+		if (CollectionUtils.isEmpty(collection)) {
+			return Comparator.IN.equals(comparator) ? Conditions.unrestricted().not() : Conditions.unrestricted();
+		}
+
+		Condition condition = null;
+		for (Object element : collection) {
+			Condition next = Conditions.nest(nestedConditionFactory.apply(element));
+			condition = condition == null ? next : condition.or(next);
+		}
+
+		return condition;
 	}
 
 	/**
@@ -469,6 +499,15 @@ public class QueryMapper {
 		);
 	}
 
+	private static Object unwrapAssociationCriteriaValue(Object value) {
+
+		if (value instanceof AggregateReference<?, ?> aggregateReference) {
+			return aggregateReference.getId();
+		}
+
+		return value;
+	}
+
 	private Condition mapEmbeddedObjectCondition(CriteriaDefinition criteria, MapSqlParameterSource parameterSource,
 			Table table, RelationalPersistentEntity<?> embeddedEntity, boolean embedded) {
 
@@ -482,20 +521,7 @@ public class QueryMapper {
 
 			Object propertyValue = embeddedAccessor.getProperty(embeddedProperty);
 
-			CriteriaWrapper cw = new CriteriaWrapper(criteria) {
-
-				@Override
-				public SqlIdentifier getColumn() {
-					return SqlIdentifier.unquoted(embeddedProperty.getName());
-				}
-
-				@Nullable
-				@Override
-				public Object getValue() {
-					return propertyValue;
-				}
-			};
-
+			CriteriaDefinition cw = new EmbeddedPropertyCriteria(criteria, embeddedProperty, propertyValue);
 			Condition mapped = mapCondition(cw, parameterSource, table, embeddedEntity, embedded);
 			condition = condition.and(mapped);
 		}
@@ -742,12 +768,76 @@ public class QueryMapper {
 		return uniqueName;
 	}
 
+	/**
+	 * {@link CriteriaDefinition} view of one element when expanding {@code IN}/{@code NOT IN} over embedded or composite
+	 * identifier values.
+	 */
+	private static final class ListElementCriteria extends CriteriaWrapper {
+
+		// private final SqlIdentifier column;
+		// private final Comparator comparator;
+		private final Object elementValue;
+
+		ListElementCriteria(CriteriaDefinition delegate, Object elementValue) {
+			super(delegate);
+			// this.column = column;
+			// this.comparator = comparator;
+			this.elementValue = elementValue;
+		}
+
+		@Override
+		public @Nullable Comparator getComparator() {
+			Comparator elementComparator = getDelegate().getComparator();
+			return Comparator.IN.equals(elementComparator) ? Comparator.EQ : Comparator.NEQ;
+		}
+
+		@Override
+		public @Nullable SqlIdentifier getColumn() {
+			return getDelegate().getColumn();
+		}
+
+		@Override
+		public @Nullable Object getValue() {
+			return this.elementValue;
+		}
+	}
+
+	/**
+	 * {@link CriteriaDefinition} for a single property of an embedded object, delegating flags to the outer criteria.
+	 */
+	private static final class EmbeddedPropertyCriteria extends CriteriaWrapper {
+
+		private final SqlIdentifier propertyColumn;
+		private final @Nullable Object propertyValue;
+
+		EmbeddedPropertyCriteria(CriteriaDefinition delegate, RelationalPersistentProperty embeddedProperty,
+				@Nullable Object propertyValue) {
+			super(delegate);
+			this.propertyColumn = SqlIdentifier.unquoted(embeddedProperty.getName());
+			this.propertyValue = propertyValue;
+		}
+
+		@Override
+		public SqlIdentifier getColumn() {
+			return this.propertyColumn;
+		}
+
+		@Override
+		public @Nullable Object getValue() {
+			return this.propertyValue;
+		}
+	}
+
 	abstract static class CriteriaWrapper implements CriteriaDefinition {
 
 		private final CriteriaDefinition delegate;
 
 		public CriteriaWrapper(CriteriaDefinition delegate) {
 			this.delegate = delegate;
+		}
+
+		protected CriteriaDefinition getDelegate() {
+			return delegate;
 		}
 
 		@Nullable
@@ -760,6 +850,7 @@ public class QueryMapper {
 		public boolean isIgnoreCase() {
 			return delegate.isIgnoreCase();
 		}
+
 		@Override
 		public boolean isGroup() {
 			return false;
@@ -775,7 +866,6 @@ public class QueryMapper {
 		public SqlIdentifier getColumn() {
 			return null;
 		}
-
 
 		@Nullable
 		@Override

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/AbstractJdbcAggregateTemplateIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/AbstractJdbcAggregateTemplateIntegrationTests.java
@@ -236,7 +236,7 @@ abstract class AbstractJdbcAggregateTemplateIntegrationTests {
 	void upsertUpdatesExistingWithNullValues() {
 
 		long id = 8891L;
-		withSqlServerIdentityInsertOn(template, List.of("LEGO_SET", "MANUAL"), () -> {
+		withSqlServerIdentityInsertOn(template, List.of("LEGO_SET"), () -> {
 
 			LegoSet lego = new LegoSet();
 			lego.id = id;
@@ -245,7 +245,11 @@ abstract class AbstractJdbcAggregateTemplateIntegrationTests {
 			Manual manual = new Manual();
 			manual.id = 42L;
 			manual.content = "Accelerates to 99% of light speed; Destroys almost everything. See https://what-if.xkcd.com/1/";
-			lego.manual = manual;
+
+			// Only one table with identity insert on at the time guard
+			if (!(template.getDataAccessStrategy().getDialect() instanceof SqlServerDialect)) {
+				lego.manual = manual;
+			}
 
 			template.upsert(lego);
 
@@ -255,8 +259,12 @@ abstract class AbstractJdbcAggregateTemplateIntegrationTests {
 			LegoSet loaded = template.findById(id, LegoSet.class);
 
 			assertThat(loaded.name).isEqualTo(null);
-			assertThat(loaded.manual).isNotNull();
-			assertThat(loaded.manual.content).isEqualTo(manual.content);
+
+			if (!(template.getDataAccessStrategy().getDialect() instanceof SqlServerDialect)) {
+				assertThat(loaded.manual).isNotNull();
+				assertThat(loaded.manual.content).isEqualTo(manual.content);
+			}
+
 		});
 	}
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/QueryMapperUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/QueryMapperUnitTests.java
@@ -192,7 +192,7 @@ public class QueryMapperUnitTests {
 		criteria = Criteria.where("id").not(new CompositeId(1, "a")).or("foo").is("bar");
 
 		assertThat(map(criteria, WithCompositeId.class)).hasToString(
-				"(withcompositeid.\"TENANT\" != ?[:tenant3] AND withcompositeid.\"NAME\" != ?[:name4]) OR withcompositeid.foo = ?[:foo5]");
+				"(withcompositeid.\"TENANT\" != ?[:tenant3] OR withcompositeid.\"NAME\" != ?[:name4]) OR withcompositeid.foo = ?[:foo5]");
 	}
 
 	@Test // DATAJDBC-318
@@ -362,11 +362,11 @@ public class QueryMapperUnitTests {
 
 		Criteria criteria = Criteria.where("id").notIn(new CompositeId(1, "a"));
 		assertThat(map(criteria, WithCompositeId.class))
-				.hasToString("(withcompositeid.\"TENANT\" != ?[:tenant] AND withcompositeid.\"NAME\" != ?[:name])");
+				.hasToString("(withcompositeid.\"TENANT\" != ?[:tenant] OR withcompositeid.\"NAME\" != ?[:name])");
 
 		criteria = Criteria.where("id").notIn(new CompositeId(1, "a"), new CompositeId(2, "b"));
 		assertThat(map(criteria, WithCompositeId.class)).hasToString(
-				"(withcompositeid.\"TENANT\" != ?[:tenant2] AND withcompositeid.\"NAME\" != ?[:name3]) OR (withcompositeid.\"TENANT\" != ?[:tenant4] AND withcompositeid.\"NAME\" != ?[:name5])");
+				"(withcompositeid.\"TENANT\" != ?[:tenant2] OR withcompositeid.\"NAME\" != ?[:name3]) AND (withcompositeid.\"TENANT\" != ?[:tenant4] OR withcompositeid.\"NAME\" != ?[:name5])");
 
 		criteria = Criteria.where("id").notIn();
 		assertThat(map(criteria, WithCompositeId.class)).hasToString("1 = 1");
@@ -413,7 +413,7 @@ public class QueryMapperUnitTests {
 				context.getRequiredPersistentEntity(DependantRoot.class));
 
 		assertThat(condition).hasToString(
-				"(dependantroot.\"TENANT\" != ?[:tenant] AND dependantroot.\"NAME\" != ?[:name]) OR (dependantroot.\"TENANT\" != ?[:tenant2] AND dependantroot.\"NAME\" != ?[:name3])");
+				"(dependantroot.\"TENANT\" != ?[:tenant] OR dependantroot.\"NAME\" != ?[:name]) AND (dependantroot.\"TENANT\" != ?[:tenant2] OR dependantroot.\"NAME\" != ?[:name3])");
 	}
 
 	@Test

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/QueryMapperUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/QueryMapperUnitTests.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.jdbc.core.mapping.AggregateReference;
 import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Embedded;
@@ -371,6 +372,50 @@ public class QueryMapperUnitTests {
 		assertThat(map(criteria, WithCompositeId.class)).hasToString("1 = 1");
 	}
 
+	@Test // GH-2276
+	void shouldMapInForAggregateReferenceWithCompositeId() {
+
+		MapSqlParameterSource parameters = new MapSqlParameterSource();
+
+		Criteria criteria = Criteria.where("referredRoot").in(AggregateReference.to(new TargetCompositeId(1, "a")),
+				AggregateReference.to(new TargetCompositeId(2, "b")));
+
+		Condition condition = mapper.getMappedObject(parameters, criteria, Table.create("dependantroot"),
+				context.getRequiredPersistentEntity(DependantRoot.class));
+
+		assertThat(condition).hasToString(
+				"(dependantroot.\"TENANT\" = ?[:tenant] AND dependantroot.\"NAME\" = ?[:name]) OR (dependantroot.\"TENANT\" = ?[:tenant2] AND dependantroot.\"NAME\" = ?[:name3])");
+	}
+
+	@Test // GH-2276
+	void shouldMapInForBareCompositeIdWhenPropertyIsAggregateReference() {
+
+		MapSqlParameterSource parameters = new MapSqlParameterSource();
+
+		Criteria criteria = Criteria.where("referredRoot").in(List.of(new TargetCompositeId(1, "a"), new TargetCompositeId(2, "b")));
+
+		Condition condition = mapper.getMappedObject(parameters, criteria, Table.create("dependantroot"),
+				context.getRequiredPersistentEntity(DependantRoot.class));
+
+		assertThat(condition).hasToString(
+				"(dependantroot.\"TENANT\" = ?[:tenant] AND dependantroot.\"NAME\" = ?[:name]) OR (dependantroot.\"TENANT\" = ?[:tenant2] AND dependantroot.\"NAME\" = ?[:name3])");
+	}
+
+	@Test // GH-2276
+	void shouldMapNotInForAggregateReferenceWithCompositeId() {
+
+		MapSqlParameterSource parameters = new MapSqlParameterSource();
+
+		Criteria criteria = Criteria.where("referredRoot").notIn(AggregateReference.to(new TargetCompositeId(1, "a")),
+				AggregateReference.to(new TargetCompositeId(2, "b")));
+
+		Condition condition = mapper.getMappedObject(parameters, criteria, Table.create("dependantroot"),
+				context.getRequiredPersistentEntity(DependantRoot.class));
+
+		assertThat(condition).hasToString(
+				"(dependantroot.\"TENANT\" != ?[:tenant] AND dependantroot.\"NAME\" != ?[:name]) OR (dependantroot.\"TENANT\" != ?[:tenant2] AND dependantroot.\"NAME\" != ?[:name3])");
+	}
+
 	@Test
 	void shouldMapIsNotInWithCollectionToStringConverter() {
 
@@ -597,6 +642,18 @@ public class QueryMapperUnitTests {
 	}
 
 	private record WithCompositeId(@Id CompositeId id) {
+	}
+
+	private record TargetCompositeId(int tenant, String name) {
+	}
+
+	private static class ReferencedRoot {
+		@Id TargetCompositeId id;
+	}
+
+	private static class DependantRoot {
+
+		AggregateReference<ReferencedRoot, TargetCompositeId> referredRoot;
 	}
 
 	static class WithEmbeddable {

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/CompositeIdJdbcRepositoryIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/CompositeIdJdbcRepositoryIntegrationTests.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jdbc.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.jdbc.core.JdbcAggregateOperations;
+import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories;
+import org.springframework.data.jdbc.testing.IntegrationTest;
+import org.springframework.data.jdbc.testing.TestConfiguration;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Embedded;
+import org.springframework.data.relational.core.mapping.Table;
+import org.springframework.data.repository.CrudRepository;
+
+/**
+ * Integration tests for JDBC repositories with a composite {@link Id}.
+ * <p>
+ *
+ * @author Christoph Strobl
+ */
+@IntegrationTest
+class CompositeIdJdbcRepositoryIntegrationTests {
+
+	@Autowired WithCompositeIdRepository repository;
+
+	@Autowired JdbcAggregateOperations jdbcAggregateOperations;
+
+	@Test // GH-2276
+	void findAllByPkNotInUsesTupleSemanticsForCompositeId() {
+
+		this.jdbcAggregateOperations.insert(new WithCompositeId(new CompositeId(42, "HBAR"), "Walter"));
+		this.jdbcAggregateOperations.insert(new WithCompositeId(new CompositeId(23, "2PI"), "Jesse"));
+		this.jdbcAggregateOperations.insert(new WithCompositeId(new CompositeId(42, "2PI"), "Extra"));
+
+		List<WithCompositeId> rows = this.repository.findAllByPkNotIn(
+				List.of(new CompositeId(42, "HBAR"), new CompositeId(23, "2PI")));
+
+		assertThat(rows).singleElement() //
+				.satisfies(row -> {
+					assertThat(row.name()).isEqualTo("Extra");
+					assertThat(row.pk()).isEqualTo(new CompositeId(42, "2PI"));
+				});
+	}
+
+	@Configuration
+	@Import(TestConfiguration.class)
+	@EnableJdbcRepositories(considerNestedRepositories = true,
+			includeFilters = @ComponentScan.Filter(value = WithCompositeIdRepository.class, type = FilterType.ASSIGNABLE_TYPE))
+	static class Config {
+	}
+
+	interface WithCompositeIdRepository extends CrudRepository<WithCompositeId, CompositeId> {
+
+		List<WithCompositeId> findAllByPkNotIn(Collection<CompositeId> ids);
+	}
+
+	@Table("with_composite_id")
+	record WithCompositeId(@Id @Embedded.Nullable CompositeId pk, @Column("NAME") String name) {
+	}
+
+	record CompositeId(@Column("col_one") Integer one, @Column("col_two") String two) {
+	}
+}

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/CompositeIdJdbcRepositoryIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/CompositeIdJdbcRepositoryIntegrationTests.java
@@ -50,7 +50,7 @@ class CompositeIdJdbcRepositoryIntegrationTests {
 	@Autowired JdbcAggregateOperations jdbcAggregateOperations;
 
 	@Test // GH-2276
-	void findAllByPkNotInUsesTupleSemanticsForCompositeId() {
+	void findAllByCompositePkNotInLooksRowsUpCorrectly() {
 
 		this.jdbcAggregateOperations.insert(new WithCompositeId(new CompositeId(42, "HBAR"), "Walter"));
 		this.jdbcAggregateOperations.insert(new WithCompositeId(new CompositeId(23, "2PI"), "Jesse"));

--- a/spring-data-jdbc/src/test/resources/org.springframework.data.jdbc.repository/CompositeIdJdbcRepositoryIntegrationTests-db2.sql
+++ b/spring-data-jdbc/src/test/resources/org.springframework.data.jdbc.repository/CompositeIdJdbcRepositoryIntegrationTests-db2.sql
@@ -1,0 +1,12 @@
+DROP TABLE "with_composite_id";
+
+CREATE TABLE "with_composite_id"
+(
+    "col_one" INTEGER      NOT NULL,
+    "col_two" VARCHAR(255) NOT NULL,
+    "NAME"    VARCHAR(255),
+    PRIMARY KEY ("col_one", "col_two")
+);
+
+INSERT INTO "with_composite_id" ("col_one", "col_two", "NAME") VALUES (42, 'HBAR', 'Walter');
+INSERT INTO "with_composite_id" ("col_one", "col_two", "NAME") VALUES (23, '2PI', 'Jesse');

--- a/spring-data-jdbc/src/test/resources/org.springframework.data.jdbc.repository/CompositeIdJdbcRepositoryIntegrationTests-db2.sql
+++ b/spring-data-jdbc/src/test/resources/org.springframework.data.jdbc.repository/CompositeIdJdbcRepositoryIntegrationTests-db2.sql
@@ -7,6 +7,3 @@ CREATE TABLE "with_composite_id"
     "NAME"    VARCHAR(255),
     PRIMARY KEY ("col_one", "col_two")
 );
-
-INSERT INTO "with_composite_id" ("col_one", "col_two", "NAME") VALUES (42, 'HBAR', 'Walter');
-INSERT INTO "with_composite_id" ("col_one", "col_two", "NAME") VALUES (23, '2PI', 'Jesse');

--- a/spring-data-jdbc/src/test/resources/org.springframework.data.jdbc.repository/CompositeIdJdbcRepositoryIntegrationTests-h2.sql
+++ b/spring-data-jdbc/src/test/resources/org.springframework.data.jdbc.repository/CompositeIdJdbcRepositoryIntegrationTests-h2.sql
@@ -1,0 +1,12 @@
+DROP TABLE IF EXISTS "with_composite_id";
+
+CREATE TABLE "with_composite_id"
+(
+    "col_one" INT            NOT NULL,
+    "col_two" VARCHAR(255) NOT NULL,
+    "NAME"    VARCHAR(255),
+    PRIMARY KEY ("col_one", "col_two")
+);
+
+INSERT INTO "with_composite_id" ("col_one", "col_two", "NAME") VALUES (42, 'HBAR', 'Walter');
+INSERT INTO "with_composite_id" ("col_one", "col_two", "NAME") VALUES (23, '2PI', 'Jesse');

--- a/spring-data-jdbc/src/test/resources/org.springframework.data.jdbc.repository/CompositeIdJdbcRepositoryIntegrationTests-h2.sql
+++ b/spring-data-jdbc/src/test/resources/org.springframework.data.jdbc.repository/CompositeIdJdbcRepositoryIntegrationTests-h2.sql
@@ -7,6 +7,3 @@ CREATE TABLE "with_composite_id"
     "NAME"    VARCHAR(255),
     PRIMARY KEY ("col_one", "col_two")
 );
-
-INSERT INTO "with_composite_id" ("col_one", "col_two", "NAME") VALUES (42, 'HBAR', 'Walter');
-INSERT INTO "with_composite_id" ("col_one", "col_two", "NAME") VALUES (23, '2PI', 'Jesse');

--- a/spring-data-jdbc/src/test/resources/org.springframework.data.jdbc.repository/CompositeIdJdbcRepositoryIntegrationTests-hsql.sql
+++ b/spring-data-jdbc/src/test/resources/org.springframework.data.jdbc.repository/CompositeIdJdbcRepositoryIntegrationTests-hsql.sql
@@ -1,0 +1,12 @@
+DROP TABLE "with_composite_id" IF EXISTS;
+
+CREATE TABLE "with_composite_id"
+(
+    "col_one" INT            NOT NULL,
+    "col_two" VARCHAR(255) NOT NULL,
+    "NAME"    VARCHAR(255),
+    PRIMARY KEY ("col_one", "col_two")
+);
+
+INSERT INTO "with_composite_id" ("col_one", "col_two", "NAME") VALUES (42, 'HBAR', 'Walter');
+INSERT INTO "with_composite_id" ("col_one", "col_two", "NAME") VALUES (23, '2PI', 'Jesse');

--- a/spring-data-jdbc/src/test/resources/org.springframework.data.jdbc.repository/CompositeIdJdbcRepositoryIntegrationTests-hsql.sql
+++ b/spring-data-jdbc/src/test/resources/org.springframework.data.jdbc.repository/CompositeIdJdbcRepositoryIntegrationTests-hsql.sql
@@ -7,6 +7,3 @@ CREATE TABLE "with_composite_id"
     "NAME"    VARCHAR(255),
     PRIMARY KEY ("col_one", "col_two")
 );
-
-INSERT INTO "with_composite_id" ("col_one", "col_two", "NAME") VALUES (42, 'HBAR', 'Walter');
-INSERT INTO "with_composite_id" ("col_one", "col_two", "NAME") VALUES (23, '2PI', 'Jesse');

--- a/spring-data-jdbc/src/test/resources/org.springframework.data.jdbc.repository/CompositeIdJdbcRepositoryIntegrationTests-mariadb.sql
+++ b/spring-data-jdbc/src/test/resources/org.springframework.data.jdbc.repository/CompositeIdJdbcRepositoryIntegrationTests-mariadb.sql
@@ -7,6 +7,3 @@ CREATE TABLE with_composite_id
     NAME    VARCHAR(255),
     PRIMARY KEY (col_one, col_two)
 );
-
-INSERT INTO with_composite_id (col_one, col_two, NAME) VALUES (42, 'HBAR', 'Walter');
-INSERT INTO with_composite_id (col_one, col_two, NAME) VALUES (23, '2PI', 'Jesse');

--- a/spring-data-jdbc/src/test/resources/org.springframework.data.jdbc.repository/CompositeIdJdbcRepositoryIntegrationTests-mariadb.sql
+++ b/spring-data-jdbc/src/test/resources/org.springframework.data.jdbc.repository/CompositeIdJdbcRepositoryIntegrationTests-mariadb.sql
@@ -1,0 +1,12 @@
+DROP TABLE IF EXISTS with_composite_id;
+
+CREATE TABLE with_composite_id
+(
+    col_one INT            NOT NULL,
+    col_two VARCHAR(255)   NOT NULL,
+    NAME    VARCHAR(255),
+    PRIMARY KEY (col_one, col_two)
+);
+
+INSERT INTO with_composite_id (col_one, col_two, NAME) VALUES (42, 'HBAR', 'Walter');
+INSERT INTO with_composite_id (col_one, col_two, NAME) VALUES (23, '2PI', 'Jesse');

--- a/spring-data-jdbc/src/test/resources/org.springframework.data.jdbc.repository/CompositeIdJdbcRepositoryIntegrationTests-mssql.sql
+++ b/spring-data-jdbc/src/test/resources/org.springframework.data.jdbc.repository/CompositeIdJdbcRepositoryIntegrationTests-mssql.sql
@@ -1,0 +1,12 @@
+DROP TABLE IF EXISTS with_composite_id;
+
+CREATE TABLE with_composite_id
+(
+    col_one INT            NOT NULL,
+    col_two VARCHAR(255)   NOT NULL,
+    [NAME] VARCHAR(255),
+    PRIMARY KEY (col_one, col_two)
+);
+
+INSERT INTO with_composite_id (col_one, col_two, [NAME]) VALUES (42, 'HBAR', 'Walter');
+INSERT INTO with_composite_id (col_one, col_two, [NAME]) VALUES (23, '2PI', 'Jesse');

--- a/spring-data-jdbc/src/test/resources/org.springframework.data.jdbc.repository/CompositeIdJdbcRepositoryIntegrationTests-mssql.sql
+++ b/spring-data-jdbc/src/test/resources/org.springframework.data.jdbc.repository/CompositeIdJdbcRepositoryIntegrationTests-mssql.sql
@@ -7,6 +7,3 @@ CREATE TABLE with_composite_id
     [NAME] VARCHAR(255),
     PRIMARY KEY (col_one, col_two)
 );
-
-INSERT INTO with_composite_id (col_one, col_two, [NAME]) VALUES (42, 'HBAR', 'Walter');
-INSERT INTO with_composite_id (col_one, col_two, [NAME]) VALUES (23, '2PI', 'Jesse');

--- a/spring-data-jdbc/src/test/resources/org.springframework.data.jdbc.repository/CompositeIdJdbcRepositoryIntegrationTests-mysql.sql
+++ b/spring-data-jdbc/src/test/resources/org.springframework.data.jdbc.repository/CompositeIdJdbcRepositoryIntegrationTests-mysql.sql
@@ -7,6 +7,3 @@ CREATE TABLE with_composite_id
     NAME    VARCHAR(255),
     PRIMARY KEY (col_one, col_two)
 );
-
-INSERT INTO with_composite_id (col_one, col_two, NAME) VALUES (42, 'HBAR', 'Walter');
-INSERT INTO with_composite_id (col_one, col_two, NAME) VALUES (23, '2PI', 'Jesse');

--- a/spring-data-jdbc/src/test/resources/org.springframework.data.jdbc.repository/CompositeIdJdbcRepositoryIntegrationTests-mysql.sql
+++ b/spring-data-jdbc/src/test/resources/org.springframework.data.jdbc.repository/CompositeIdJdbcRepositoryIntegrationTests-mysql.sql
@@ -1,0 +1,12 @@
+DROP TABLE IF EXISTS with_composite_id;
+
+CREATE TABLE with_composite_id
+(
+    col_one INT            NOT NULL,
+    col_two VARCHAR(255)   NOT NULL,
+    NAME    VARCHAR(255),
+    PRIMARY KEY (col_one, col_two)
+);
+
+INSERT INTO with_composite_id (col_one, col_two, NAME) VALUES (42, 'HBAR', 'Walter');
+INSERT INTO with_composite_id (col_one, col_two, NAME) VALUES (23, '2PI', 'Jesse');

--- a/spring-data-jdbc/src/test/resources/org.springframework.data.jdbc.repository/CompositeIdJdbcRepositoryIntegrationTests-oracle.sql
+++ b/spring-data-jdbc/src/test/resources/org.springframework.data.jdbc.repository/CompositeIdJdbcRepositoryIntegrationTests-oracle.sql
@@ -7,6 +7,3 @@ CREATE TABLE "with_composite_id"
     "NAME"    VARCHAR2(255),
     PRIMARY KEY ("col_one", "col_two")
 );
-
-INSERT INTO "with_composite_id" ("col_one", "col_two", "NAME") VALUES (42, 'HBAR', 'Walter');
-INSERT INTO "with_composite_id" ("col_one", "col_two", "NAME") VALUES (23, '2PI', 'Jesse');

--- a/spring-data-jdbc/src/test/resources/org.springframework.data.jdbc.repository/CompositeIdJdbcRepositoryIntegrationTests-oracle.sql
+++ b/spring-data-jdbc/src/test/resources/org.springframework.data.jdbc.repository/CompositeIdJdbcRepositoryIntegrationTests-oracle.sql
@@ -1,0 +1,12 @@
+DROP TABLE IF EXISTS "with_composite_id";
+
+CREATE TABLE "with_composite_id"
+(
+    "col_one" NUMBER         NOT NULL,
+    "col_two" VARCHAR2(255)  NOT NULL,
+    "NAME"    VARCHAR2(255),
+    PRIMARY KEY ("col_one", "col_two")
+);
+
+INSERT INTO "with_composite_id" ("col_one", "col_two", "NAME") VALUES (42, 'HBAR', 'Walter');
+INSERT INTO "with_composite_id" ("col_one", "col_two", "NAME") VALUES (23, '2PI', 'Jesse');

--- a/spring-data-jdbc/src/test/resources/org.springframework.data.jdbc.repository/CompositeIdJdbcRepositoryIntegrationTests-postgres.sql
+++ b/spring-data-jdbc/src/test/resources/org.springframework.data.jdbc.repository/CompositeIdJdbcRepositoryIntegrationTests-postgres.sql
@@ -1,0 +1,12 @@
+DROP TABLE IF EXISTS "with_composite_id";
+
+CREATE TABLE "with_composite_id"
+(
+    "col_one" INTEGER      NOT NULL,
+    "col_two" VARCHAR(255) NOT NULL,
+    "NAME"    VARCHAR(255),
+    PRIMARY KEY ("col_one", "col_two")
+);
+
+INSERT INTO "with_composite_id" ("col_one", "col_two", "NAME") VALUES (42, 'HBAR', 'Walter');
+INSERT INTO "with_composite_id" ("col_one", "col_two", "NAME") VALUES (23, '2PI', 'Jesse');

--- a/spring-data-jdbc/src/test/resources/org.springframework.data.jdbc.repository/CompositeIdJdbcRepositoryIntegrationTests-postgres.sql
+++ b/spring-data-jdbc/src/test/resources/org.springframework.data.jdbc.repository/CompositeIdJdbcRepositoryIntegrationTests-postgres.sql
@@ -7,6 +7,3 @@ CREATE TABLE "with_composite_id"
     "NAME"    VARCHAR(255),
     PRIMARY KEY ("col_one", "col_two")
 );
-
-INSERT INTO "with_composite_id" ("col_one", "col_two", "NAME") VALUES (42, 'HBAR', 'Walter');
-INSERT INTO "with_composite_id" ("col_one", "col_two", "NAME") VALUES (23, '2PI', 'Jesse');

--- a/spring-data-r2dbc/pom.xml
+++ b/spring-data-r2dbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-r2dbc</artifactId>
-	<version>4.1.0-SNAPSHOT</version>
+	<version>4.1.x-GH-2276-SNAPSHOT</version>
 
 	<name>Spring Data R2DBC</name>
 	<description>Spring Data module for R2DBC</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>4.1.x-GH-2276-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/query/QueryMapper.java
+++ b/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/query/QueryMapper.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.regex.Pattern;
 
 import org.jspecify.annotations.Nullable;
@@ -51,6 +52,7 @@ import org.springframework.r2dbc.core.binding.Bindings;
 import org.springframework.r2dbc.core.binding.MutableBindings;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
+import org.springframework.util.CollectionUtils;
 
 /**
  * Maps {@link CriteriaDefinition} and {@link Sort} objects considering mapping metadata and dialect-specific
@@ -61,6 +63,7 @@ import org.springframework.util.ClassUtils;
  * @author Manousos Mathioudakis
  * @author Jens Schauder
  * @author Yan Qiang
+ * @author Christoph Strobl
  */
 public class QueryMapper {
 
@@ -368,10 +371,7 @@ public class QueryMapper {
 			if ((Comparator.IN.equals(comparator) || Comparator.NOT_IN.equals(comparator))
 					&& value instanceof Collection<?> collection) {
 
-				Condition condition = null;
-
-				for (Object o : collection) {
-
+				return expandInCollectionComparison(comparator, collection, element -> {
 					CriteriaWrapper cw = new CriteriaWrapper(criteria) {
 
 						@Override
@@ -382,7 +382,7 @@ public class QueryMapper {
 						@Nullable
 						@Override
 						public Object getValue() {
-							return o;
+							return element;
 						}
 
 						@Override
@@ -390,16 +390,8 @@ public class QueryMapper {
 							return criteriaColumn;
 						}
 					};
-
-					Condition c = Conditions.nest(mapCondition(cw, bindings, table, entity, true));
-					condition = condition == null ? c : condition.or(c);
-				}
-
-				if (condition == null) {
-					return Comparator.IN.equals(comparator) ? Conditions.unrestricted().not() : Conditions.unrestricted();
-				}
-
-				return condition;
+					return mapCondition(cw, bindings, table, entity, true);
+				});
 			}
 
 			RelationalPersistentEntity<?> embeddedEntity = mappingContext
@@ -407,7 +399,10 @@ public class QueryMapper {
 			PersistentPropertyAccessor<Object> propertyAccessor = getEmbeddedPropertyAccessor(value, embeddedEntity,
 					propertyField);
 
-			Condition condition = Conditions.unrestricted();
+			Assert.notNull(comparator, "Comparator must not be null");
+			boolean negateTuple = Comparator.NEQ.equals(comparator);
+
+			Condition condition = null;
 
 			for (RelationalPersistentProperty embeddedProperty : embeddedEntity) {
 
@@ -428,9 +423,13 @@ public class QueryMapper {
 				};
 
 				Condition mapped = mapCondition(cw, bindings, table, embeddedEntity, true);
-				condition = condition.and(mapped);
+				condition = condition == null ? mapped : (negateTuple ? condition.or(mapped) : condition.and(mapped));
 			}
 
+			condition = condition != null ? condition : Conditions.unrestricted();
+			if (!embedded && condition instanceof OrCondition) {
+				return Conditions.nest(condition);
+			}
 			return embedded || !(condition instanceof AndCondition) ? condition : Conditions.nest(condition);
 		}
 
@@ -459,6 +458,29 @@ public class QueryMapper {
 		}
 
 		return createCondition(column, mappedValue, typeHint, bindings, comparator, criteria.isIgnoreCase());
+	}
+
+	/**
+	 * Expands {@link Comparator#IN}/{@link Comparator#NOT_IN} over a collection to a disjunction of nested conditions,
+	 * one per element (used for embedded types and composite association identifiers).
+	 * <p>
+	 * IN: (col = v AND …) OR (…) per element.
+	 * NOT_IN: AND over tuple negations; each negation is (col != v OR …), i.e. NOT (c1 = v1 AND c2 = v2) ≡ (c1 != v1 OR c2 != v2).
+	 */
+	@SuppressWarnings("NullAway")
+	private Condition expandInCollectionComparison(Comparator comparator, Collection<?> collection,
+			Function<Object, Condition> nestedConditionFactory) {
+
+		if (CollectionUtils.isEmpty(collection)) {
+			return Comparator.IN.equals(comparator) ? Conditions.unrestricted().not() : Conditions.unrestricted();
+		}
+
+		Condition condition = null;
+		for (Object element : collection) {
+			Condition next = Conditions.nest(nestedConditionFactory.apply(element));
+			condition = condition == null ? next : (Comparator.IN.equals(comparator) ? condition.or(next) : condition.and(next));
+		}
+		return condition;
 	}
 
 	static PersistentPropertyAccessor<Object> getEmbeddedPropertyAccessor(@Nullable Object value,

--- a/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/query/QueryMapperUnitTests.java
+++ b/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/query/QueryMapperUnitTests.java
@@ -225,7 +225,7 @@ class QueryMapperUnitTests {
 		criteria = Criteria.where("id").not(new CompositeId(1, "a")).or("foo").is("bar");
 
 		assertThat(map(criteria, WithCompositeId.class).getCondition()).hasToString(
-				"(withcompositeid.tenant != ?[$1] AND withcompositeid.name != ?[$2]) OR withcompositeid.foo = ?[$3]");
+				"(withcompositeid.tenant != ?[$1] OR withcompositeid.name != ?[$2]) OR withcompositeid.foo = ?[$3]");
 	}
 
 	@Test // gh-300
@@ -402,11 +402,11 @@ class QueryMapperUnitTests {
 
 		Criteria criteria = Criteria.where("id").notIn(new CompositeId(1, "a"));
 		assertThat(map(criteria, WithCompositeId.class).getCondition())
-				.hasToString("(withcompositeid.tenant != ?[$1] AND withcompositeid.name != ?[$2])");
+				.hasToString("(withcompositeid.tenant != ?[$1] OR withcompositeid.name != ?[$2])");
 
 		criteria = Criteria.where("id").notIn(new CompositeId(1, "a"), new CompositeId(2, "b"));
 		assertThat(map(criteria, WithCompositeId.class).getCondition()).hasToString(
-				"(withcompositeid.tenant != ?[$1] AND withcompositeid.name != ?[$2]) OR (withcompositeid.tenant != ?[$3] AND withcompositeid.name != ?[$4])");
+				"(withcompositeid.tenant != ?[$1] OR withcompositeid.name != ?[$2]) AND (withcompositeid.tenant != ?[$3] OR withcompositeid.name != ?[$4])");
 
 		criteria = Criteria.where("id").notIn();
 		assertThat(map(criteria, WithCompositeId.class).getCondition()).hasToString("1 = 1");

--- a/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/repository/CompositeIdRepositoryIntegrationTests.java
+++ b/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/repository/CompositeIdRepositoryIntegrationTests.java
@@ -23,6 +23,7 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -61,6 +62,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  *
  * @author Jens Schauder
  * @author Mark Paluch
+ * @author Christoph Strobl
  */
 @ExtendWith(SpringExtension.class)
 public class CompositeIdRepositoryIntegrationTests {
@@ -233,8 +235,27 @@ public class CompositeIdRepositoryIntegrationTests {
 				.verifyComplete();
 	}
 
+	@Test // GH-2276
+	void findAllByCompositePkNotInLooksRowsUpCorrectly() {
+
+		this.jdbc.execute("INSERT INTO with_composite_id VALUES (42, '2PI','Extra')");
+
+		repository.findAllByPkNotIn(List.of(new CompositeId(42, "HBAR"), new CompositeId(23, "2PI"))) //
+				.collectList() //
+				.as(StepVerifier::create) //
+				.assertNext(rows -> assertThat(rows).singleElement() //
+						.satisfies(row -> {
+							assertThat(row.name()).isEqualTo("Extra");
+							assertThat(row.pk()).isEqualTo(new CompositeId(42, "2PI"));
+						})) //
+				.verifyComplete();
+	}
+
 	interface WithCompositeIdRepository extends ReactiveCrudRepository<WithCompositeId, CompositeId> {
+
 		Flux<WithCompositeId> findByName(String name);
+
+		Flux<WithCompositeId> findAllByPkNotIn(Collection<CompositeId> ids);
 	}
 
 	@Table("with_composite_id")

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>spring-data-relational</artifactId>
-    <version>4.1.0-SNAPSHOT</version>
+    <version>4.1.x-GH-2276-SNAPSHOT</version>
 
     <name>Spring Data Relational</name>
     <description>Spring Data Relational support</description>
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.data</groupId>
         <artifactId>spring-data-relational-parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.1.x-GH-2276-SNAPSHOT</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
This PR makes sure to expand composite ids used in `IN`/`NOT IN` queries on an association property.
It also addresses an issue in the combination logic for not in that may lead to missing out matching results.

Future development may consider database specific tuple syntax for more readable statements and potentially improved server side query planning.

Closes: #2276 