### PR TITLE
Consider custom write converters before pinning the column type

### DIFF
--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/MappingJdbcConverterUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/MappingJdbcConverterUnitTests.java
@@ -58,6 +58,7 @@ import org.springframework.data.relational.domain.RowDocument;
  *
  * @author Mark Paluch
  * @author Jens Schauder
+ * @author Donghwan Kim
  */
 class MappingJdbcConverterUnitTests {
 
@@ -185,6 +186,27 @@ class MappingJdbcConverterUnitTests {
 			checkReadConversion(softly, converter, "uuid", UUID);
 			checkReadConversion(softly, converter, "optionalUuid", Optional.of(UUID));
 		});
+	}
+
+	@Test // GH-2292
+	void writeConverterForSourceTypeWinsOverStorePinnedColumnType() {
+
+		MappingJdbcConverter converter = new MappingJdbcConverter( //
+				context, //
+				(identifier, path) -> {
+					throw new UnsupportedOperationException();
+				}, //
+				new JdbcCustomConversions(List.of(InstantToStringConverter.INSTANCE)), //
+				typeFactory //
+		);
+
+		RelationalPersistentEntity<?> entity = context.getRequiredPersistentEntity(DummyEntity.class);
+		RelationalPersistentProperty property = entity.getRequiredPersistentProperty("instant");
+		Instant value = Instant.parse("2024-05-01T10:15:30Z");
+
+		Object converted = converter.writeValue(value, TypeInformation.of(converter.getColumnType(property)));
+
+		assertThat(converted).isEqualTo(value.toString());
 	}
 
 	@Test // GH-2188
@@ -338,6 +360,16 @@ class MappingJdbcConverterUnitTests {
 		@Override
 		public Long convert(CustomId source) {
 			return source.id;
+		}
+	}
+
+	@WritingConverter
+	enum InstantToStringConverter implements Converter<Instant, String> {
+		INSTANCE;
+
+		@Override
+		public String convert(Instant source) {
+			return source.toString();
 		}
 	}
 

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/MappingRelationalConverter.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/MappingRelationalConverter.java
@@ -90,6 +90,7 @@ import org.springframework.util.ObjectUtils;
  * @author Vincent Galloy
  * @author Chanhyeong Cho
  * @author Lukáš Křečan
+ * @author Donghwan Kim
  * @see org.springframework.data.mapping.context.MappingContext
  * @see SimpleTypeHolder
  * @see CustomConversions
@@ -726,9 +727,12 @@ public class MappingRelationalConverter extends AbstractRelationalConverter
 
 	private Optional<Class<?>> determineCustomWriteTarget(Object value, TypeInformation<?> type) {
 
-		return getConversions().getCustomWriteTarget(value.getClass(), type.getType())
-				.or(() -> getConversions().getCustomWriteTarget(type.getType()))
-				.or(() -> getConversions().getCustomWriteTarget(value.getClass()));
+		// A write target registered for the value type takes precedence over the target type pinned by the
+		// store (e.g. Temporal -> Timestamp), so a user converter is not shadowed by a store converter that
+		// happens to register the same source type. See GH-2292.
+		return getConversions().getCustomWriteTarget(value.getClass())
+				.or(() -> getConversions().getCustomWriteTarget(value.getClass(), type.getType()))
+				.or(() -> getConversions().getCustomWriteTarget(type.getType()));
 	}
 
 	@Nullable


### PR DESCRIPTION
Fixes #2292.

A user-registered `@WritingConverter` for a source type (e.g. `Instant -> String`) was ignored on write — the value was always stored as a `Timestamp`.

`MappingRelationalConverter.determineCustomWriteTarget` first asks whether the source can be written as the *target* type, and for `java.time` values that target type is pinned to `Timestamp` by `JdbcColumnTypes`. The store's own `Instant -> Timestamp` converter satisfies that check, so a user converter registered for the same source type is never consulted.

This reorders the lookup so a custom write target registered for the source type is considered *before* the target type pinned by the store — the direction @christophstrobl pointed at on the issue ("checks for custom write targets happen before pinning the target type to `Timestamp`").

Since a `source -> target` registration implies a `source -> *` registration, the previously-first two-arg lookup only ever matched when the source-only lookup would too, so the reorder changes behaviour only for the shadowing case above.

Added a unit test in `MappingJdbcConverterUnitTests` that writes an `Instant` through a user `Instant -> String` converter and asserts the result is the `String`, not a `Timestamp`. The existing converter suites in `spring-data-jdbc` and `spring-data-relational` stay green (the `Timestamp` round-trip tests included).

This was prepared with AI assistance (Claude Code) and reviewed by me before submitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
