### PR TITLE
GH-2303: Support suffix attribute for @Embedded annotations

### DIFF
--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/BasicRelationalPersistentProperty.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/BasicRelationalPersistentProperty.java
@@ -61,6 +61,7 @@ public class BasicRelationalPersistentProperty extends AnnotationBasedPersistent
 	private final @Nullable ValueExpression collectionKeyColumnNameExpression;
 	private final boolean isEmbedded;
 	private final String embeddedPrefix;
+	private final String embeddedSuffix;
 
 	private final NamingStrategy namingStrategy;
 	private boolean forceQuote = true;
@@ -88,6 +89,9 @@ public class BasicRelationalPersistentProperty extends AnnotationBasedPersistent
 		this.isEmbedded = isAnnotationPresent(Embedded.class);
 		this.embeddedPrefix = Optional.ofNullable(findAnnotation(Embedded.class)) //
 				.map(Embedded::prefix) //
+				.orElse("");
+		this.embeddedSuffix = Optional.ofNullable(findAnnotation(Embedded.class)) //
+				.map(Embedded::suffix) //
 				.orElse("");
 
 		Lazy<Optional<SqlIdentifier>> collectionIdColumnName = null;
@@ -267,6 +271,11 @@ public class BasicRelationalPersistentProperty extends AnnotationBasedPersistent
 	@Override
 	public String getEmbeddedPrefix() {
 		return isEmbedded() ? embeddedPrefix : "";
+	}
+
+	@Override
+	public String getEmbeddedSuffix() {
+		return isEmbedded() ? embeddedSuffix : "";
 	}
 
 	@Override

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/Embedded.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/Embedded.java
@@ -57,6 +57,11 @@ public @interface Embedded {
 	String prefix() default "";
 
 	/**
+	 * @return suffix for columns in the embedded value object. An empty {@link String} by default.
+	 */
+	String suffix() default "";
+
+	/**
 	 * Load strategy to be used {@link Embedded#onEmpty()}.
 	 *
 	 * @author Christoph Strobl
@@ -104,6 +109,12 @@ public @interface Embedded {
 		 */
 		@AliasFor(annotation = Embedded.class, attribute = "prefix")
 		String prefix() default "";
+
+		/**
+		 * @return suffix for columns in the embedded value object. An empty {@link String} by default.
+		 */
+		@AliasFor(annotation = Embedded.class, attribute = "suffix")
+		String suffix() default "";
 	}
 
 	/**
@@ -144,5 +155,11 @@ public @interface Embedded {
 		 */
 		@AliasFor(annotation = Embedded.class, attribute = "prefix")
 		String prefix() default "";
+
+		/**
+		 * @return suffix for columns in the embedded value object. An empty {@link String} by default.
+		 */
+		@AliasFor(annotation = Embedded.class, attribute = "suffix")
+		String suffix() default "";
 	}
 }

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/EmbeddedContext.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/EmbeddedContext.java
@@ -32,4 +32,14 @@ record EmbeddedContext(RelationalPersistentProperty ownerProperty) {
 		String embeddedPrefix = ownerProperty.getEmbeddedPrefix();
 		return embeddedPrefix + name;
 	}
+
+	public String withEmbeddedSuffix(String name) {
+
+		if (!ownerProperty.isEmbedded()) {
+			return name;
+		}
+
+		String embeddedSuffix = ownerProperty.getEmbeddedSuffix();
+		return name + embeddedSuffix;
+	}
 }

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/EmbeddedRelationalPersistentProperty.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/EmbeddedRelationalPersistentProperty.java
@@ -55,8 +55,15 @@ class EmbeddedRelationalPersistentProperty implements RelationalPersistentProper
 	}
 
 	@Override
+	public String getEmbeddedSuffix() {
+		return context.withEmbeddedSuffix(delegate.getEmbeddedSuffix());
+	}
+
+	@Override
 	public SqlIdentifier getColumnName() {
-		return delegate.getColumnName().transform(context::withEmbeddedPrefix);
+		return delegate.getColumnName()
+				.transform(context::withEmbeddedPrefix)
+				.transform(context::withEmbeddedSuffix);
 	}
 
 	@Override

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/RelationalPersistentProperty.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/RelationalPersistentProperty.java
@@ -84,6 +84,13 @@ public interface RelationalPersistentProperty extends PersistentProperty<Relatio
 	}
 
 	/**
+	 * @return Suffix for embedded columns. If the column is not embedded the return value is empty.
+	 */
+	default String getEmbeddedSuffix() {
+		return "";
+	}
+
+	/**
 	 * Returns whether an empty embedded object is supposed to be created for this property.
 	 */
 	boolean shouldCreateEmptyEmbedded();

--- a/spring-data-relational/src/test/java/org/springframework/data/relational/core/mapping/BasicRelationalPersistentPropertyUnitTests.java
+++ b/spring-data-relational/src/test/java/org/springframework/data/relational/core/mapping/BasicRelationalPersistentPropertyUnitTests.java
@@ -93,7 +93,7 @@ class BasicRelationalPersistentPropertyUnitTests {
 		assertThat(property.getKeyColumn()).isEqualTo(quoted("key_col"));
 	}
 
-	@Test // DATAJDBC-111
+	@Test // DATAJDBC-111, GH-2303
 	void detectsEmbeddedEntity() {
 
 		final RelationalPersistentEntity<?> requiredPersistentEntity = context
@@ -101,11 +101,12 @@ class BasicRelationalPersistentPropertyUnitTests {
 
 		SoftAssertions softly = new SoftAssertions();
 
-		BiConsumer<String, String> checkEmbedded = (name, prefix) -> {
-
+		BiConsumer<String, String[]> checkEmbedded = (name, args) -> {
+			String expectedPrefix = args[0];
+			String expectedSuffix = args[1];
 			RelationalPersistentProperty property = requiredPersistentEntity.getRequiredPersistentProperty(name);
 
-			if (!prefix.isEmpty()) {
+			if (!expectedPrefix.isEmpty() || !expectedSuffix.isEmpty()) {
 				softly.assertThat(property.isEmbedded()) //
 						.describedAs(name + " is embedded") //
 						.isTrue();
@@ -113,13 +114,19 @@ class BasicRelationalPersistentPropertyUnitTests {
 
 			softly.assertThat(property.getEmbeddedPrefix()) //
 					.describedAs(name + " prefix") //
-					.isEqualTo(prefix);
+					.isEqualTo(expectedPrefix);
+
+			softly.assertThat(property.getEmbeddedSuffix()) //
+					.describedAs(name + " suffix") //
+					.isEqualTo(expectedSuffix);
 		};
 
-		checkEmbedded.accept("someList", "");
-		checkEmbedded.accept("id", "");
-		checkEmbedded.accept("embeddableEntity", "");
-		checkEmbedded.accept("prefixedEmbeddableEntity", "prefix");
+		checkEmbedded.accept("someList", new String[]{"", ""});
+		checkEmbedded.accept("id", new String[]{"", ""});
+		checkEmbedded.accept("embeddableEntity", new String[]{"", ""});
+
+		checkEmbedded.accept("prefixedEmbeddableEntity", new String[]{"prefix", ""});
+		checkEmbedded.accept("suffixedEmbeddableEntity", new String[]{"", "_suffixed"});
 
 		softly.assertAll();
 	}
@@ -190,6 +197,18 @@ class BasicRelationalPersistentPropertyUnitTests {
 				.isEqualTo(SqlIdentifier.from(SqlIdentifier.quoted("public"), SqlIdentifier.quoted("my_seq")));
 	}
 
+	@Test // GH-2303
+	void detectsEmbeddedEntitySuffix() {
+		final RelationalPersistentEntity<?> requiredPersistentEntity = context
+				.getRequiredPersistentEntity(DummyEntity.class);
+
+		RelationalPersistentProperty property = requiredPersistentEntity
+				.getRequiredPersistentProperty("suffixedEmbeddableEntity");
+
+		assertThat(property.isEmbedded()).isTrue();
+		assertThat(property.getEmbeddedSuffix()).isEqualTo("_suffixed");
+	}
+
 	@SuppressWarnings("unused")
 	static class DummyEntity {
 
@@ -229,6 +248,8 @@ class BasicRelationalPersistentPropertyUnitTests {
 
 		// DATAJDBC-111
 		private @Embedded(onEmpty = OnEmpty.USE_NULL, prefix = "prefix") EmbeddableEntity prefixedEmbeddableEntity;
+
+		private @Embedded(onEmpty = OnEmpty.USE_NULL, suffix = "_suffixed") EmbeddableEntity suffixedEmbeddableEntity;
 
 		public DummyEntity(Long id, SomeEnum someEnum, LocalDateTime localDateTime, ZonedDateTime zonedDateTime,
 				List<String> listOfString, String[] arrayOfString, List<OtherEntity> listOfEntity,

--- a/spring-data-relational/src/test/java/org/springframework/data/relational/core/mapping/RelationalMappingContextUnitTests.java
+++ b/spring-data-relational/src/test/java/org/springframework/data/relational/core/mapping/RelationalMappingContextUnitTests.java
@@ -90,7 +90,7 @@ public class RelationalMappingContextUnitTests {
 		assertThat((Object) one).isSameAs(two);
 	}
 
-	@Test // GH-1586
+	@Test // GH-1586, GH-2303
 	void correctlyCascadesPrefix() {
 
 		RelationalPersistentEntity<?> entity = context.getRequiredPersistentEntity(WithEmbedded.class);
@@ -102,8 +102,10 @@ public class RelationalMappingContextUnitTests {
 		RelationalPersistentProperty name = childEntity.getRequiredPersistentProperty("name");
 
 		assertThat(parent.getEmbeddedPrefix()).isEqualTo("prnt_");
+		assertThat(parent.getEmbeddedSuffix()).isEqualTo("_prnt");
 		assertThat(child.getEmbeddedPrefix()).isEqualTo("prnt_chld_");
-		assertThat(name.getColumnName()).isEqualTo(SqlIdentifier.quoted("PRNT_CHLD_NAME"));
+		assertThat(child.getEmbeddedSuffix()).isEqualTo("_chld_prnt");
+		assertThat(name.getColumnName()).isEqualTo(SqlIdentifier.quoted("PRNT_CHLD_NAME_CHLD_PRNT"));
 	}
 
 	@Test // GH-1657
@@ -125,7 +127,7 @@ public class RelationalMappingContextUnitTests {
 	}
 
 	static class WithEmbedded {
-		@Embedded.Empty(prefix = "prnt_") Parent parent;
+		@Embedded.Empty(prefix = "prnt_", suffix = "_prnt") Parent parent;
 	}
 
 	static class WithEmbeddedId {
@@ -138,7 +140,7 @@ public class RelationalMappingContextUnitTests {
 
 	static class Parent {
 
-		@Embedded.Empty(prefix = "chld_") Child child;
+		@Embedded.Empty(prefix = "chld_", suffix = "_chld") Child child;
 	}
 
 	static class Child {


### PR DESCRIPTION
Introduce the 'suffix' attribute within the @Embedded annotation and its associated shortcuts (@Embedded.Nullable, @Embedded.Empty) to mirror the existing prefix functionality. Update RelationalPersistentProperty, BasicRelationalPersistentProperty, and EmbeddedContext to propagate and accumulate column name suffixes recursively during embeddable nesting. Update EmbeddedRelationalPersistentProperty to transform the final database column identifier with the computed suffix chain.