### PR TITLE
Add H2 Interval converters for Duration

### DIFF
--- a/spring-data-r2dbc/pom.xml
+++ b/spring-data-r2dbc/pom.xml
@@ -189,6 +189,13 @@
 		<!-- R2DBC Drivers -->
 
 		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<version>${h2.version}</version>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>r2dbc-postgresql</artifactId>
 			<version>${r2dbc-postgresql.version}</version>

--- a/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/dialect/H2Dialect.java
+++ b/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/dialect/H2Dialect.java
@@ -15,11 +15,25 @@
  */
 package org.springframework.data.r2dbc.dialect;
 
+import org.h2.api.Interval;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
+import org.springframework.data.convert.WritingConverter;
 import org.springframework.data.relational.core.dialect.ArrayColumns;
 import org.springframework.data.relational.core.dialect.ObjectArrayColumns;
 import org.springframework.data.relational.core.sql.SqlIdentifier;
 import org.springframework.data.util.Lazy;
 import org.springframework.r2dbc.core.binding.BindMarkersFactory;
+import org.springframework.util.ClassUtils;
 
 /**
  * R2DBC dialect for H2.
@@ -28,8 +42,25 @@ import org.springframework.r2dbc.core.binding.BindMarkersFactory;
  * @author Jens Schauder
  * @author Diego Krupitza
  * @author Kurt Niemi
+ * @author YeongJae Min
  */
 public class H2Dialect extends org.springframework.data.relational.core.dialect.H2Dialect implements R2dbcDialect {
+
+	private static final Set<Class<?>> SIMPLE_TYPES;
+
+	private static final boolean H2_INTERVAL_PRESENT = ClassUtils.isPresent("org.h2.api.Interval",
+			H2Dialect.class.getClassLoader());
+
+	static {
+
+		Set<Class<?>> simpleTypes = new HashSet<>(
+				org.springframework.data.relational.core.dialect.H2Dialect.INSTANCE.simpleTypes());
+
+		// conditional H2 Interval support.
+		ifClassPresent("org.h2.api.Interval", simpleTypes::add);
+
+		SIMPLE_TYPES = simpleTypes;
+	}
 
 	/**
 	 * Singleton instance.
@@ -38,8 +69,35 @@ public class H2Dialect extends org.springframework.data.relational.core.dialect.
 
 	private static final BindMarkersFactory INDEXED = BindMarkersFactory.indexed("$", 1);
 
+	private static final List<Object> CONVERTERS = List.copyOf(createConverters());
+
 	private final Lazy<ArrayColumns> arrayColumns = Lazy
 			.of(() -> new SimpleTypeArrayColumns(ObjectArrayColumns.INSTANCE, getSimpleTypeHolder()));
+
+	private static List<Object> createConverters() {
+
+		List<Object> converters = new ArrayList<>();
+
+		if (H2_INTERVAL_PRESENT) {
+			converters.add(H2IntervalToDurationConverter.INSTANCE);
+			converters.add(DurationToH2IntervalConverter.INSTANCE);
+		}
+
+		return converters;
+	}
+
+	/**
+	 * If the class is present on the class path, invoke the specified consumer {@code action} with the class object,
+	 * otherwise do nothing.
+	 *
+	 * @param action block to be executed if a value is present.
+	 */
+	private static void ifClassPresent(String className, Consumer<Class<?>> action) {
+
+		if (ClassUtils.isPresent(className, H2Dialect.class.getClassLoader())) {
+			action.accept(ClassUtils.resolveClassName(className, H2Dialect.class.getClassLoader()));
+		}
+	}
 
 	@Override
 	public ArrayColumns getArraySupport() {
@@ -54,6 +112,59 @@ public class H2Dialect extends org.springframework.data.relational.core.dialect.
 	@Override
 	public String renderForGeneratedValues(SqlIdentifier identifier) {
 		return identifier.getReference();
+	}
+
+	@Override
+	public Collection<Object> getConverters() {
+		return CONVERTERS;
+	}
+
+	@Override
+	public Set<Class<?>> simpleTypes() {
+		return SIMPLE_TYPES;
+	}
+
+	@ReadingConverter
+	private enum H2IntervalToDurationConverter implements Converter<Interval, Duration> {
+
+		INSTANCE;
+
+		@Override
+		public Duration convert(Interval source) {
+
+			if (source.getQualifier().isYearMonth()) {
+				throw new IllegalArgumentException("Year-month intervals cannot be represented as Duration");
+			}
+
+			return Duration.ZERO //
+					.plusDays(source.getDays()) //
+					.plusHours(source.getHours()) //
+					.plusMinutes(source.getMinutes()) //
+					.plusSeconds(source.getSeconds()) //
+					.plusNanos(source.getNanosOfSecond());
+		}
+	}
+
+	@WritingConverter
+	private enum DurationToH2IntervalConverter implements Converter<Duration, Interval> {
+
+		INSTANCE;
+
+		private static final int NANOS_PER_SECOND = 1_000_000_000;
+
+		@Override
+		public Interval convert(Duration source) {
+
+			long seconds = source.getSeconds();
+			int nanos = source.getNano();
+
+			if (seconds < 0 && nanos > 0) {
+				seconds++;
+				nanos -= NANOS_PER_SECOND;
+			}
+
+			return Interval.ofSeconds(seconds, nanos);
+		}
 	}
 
 }

--- a/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/config/H2IntegrationTests.java
+++ b/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/config/H2IntegrationTests.java
@@ -15,9 +15,13 @@
  */
 package org.springframework.data.r2dbc.config;
 
+import static org.assertj.core.api.Assertions.*;
+
 import io.r2dbc.spi.ConnectionFactory;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
+
+import java.time.Duration;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,6 +32,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.r2dbc.core.R2dbcEntityTemplate;
+import org.springframework.data.r2dbc.dialect.H2Dialect;
 import org.springframework.data.r2dbc.repository.Query;
 import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories;
 import org.springframework.data.r2dbc.testing.H2TestSupport;
@@ -42,6 +48,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  * Integration test for {@link DatabaseClient} and repositories using H2.
  *
  * @author Mark Paluch
+ * @author YeongJae Min
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration
@@ -85,6 +92,29 @@ class H2IntegrationTests {
 				.verifyComplete();
 	}
 
+	@Test // GH-502
+	void shouldReadAndWriteDurationAsInterval() {
+
+		jdbc.execute("DROP TABLE IF EXISTS \"duration_holder\"");
+		jdbc.execute("CREATE TABLE \"duration_holder\" (" //
+				+ "\"ID\" integer PRIMARY KEY," //
+				+ "\"DURATION\" INTERVAL SECOND(18, 9)" //
+				+ ")");
+
+		DurationHolder durationHolder = new DurationHolder();
+		durationHolder.id = 1;
+		durationHolder.duration = Duration.ofSeconds(42, 123_000_000);
+
+		R2dbcEntityTemplate template = new R2dbcEntityTemplate(databaseClient, H2Dialect.INSTANCE);
+
+		template.insert(durationHolder) //
+				.thenMany(template.select(org.springframework.data.relational.core.query.Query.empty(),
+						DurationHolder.class)) //
+				.as(StepVerifier::create) //
+				.consumeNextWith(actual -> assertThat(actual.duration).isEqualTo(durationHolder.duration)) //
+				.verifyComplete();
+	}
+
 	@Configuration
 	@EnableR2dbcRepositories(considerNestedRepositories = true,
 			includeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = H2Repository.class),
@@ -108,5 +138,12 @@ class H2IntegrationTests {
 		@Id Integer id;
 		String name;
 		Integer manual;
+	}
+
+	@Table("duration_holder")
+	static class DurationHolder {
+
+		@Id Integer id;
+		Duration duration;
 	}
 }

--- a/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/core/DefaultReactiveDataAccessStrategyUnitTests.java
+++ b/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/core/DefaultReactiveDataAccessStrategyUnitTests.java
@@ -2,15 +2,21 @@ package org.springframework.data.r2dbc.core;
 
 import static org.assertj.core.api.Assertions.*;
 
+import org.h2.api.Interval;
+
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import org.springframework.data.annotation.Id;
 import org.springframework.data.r2dbc.dialect.H2Dialect;
+import org.springframework.data.r2dbc.mapping.OutboundRow;
+import org.springframework.data.r2dbc.testing.OutboundRowAssert;
 import org.springframework.data.relational.core.mapping.Embedded;
 import org.springframework.data.relational.core.sql.SqlIdentifier;
 
@@ -18,6 +24,7 @@ import org.springframework.data.relational.core.sql.SqlIdentifier;
  * Unit tests for {@link DefaultReactiveDataAccessStrategy}.
  *
  * @author Jens Schauder
+ * @author YeongJae Min
  */
 class DefaultReactiveDataAccessStrategyUnitTests {
 
@@ -31,6 +38,15 @@ class DefaultReactiveDataAccessStrategyUnitTests {
 
 		assertThat(dataAccessStrategy.getAllColumns(fixture.entityType()))
 				.containsExactlyInAnyOrder(sqlIdentifiers.toArray(new SqlIdentifier[0]));
+	}
+
+	@Test // GH-502
+	void shouldWriteDurationAsH2Interval() {
+
+		OutboundRow outboundRow = dataAccessStrategy.getOutboundRow(new WithDuration(Duration.ofMillis(-500)));
+
+		OutboundRowAssert.assertThat(outboundRow).withColumn(SqlIdentifier.quoted("DURATION"))
+				.hasValue(Interval.ofSeconds(0, -500_000_000)).hasType(Interval.class);
 	}
 
 	static Stream<Fixture> fixtures() {
@@ -60,6 +76,9 @@ class DefaultReactiveDataAccessStrategyUnitTests {
 	}
 
 	record WithEmbeddedId(@Id @Embedded.Empty(prefix = "ID_") Level2 id, String name) {
+	}
+
+	record WithDuration(Duration duration) {
 	}
 
 }

--- a/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/dialect/H2DialectUnitTests.java
+++ b/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/dialect/H2DialectUnitTests.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.r2dbc.dialect;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.h2.api.Interval;
+
+import java.time.Duration;
+import java.util.LinkedHashSet;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.core.convert.ConversionFailedException;
+import org.springframework.core.convert.support.ConversionServiceFactory;
+import org.springframework.core.convert.support.GenericConversionService;
+import org.springframework.data.mapping.model.SimpleTypeHolder;
+
+/**
+ * Unit tests for {@link H2Dialect}.
+ *
+ * @author YeongJae Min
+ */
+class H2DialectUnitTests {
+
+	@Test // GH-502
+	void shouldConsiderIntervalSimpleType() {
+
+		SimpleTypeHolder holder = H2Dialect.INSTANCE.getSimpleTypeHolder();
+
+		assertThat(holder.isSimpleType(Interval.class)).isTrue();
+	}
+
+	@Test // GH-502
+	void shouldConvertDayTimeIntervalToDuration() {
+
+		Interval interval = Interval.ofDaysHoursMinutesNanos(1, 2, 3, 4_500_000_000L);
+		Duration converted = conversionService().convert(interval, Duration.class);
+
+		assertThat(converted).isEqualTo(Duration.ofDays(1).plusHours(2).plusMinutes(3).plusSeconds(4)
+				.plusNanos(500_000_000));
+	}
+
+	@Test // GH-502
+	void shouldRejectYearMonthIntervalToDurationConversion() {
+
+		assertThatThrownBy(() -> conversionService().convert(Interval.ofYearsMonths(1, 2), Duration.class))
+				.isInstanceOf(ConversionFailedException.class)
+				.hasRootCauseInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test // GH-502
+	void shouldConvertNegativeDurationToInterval() {
+
+		Duration duration = Duration.ofMillis(-500);
+		Interval interval = conversionService().convert(duration, Interval.class);
+
+		assertThat(interval).isEqualTo(Interval.ofSeconds(0, -500_000_000));
+		assertThat(conversionService().convert(interval, Duration.class)).isEqualTo(duration);
+	}
+
+	private static GenericConversionService conversionService() {
+
+		GenericConversionService conversionService = new GenericConversionService();
+		ConversionServiceFactory.registerConverters(new LinkedHashSet<>(H2Dialect.INSTANCE.getConverters()),
+				conversionService);
+
+		return conversionService;
+	}
+}


### PR DESCRIPTION
Closes spring-projects/spring-data-r2dbc#502

Add H2 `Interval` to `Duration` conversion support to the R2DBC H2 dialect.

This follows the feedback from #2248 by using the H2 API directly instead of reflection, while guarding registration by classpath presence.

Changes include:
- registering `org.h2.api.Interval` as a dialect simple type when H2 is available
- adding `Interval` -> `Duration` and `Duration` -> `Interval` converters
- supporting H2 day-time intervals and rejecting year-month intervals that cannot be represented as `Duration`
- adding unit and integration tests for simple type registration, conversion, writing, and H2 round-tripping

`com.h2database:h2` is added as an optional dependency because the converters directly use `org.h2.api.Interval`, which is provided by the H2 artifact.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).