### PR TITLE
Wrap `Query`-mapped `MapSqlParameterSource` in `EscapingParameterSource`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-relational-parent</artifactId>
-	<version>4.2.0-SNAPSHOT</version>
+	<version>4.2.0-GH-2317-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Relational Parent</name>

--- a/spring-data-jdbc-distribution/pom.xml
+++ b/spring-data-jdbc-distribution/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.0-GH-2317-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-jdbc</artifactId>
-	<version>4.2.0-SNAPSHOT</version>
+	<version>4.2.0-GH-2317-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.0-GH-2317-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/AggregateReader.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/AggregateReader.java
@@ -54,6 +54,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
  */
 class AggregateReader implements PathToColumnMapping {
 
+	private final Dialect dialect;
 	private final AliasFactory aliasFactory;
 	private final SqlGenerator sqlGenerator;
 	private final JdbcConverter converter;
@@ -62,6 +63,7 @@ class AggregateReader implements PathToColumnMapping {
 
 	AggregateReader(Dialect dialect, JdbcConverter converter, NamedParameterJdbcOperations jdbcTemplate) {
 
+		this.dialect = dialect;
 		this.aliasFactory = new AliasFactory();
 		this.converter = converter;
 		this.jdbcTemplate = jdbcTemplate;
@@ -164,7 +166,7 @@ class AggregateReader implements PathToColumnMapping {
 		Condition condition = createCondition(query, parameterSource, entity);
 		String sql = sqlGenerator.findAll(entity, condition);
 
-		return jdbcTemplate.query(sql, parameterSource, extractor);
+		return jdbcTemplate.query(sql, new EscapingParameterSource(parameterSource, dialect.getLikeEscaper()), extractor);
 	}
 
 	@Nullable

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DefaultDataAccessStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DefaultDataAccessStrategy.java
@@ -25,11 +25,9 @@ import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.jspecify.annotations.Nullable;
 
-import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.dao.support.DataAccessUtils;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mapping.PersistentPropertyPath;
@@ -72,8 +70,6 @@ import org.springframework.util.Assert;
  */
 @SuppressWarnings("SqlSourceToSinkFlow")
 public class DefaultDataAccessStrategy implements DataAccessStrategy {
-
-	private final Log logger = LogFactory.getLog(getClass());
 
 	private final SqlGeneratorSource sqlGeneratorSource;
 	private final RelationalMappingContext context;
@@ -276,7 +272,6 @@ public class DefaultDataAccessStrategy implements DataAccessStrategy {
 	public <T> void acquireLockAll(LockMode lockMode, Class<T> domainType) {
 
 		String acquireLockAllSql = sql(domainType).getAcquireLockAll(lockMode);
-
 		operations.getJdbcOperations().query(acquireLockAllSql, ResultSet::next);
 	}
 
@@ -296,11 +291,7 @@ public class DefaultDataAccessStrategy implements DataAccessStrategy {
 		String findOneSql = sql(domainType).getFindOne();
 		SqlIdentifierParameterSource parameter = parametersFactory.forQueryById(id, domainType);
 
-		try {
-			return operations.queryForObject(findOneSql, parameter, getRowMapper(domainType));
-		} catch (EmptyResultDataAccessException e) {
-			return null;
-		}
+		return DataAccessUtils.singleResult(operations.query(findOneSql, parameter, getRowMapper(domainType)));
 	}
 
 	@Override
@@ -410,15 +401,7 @@ public class DefaultDataAccessStrategy implements DataAccessStrategy {
 
 	@Override
 	public <T> Optional<T> findOne(Query query, Class<T> domainType) {
-
-		PreparedQuery operation = prepareQuery(domainType, query, SqlGenerator::selectByQuery);
-
-		try {
-			// TODO
-			return Optional.ofNullable(operations.queryForObject(operation.sql(), operation, getRowMapper(domainType)));
-		} catch (EmptyResultDataAccessException e) {
-			return Optional.empty();
-		}
+		return DataAccessUtils.optionalResult(findAll(query, domainType));
 	}
 
 	@Override

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DefaultDataAccessStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DefaultDataAccessStrategy.java
@@ -22,6 +22,7 @@ import java.sql.SQLException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
 import org.apache.commons.logging.Log;
@@ -69,6 +70,7 @@ import org.springframework.util.Assert;
  * @author Mikhail Polivakha
  * @since 1.1
  */
+@SuppressWarnings("SqlSourceToSinkFlow")
 public class DefaultDataAccessStrategy implements DataAccessStrategy {
 
 	private final Log logger = LogFactory.getLog(getClass());
@@ -409,11 +411,11 @@ public class DefaultDataAccessStrategy implements DataAccessStrategy {
 	@Override
 	public <T> Optional<T> findOne(Query query, Class<T> domainType) {
 
-		MapSqlParameterSource parameterSource = new MapSqlParameterSource();
-		String sqlQuery = sql(domainType).selectByQuery(query, parameterSource);
+		PreparedQuery operation = prepareQuery(domainType, query, SqlGenerator::selectByQuery);
 
 		try {
-			return Optional.ofNullable(operations.queryForObject(sqlQuery, parameterSource, getRowMapper(domainType)));
+			// TODO
+			return Optional.ofNullable(operations.queryForObject(operation.sql(), operation, getRowMapper(domainType)));
 		} catch (EmptyResultDataAccessException e) {
 			return Optional.empty();
 		}
@@ -422,37 +424,30 @@ public class DefaultDataAccessStrategy implements DataAccessStrategy {
 	@Override
 	public <T> List<T> findAll(Query query, Class<T> domainType) {
 
-		MapSqlParameterSource parameterSource = new MapSqlParameterSource();
-		String sqlQuery = sql(domainType).selectByQuery(query, parameterSource);
-
-		return operations.query(sqlQuery, parameterSource, getRowMapper(domainType));
+		PreparedQuery operation = prepareQuery(domainType, query, SqlGenerator::selectByQuery);
+		return operations.query(operation.sql(), operation, getRowMapper(domainType));
 	}
 
 	@Override
 	public <T> Stream<T> streamAll(Query query, Class<T> domainType) {
 
-		MapSqlParameterSource parameterSource = new MapSqlParameterSource();
-		String sqlQuery = sql(domainType).selectByQuery(query, parameterSource);
-
-		return operations.queryForStream(sqlQuery, parameterSource, getRowMapper(domainType));
+		PreparedQuery operation = prepareQuery(domainType, query, SqlGenerator::selectByQuery);
+		return operations.queryForStream(operation.sql(), operation, getRowMapper(domainType));
 	}
 
 	@Override
 	public <T> List<T> findAll(Query query, Class<T> domainType, Pageable pageable) {
 
-		MapSqlParameterSource parameterSource = new MapSqlParameterSource();
-		String sqlQuery = sql(domainType).selectByQuery(query, parameterSource, pageable);
-
-		return operations.query(sqlQuery, parameterSource, getRowMapper(domainType));
+		PreparedQuery operation = prepareQuery(domainType,
+				(sql, parameterSource) -> sql.selectByQuery(query, parameterSource, pageable));
+		return operations.query(operation.sql(), operation, getRowMapper(domainType));
 	}
 
 	@Override
 	public <T> boolean exists(Query query, Class<T> domainType) {
 
-		MapSqlParameterSource parameterSource = new MapSqlParameterSource();
-		String sqlQuery = sql(domainType).existsByQuery(query, parameterSource);
-
-		Boolean result = operations.queryForObject(sqlQuery, parameterSource, Boolean.class);
+		PreparedQuery operation = prepareQuery(domainType, query, SqlGenerator::existsByQuery);
+		Boolean result = operations.queryForObject(operation.sql(), operation, Boolean.class);
 
 		Assert.state(result != null, "The result of an exists query must not be null");
 
@@ -462,10 +457,9 @@ public class DefaultDataAccessStrategy implements DataAccessStrategy {
 	@Override
 	public <T> long count(Query query, Class<T> domainType) {
 
-		MapSqlParameterSource parameterSource = new MapSqlParameterSource();
-		String sqlQuery = sql(domainType).countByQuery(query, parameterSource);
+		PreparedQuery operation = prepareQuery(domainType, query, SqlGenerator::countByQuery);
+		Long result = operations.queryForObject(operation.sql(), operation, Long.class);
 
-		Long result = operations.queryForObject(sqlQuery, parameterSource, Long.class);
 		Assert.state(result != null, "The result of a count query must not be null.");
 
 		return result;
@@ -517,6 +511,59 @@ public class DefaultDataAccessStrategy implements DataAccessStrategy {
 		Assert.notNull(baseProperty, "The base property must not be null");
 
 		return baseProperty.getOwner().getType();
+	}
+
+	private PreparedQuery prepareQuery(Class<?> domainType,
+			BiFunction<SqlGenerator, MapSqlParameterSource, String> queryCreator) {
+
+		MapSqlParameterSource parameterSource = new MapSqlParameterSource();
+		String sql = queryCreator.apply(sql(domainType), parameterSource);
+		return new PreparedQuery(sql, new EscapingParameterSource(parameterSource, getDialect().getLikeEscaper()));
+	}
+
+	private PreparedQuery prepareQuery(Class<?> domainType, Query query, QueryCreator queryCreator) {
+
+		MapSqlParameterSource parameterSource = new MapSqlParameterSource();
+		String sql = queryCreator.createQuery(sql(domainType), query, parameterSource);
+		return new PreparedQuery(sql, new EscapingParameterSource(parameterSource, getDialect().getLikeEscaper()));
+	}
+
+	interface QueryCreator {
+		String createQuery(SqlGenerator sql, Query query, MapSqlParameterSource parameterSource);
+	}
+
+	record PreparedQuery(String sql, SqlParameterSource parameterSource) implements SqlParameterSource {
+
+		@Override
+		public boolean hasValue(String paramName) {
+			return parameterSource.hasValue(paramName);
+		}
+
+		@Override
+		public @Nullable Object getValue(String paramName) throws IllegalArgumentException {
+			return parameterSource.getValue(paramName);
+		}
+
+		@Override
+		public int getSqlType(String paramName) {
+			return parameterSource.getSqlType(paramName);
+		}
+
+		@Override
+		public @Nullable String getTypeName(String paramName) {
+			return parameterSource.getTypeName(paramName);
+		}
+
+		@Override
+		public String @Nullable [] getParameterNames() {
+			return parameterSource.getParameterNames();
+		}
+
+		@Override
+		public String toString() {
+			return sql();
+		}
+
 	}
 
 }

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/EscapingParameterSource.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/EscapingParameterSource.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.jdbc.core.convert;
+
+import org.jspecify.annotations.Nullable;
+import org.springframework.data.relational.core.dialect.Escaper;
+import org.springframework.data.relational.core.query.ValueFunction;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.util.Assert;
+
+/**
+ * This {@link SqlParameterSource} will apply escaping to its values.
+ *
+ * @author Jens Schauder
+ * @author Mark Paluch
+ * @since 4.1.1
+ */
+class EscapingParameterSource implements SqlParameterSource {
+
+	private final SqlParameterSource parameterSource;
+	private final Escaper escaper;
+
+	public EscapingParameterSource(SqlParameterSource parameterSource, Escaper escaper) {
+
+		this.parameterSource = parameterSource;
+		this.escaper = escaper;
+	}
+
+	@Override
+	public boolean hasValue(String paramName) {
+		return parameterSource.hasValue(paramName);
+	}
+
+	@Override
+	public @Nullable Object getValue(String paramName) throws IllegalArgumentException {
+
+		Object value = parameterSource.getValue(paramName);
+		if (value instanceof ValueFunction<?> valueFunction) {
+			return valueFunction.apply(escaper);
+		}
+		return value;
+	}
+
+	@Override
+	public int getSqlType(String paramName) {
+		return parameterSource.getSqlType(paramName);
+	}
+
+	@Override
+	public @Nullable String getTypeName(String paramName) {
+		return parameterSource.getTypeName(paramName);
+	}
+
+	@Override
+	public String[] getParameterNames() {
+		String[] parameterNames = parameterSource.getParameterNames();
+
+		Assert.state(parameterNames != null, "Parameter names must not be null");
+
+		return parameterNames;
+	}
+}

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/DefaultDataAccessStrategyUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/DefaultDataAccessStrategyUnitTests.java
@@ -16,19 +16,27 @@
 package org.springframework.data.jdbc.core.convert;
 
 import static java.util.Collections.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
 import org.springframework.data.annotation.Id;
+import org.springframework.data.domain.Example;
+import org.springframework.data.domain.ExampleMatcher;
 import org.springframework.data.jdbc.core.dialect.JdbcHsqlDbDialect;
 import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
 import org.springframework.data.relational.core.conversion.IdValueSource;
 import org.springframework.data.relational.core.dialect.Dialect;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
+import org.springframework.data.relational.core.query.Query;
 import org.springframework.data.relational.core.sql.SqlIdentifier;
+import org.springframework.data.relational.repository.query.RelationalExampleMapper;
 import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 
 /**
  * Unit tests for {@link DefaultDataAccessStrategy}.
@@ -113,6 +121,25 @@ class DefaultDataAccessStrategyUnitTests {
 		verify(insertStrategyFactory).batchInsertStrategy(IdValueSource.GENERATED, null);
 	}
 
+	@Test // GH-1159
+	void countByExample() {
+
+		RelationalExampleMapper exampleMapper = new RelationalExampleMapper(context);
+
+		Person person = new Person();
+		person.name = "Walter";
+		Example<Person> example = Example.of(person,
+				ExampleMatcher.matching().withStringMatcher(ExampleMatcher.StringMatcher.CONTAINING));
+		Query query = exampleMapper.getMappedExample(example);
+
+		ArgumentCaptor<SqlParameterSource> captor = ArgumentCaptor.forClass(SqlParameterSource.class);
+		doReturn(1L).when(namedJdbcOperations).queryForObject(anyString(), captor.capture(), (Class<?>) eq(Long.class));
+		accessStrategy.count(query, Person.class);
+
+		SqlParameterSource parameters = captor.getValue();
+		assertThat(parameters.getValue("name")).isEqualTo("%Walter%");
+	}
+
 	private static class DummyEntity {
 
 		@Id private final Long id;
@@ -120,6 +147,13 @@ class DefaultDataAccessStrategyUnitTests {
 		public DummyEntity(Long id) {
 			this.id = id;
 		}
+	}
+
+	static class Person {
+
+		private @Id Long id;
+		private String name;
+
 	}
 
 	private static class DummyEntityWithoutIdAnnotation {

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryIntegrationTests.java
@@ -19,6 +19,7 @@ import static java.util.Arrays.*;
 import static java.util.Collections.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.SoftAssertions.*;
+import static org.springframework.data.domain.ExampleMatcher.*;
 
 import java.io.IOException;
 import java.sql.ResultSet;
@@ -62,9 +63,17 @@ import org.springframework.data.annotation.Transient;
 import org.springframework.data.convert.CustomConversions;
 import org.springframework.data.convert.ReadingConverter;
 import org.springframework.data.convert.WritingConverter;
-import org.springframework.data.domain.*;
+import org.springframework.data.domain.Example;
+import org.springframework.data.domain.Limit;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Persistable;
+import org.springframework.data.domain.ScrollPosition;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Window;
 import org.springframework.data.jdbc.CapturingEventListener;
-import org.springframework.data.jdbc.core.JdbcAggregateOperations;
 import org.springframework.data.jdbc.core.dialect.JdbcDialect;
 import org.springframework.data.jdbc.core.mapping.AggregateReference;
 import org.springframework.data.jdbc.repository.config.JdbcConfiguration;
@@ -1247,6 +1256,24 @@ public class JdbcRepositoryIntegrationTests {
 		assertThat(count).isOne();
 	}
 
+	@Test // GH-2317
+	void countByExampleConsidersLike() {
+
+		DummyEntity entity = createEntity();
+		entity.setName("Diego");
+		entity.setPointInTime(Instant.now());
+		repository.save(entity);
+
+		DummyEntity exampleEntitiy = createEntity();
+		exampleEntitiy.setName("Di");
+
+		Example<DummyEntity> example = Example.of(exampleEntitiy, matching()
+				.withMatcher(DummyEntity::getName, GenericPropertyMatchers.contains()).withIgnorePaths(DummyEntity::isFlag));
+
+		long count = repository.count(example);
+		assertThat(count).isOne();
+	}
+
 	@Test // GH-1192
 	void fetchByExampleFluentAllSimple() {
 
@@ -1296,7 +1323,7 @@ public class JdbcRepositoryIntegrationTests {
 
 		repository.saveAll(Arrays.asList(one, two, three, four));
 
-		Example<DummyEntity> example = Example.of(one, ExampleMatcher.matching().withIgnorePaths("name", "idProp"));
+		Example<DummyEntity> example = Example.of(one, matching().withIgnorePaths("name", "idProp"));
 
 		Window<DummyEntity> first = repository.findBy(example, q -> q.limit(2).sortBy(Sort.by("name")))
 				.scroll(ScrollPosition.offset());

--- a/spring-data-r2dbc/pom.xml
+++ b/spring-data-r2dbc/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-r2dbc</artifactId>
-	<version>4.2.0-SNAPSHOT</version>
+	<version>4.2.0-GH-2317-SNAPSHOT</version>
 
 	<name>Spring Data R2DBC</name>
 	<description>Spring Data module for R2DBC</description>
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.0-GH-2317-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>spring-data-relational</artifactId>
-    <version>4.2.0-SNAPSHOT</version>
+	<version>4.2.0-GH-2317-SNAPSHOT</version>
 
     <name>Spring Data Relational</name>
     <description>Spring Data Relational support</description>
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.springframework.data</groupId>
         <artifactId>spring-data-relational-parent</artifactId>
-        <version>4.2.0-SNAPSHOT</version>
+	    <version>4.2.0-GH-2317-SNAPSHOT</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
We now correctly wrap `MapSqlParameterSource` in `EscapingParameterSource` to evaluate ValueFunction using LikeEscaper. Previously, we've bound the ValueEscaper.toString() as value yielding a `org.springframework.data.relational.core.query.ValueFunction$$Lambda…` bind value.

Closes #2317