### PR TITLE
Do not render the reference ID and key columns if RN does not equal.

### DIFF
--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sqlgeneration/SingleQuerySqlGenerator.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sqlgeneration/SingleQuerySqlGenerator.java
@@ -96,15 +96,14 @@ public class SingleQuerySqlGenerator implements SqlGenerator {
 				.forEach(e -> expressions.add(filteredColumnExpression(queryMeta.rowNumber.toString(), e.toString())));
 
 		for (QueryMeta meta : inlineQueries) {
-
 			meta.simpleColumns
 					.forEach(e -> expressions.add(filteredColumnExpression(meta.rowNumber.toString(), e.toString())));
 
 			if (meta.id != null) {
-				expressions.add(meta.id);
+				expressions.add(filteredColumnExpression(meta.rowNumber.toString(), meta.id.toString()));
 			}
 			if (meta.key != null) {
-				expressions.add(meta.key);
+				expressions.add(filteredColumnExpression(meta.rowNumber.toString(), meta.key.toString()));
 			}
 		}
 


### PR DESCRIPTION
This PR ensures that the ID and key columns of the reference table are not rendered when `rn` does not match with `singlequeryloading` enabled.

Closes #2122