### PR TITLE
Fix upsert update columns for embedded identifiers

### DIFF
--- a/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/core/R2dbcEntityTemplate.java
+++ b/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/core/R2dbcEntityTemplate.java
@@ -101,6 +101,7 @@ import org.springframework.util.Assert;
  * @author Mikhail Polivakha
  * @author Jens Schauder
  * @author Christoph Strobl
+ * @author leewoo97
  * @since 1.1
  */
 public class R2dbcEntityTemplate implements R2dbcEntityOperations, BeanFactoryAware, ApplicationContextAware {
@@ -742,11 +743,18 @@ public class R2dbcEntityTemplate implements R2dbcEntityOperations, BeanFactoryAw
 		}
 
 		List<SqlIdentifier> updateColumns = new ArrayList<>();
+		Set<SqlIdentifier> insertOnlyColumns = new LinkedHashSet<>();
 		persistentEntity.forEach(p -> {
-			if (!p.isInsertOnly() && !identifierColumns.contains(p.getColumnName())) {
-				updateColumns.add(p.getColumnName());
+			if (p.isInsertOnly()) {
+				insertOnlyColumns.add(p.getColumnName());
 			}
 		});
+
+		for (SqlIdentifier column : outboundRow.keySet()) {
+			if (!identifierColumns.contains(column) && !insertOnlyColumns.contains(column)) {
+				updateColumns.add(column);
+			}
+		}
 
 		upsert = upsert.withUpdateColumns(updateColumns);
 

--- a/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/core/ReactiveUpsertOperationUnitTests.java
+++ b/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/core/ReactiveUpsertOperationUnitTests.java
@@ -28,6 +28,8 @@ import org.springframework.data.r2dbc.dialect.PostgresDialect;
 import org.springframework.data.r2dbc.mapping.R2dbcMappingContext;
 import org.springframework.data.r2dbc.testing.StatementRecorder;
 import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Embedded;
+import org.springframework.data.relational.core.mapping.Table;
 import org.springframework.r2dbc.core.DatabaseClient;
 import org.springframework.r2dbc.core.Parameter;
 
@@ -35,6 +37,7 @@ import org.springframework.r2dbc.core.Parameter;
  * Unit tests for {@link ReactiveUpsertOperation}.
  *
  * @author Christoph Strobl
+ * @author leewoo97
  */
 public class ReactiveUpsertOperationUnitTests {
 
@@ -158,6 +161,25 @@ public class ReactiveUpsertOperationUnitTests {
 		assertThat(statement.getSql()).contains("insert_only");
 	}
 
+	@Test // GH-2313
+	void upsertDoesNotUpdateEmbeddedIdProperty() {
+
+		MockRowMetadata metadata = MockRowMetadata.builder().build();
+		MockResult result = MockResult.builder().rowMetadata(metadata).rowsUpdated(1).build();
+
+		recorder.addStubbing(s -> s.startsWith("INSERT"), result);
+
+		entityTemplate.upsert(new EntityWithEmbeddedId(new EntityId("one", "two"), "Walter")) //
+				.as(StepVerifier::create) //
+				.expectNextCount(1) //
+				.verifyComplete();
+
+		StatementRecorder.RecordedStatement statement = recorder.getCreatedStatement(s -> s.startsWith("INSERT"));
+
+		assertThat(statement.getSql()).isEqualTo(
+				"INSERT INTO entity (col1, col2, name) VALUES ($1, $2, $3) ON CONFLICT (col1, col2) DO UPDATE SET name = EXCLUDED.name");
+	}
+
 	static class Person {
 
 		@Id Long id;
@@ -182,6 +204,13 @@ public class ReactiveUpsertOperationUnitTests {
 		public void setName(String name) {
 			this.name = name;
 		}
+	}
+
+	@Table("entity")
+	record EntityWithEmbeddedId(@Id @Embedded.Empty EntityId id, String name) {
+	}
+
+	record EntityId(String col1, String col2) {
 	}
 
 }


### PR DESCRIPTION
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

Fixes #2313

R2dbcEntityTemplate upsert now derives update columns from the mapped OutboundRow columns and excludes identifier and insert-only columns. This prevents embedded id property names from being rendered in DO UPDATE SET.

Tested with:

./mvnw -pl spring-data-r2dbc clean test -Dtest=ReactiveUpsertOperationUnitTests