### PR TITLE
Support dynamic SQL provider for @Query methods

### DIFF
--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/aot/JdbcRepositoryContributor.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/aot/JdbcRepositoryContributor.java
@@ -52,6 +52,7 @@ import org.springframework.util.StringUtils;
  * JDBC-specific {@link RepositoryContributor} contributing an AOT repository fragment.
  *
  * @author Mark Paluch
+ * @author Sanghyuk Jung
  * @since 4.0
  */
 public class JdbcRepositoryContributor extends RepositoryContributor {
@@ -113,6 +114,11 @@ public class JdbcRepositoryContributor extends RepositoryContributor {
 
 		JdbcQueryMethod queryMethod = new JdbcQueryMethod(method, getRepositoryInformation(), getProjectionFactory(),
 				queriesFactory.getNamedQueries(), mappingContext);
+
+		// SQL obtained from a QueryProvider is only available at runtime, hence no AOT contribution.
+		if (queryMethod.hasQueryProvider()) {
+			return null;
+		}
 
 		ReturnedType returnedType = queryMethod.getResultProcessor().getReturnedType();
 		MergedAnnotation<Query> query = MergedAnnotations.from(method).get(Query.class);

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/JdbcQueryMethod.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/JdbcQueryMethod.java
@@ -51,6 +51,7 @@ import org.springframework.util.StringUtils;
  * @author Diego Krupitza
  * @author Mark Paluch
  * @author Daeho Kwon
+ * @author Sanghyuk Jung
  */
 public class JdbcQueryMethod extends QueryMethod {
 
@@ -206,6 +207,27 @@ public class JdbcQueryMethod extends QueryMethod {
 	@Nullable
 	String getResultSetExtractorRef() {
 		return getMergedAnnotationAttribute("resultSetExtractorRef");
+	}
+
+	/**
+	 * Returns the class to be used as {@link QueryProvider} to generate the SQL statement to execute at runtime.
+	 *
+	 * @return May be {@code null}.
+	 * @since 4.2
+	 */
+	@Nullable
+	public Class<? extends QueryProvider> getQueryProviderClass() {
+		return getMergedAnnotationAttribute("queryProviderClass");
+	}
+
+	/**
+	 * @return {@literal true} if the method is annotated with {@code @Query(queryProviderClass=…)}.
+	 * @since 4.2
+	 */
+	public boolean hasQueryProvider() {
+
+		Class<? extends QueryProvider> queryProviderClass = getQueryProviderClass();
+		return queryProviderClass != null && queryProviderClass != QueryProvider.class;
 	}
 
 	/**

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/Query.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/Query.java
@@ -46,6 +46,7 @@ import org.springframework.jdbc.core.RowMapper;
  * @author Moises Cisneros
  * @author Hebert Coelho
  * @author Mikhail Polivakha
+ * @author Sanghyuk Jung
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
@@ -86,4 +87,13 @@ public @interface Query {
 	 * @since 2.1
 	 */
 	String resultSetExtractorRef() default "";
+
+	/**
+	 * Optional {@link QueryProvider} to generate the SQL statement to execute at runtime, based on the bound parameter
+	 * values. The configured class must expose a default constructor. This attribute is mutually exclusive with
+	 * {@link #value()} and {@link #name()}.
+	 *
+	 * @since 4.2
+	 */
+	Class<? extends QueryProvider> queryProviderClass() default QueryProvider.class;
 }

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/QueryProvider.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/QueryProvider.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jdbc.repository.query;
+
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.util.ObjectUtils;
+
+/**
+ * SPI to generate the SQL statement for a repository query method at runtime, based on the actual parameter values.
+ * <p>
+ * Implementations are configured via {@link Query#queryProviderClass()} and get instantiated using their default
+ * constructor. {@link #getQuery(SqlParameterSource)} gets invoked on every query method execution with the fully bound
+ * parameter source, so that implementations can inspect the bound values and compose the SQL statement accordingly,
+ * e.g. by appending conditions only for non-{@literal null} parameters. Parameter binding, query execution, and result
+ * mapping remain the responsibility of Spring Data JDBC.
+ * <p>
+ * The returned SQL statement may contain named parameters matching the bound parameter names. Value expressions
+ * ({@code :#{…}}) and table name expressions ({@code #{#tableName}}) are not supported within the returned SQL
+ * statement. Implementations must be thread-safe as a single instance is shared across query method executions.
+ *
+ * @author Sanghyuk Jung
+ * @since 4.2
+ * @see Query#queryProviderClass()
+ */
+@FunctionalInterface
+public interface QueryProvider {
+
+	/**
+	 * Returns the SQL statement to execute for the actual query method invocation.
+	 *
+	 * @param parameterSource the fully bound method parameters. Must only be inspected, not mutated.
+	 * @return the SQL statement to execute. Must not be {@literal null} or empty.
+	 */
+	String getQuery(SqlParameterSource parameterSource);
+
+	/**
+	 * Returns whether the given parameter is bound and its value is not {@literal null}.
+	 *
+	 * @param parameterSource the parameter source to inspect.
+	 * @param parameterName the name of the parameter.
+	 * @return {@literal true} if the parameter is bound and its value is not {@literal null}.
+	 */
+	default boolean isNotNull(SqlParameterSource parameterSource, String parameterName) {
+		return parameterSource.hasValue(parameterName) && parameterSource.getValue(parameterName) != null;
+	}
+
+	/**
+	 * Returns whether the given parameter is bound and its value is neither {@literal null} nor empty.
+	 *
+	 * @param parameterSource the parameter source to inspect.
+	 * @param parameterName the name of the parameter.
+	 * @return {@literal true} if the parameter is bound and its value is neither {@literal null} nor empty.
+	 * @see ObjectUtils#isEmpty(Object)
+	 */
+	default boolean isNotEmpty(SqlParameterSource parameterSource, String parameterName) {
+		return parameterSource.hasValue(parameterName) && !ObjectUtils.isEmpty(parameterSource.getValue(parameterName));
+	}
+}

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/StringBasedJdbcQuery.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/StringBasedJdbcQuery.java
@@ -48,9 +48,11 @@ import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * A query to be executed based on a repository method, it's annotated SQL query and the arguments provided to the
@@ -66,6 +68,7 @@ import org.springframework.util.ObjectUtils;
  * @author Christopher Klein
  * @author Mikhail Polivakha
  * @author Marcin Grzejszczak
+ * @author Sanghyuk Jung
  * @since 2.0
  */
 public class StringBasedJdbcQuery extends AbstractJdbcQuery {
@@ -74,8 +77,9 @@ public class StringBasedJdbcQuery extends AbstractJdbcQuery {
 	private static final String LOCKING_IS_NOT_SUPPORTED = "Currently, @Lock is supported only on derived queries. In other words, for queries created with @Query, the locking condition specified with @Lock does nothing. Offending method: ";
 	private final JdbcConverter converter;
 	private final org.springframework.data.jdbc.repository.query.RowMapperFactory rowMapperFactory;
-	private final ValueExpressionQueryRewriter.ParsedQuery parsedQuery;
-	private final String query;
+	private final ValueExpressionQueryRewriter.@Nullable ParsedQuery parsedQuery;
+	private final @Nullable String query;
+	private final @Nullable QueryProvider queryProvider;
 
 	private final CachedRowMapperFactory cachedRowMapperFactory;
 	private final CachedResultSetExtractorFactory cachedResultSetExtractorFactory;
@@ -113,10 +117,21 @@ public class StringBasedJdbcQuery extends AbstractJdbcQuery {
 	public StringBasedJdbcQuery(String query, JdbcQueryMethod queryMethod, NamedParameterJdbcOperations operations,
 			org.springframework.data.jdbc.repository.query.RowMapperFactory rowMapperFactory, JdbcConverter converter,
 			ValueExpressionDelegate delegate) {
+		this(query, null, queryMethod, operations, rowMapperFactory, converter, delegate);
+	}
+
+	private StringBasedJdbcQuery(@Nullable String query, @Nullable QueryProvider queryProvider,
+			JdbcQueryMethod queryMethod, NamedParameterJdbcOperations operations,
+			org.springframework.data.jdbc.repository.query.RowMapperFactory rowMapperFactory, JdbcConverter converter,
+			ValueExpressionDelegate delegate) {
 
 		super(queryMethod, operations);
 
-		Assert.hasText(query, "Query must not be null or empty");
+		if (query == null) {
+			Assert.notNull(queryProvider, "Either Query or QueryProvider must not be null");
+		} else {
+			Assert.hasText(query, "Query must not be null or empty");
+		}
 		Assert.notNull(rowMapperFactory, "RowMapperFactory must not be null");
 
 		this.converter = converter;
@@ -146,11 +161,12 @@ public class StringBasedJdbcQuery extends AbstractJdbcQuery {
 				(counter, expression) -> String.format("__$synthetic$__%d", counter + 1), String::concat);
 
 		this.query = query;
+		this.queryProvider = queryProvider;
 
 		if (queryMethod.hasLockMode()) {
 			throw new UnsupportedOperationException(LOCKING_IS_NOT_SUPPORTED + queryMethod);
 		}
-		this.parsedQuery = rewriter.parse(this.query);
+		this.parsedQuery = query != null ? rewriter.parse(query) : null;
 		this.delegate = delegate;
 	}
 
@@ -171,6 +187,43 @@ public class StringBasedJdbcQuery extends AbstractJdbcQuery {
 				operations.getConverter(), delegate);
 	}
 
+	/**
+	 * Creates a new {@link StringBasedJdbcQuery} for the given {@link QueryProvider}, {@link JdbcQueryMethod},
+	 * {@link JdbcAggregateOperations} and {@link RowMapperFactory}. The SQL statement to execute gets obtained from the
+	 * given {@link QueryProvider} on every query method invocation.
+	 *
+	 * @param queryProvider must not be {@literal null}.
+	 * @param queryMethod must not be {@literal null}.
+	 * @param operations must not be {@literal null}.
+	 * @param rowMapperFactory must not be {@literal null}.
+	 * @param delegate must not be {@literal null}.
+	 * @since 4.2
+	 */
+	public StringBasedJdbcQuery(QueryProvider queryProvider, JdbcQueryMethod queryMethod,
+			JdbcAggregateOperations operations, RowMapperFactory rowMapperFactory, ValueExpressionDelegate delegate) {
+		this(null, queryProvider, queryMethod, operations.getDataAccessStrategy().getJdbcOperations(), rowMapperFactory,
+				operations.getConverter(), delegate);
+	}
+
+	/**
+	 * Creates a new {@link StringBasedJdbcQuery} for the given {@link QueryProvider}, {@link JdbcQueryMethod},
+	 * {@link RelationalMappingContext} and {@link RowMapperFactory}. The SQL statement to execute gets obtained from the
+	 * given {@link QueryProvider} on every query method invocation.
+	 *
+	 * @param queryProvider must not be {@literal null}.
+	 * @param queryMethod must not be {@literal null}.
+	 * @param operations must not be {@literal null}.
+	 * @param rowMapperFactory must not be {@literal null}.
+	 * @param converter must not be {@literal null}.
+	 * @param delegate must not be {@literal null}.
+	 * @since 4.2
+	 */
+	public StringBasedJdbcQuery(QueryProvider queryProvider, JdbcQueryMethod queryMethod,
+			NamedParameterJdbcOperations operations, RowMapperFactory rowMapperFactory, JdbcConverter converter,
+			ValueExpressionDelegate delegate) {
+		this(null, queryProvider, queryMethod, operations, rowMapperFactory, converter, delegate);
+	}
+
 	@Override
 	public @Nullable Object execute(Object[] objects) {
 
@@ -180,14 +233,30 @@ public class StringBasedJdbcQuery extends AbstractJdbcQuery {
 		JdbcQueryExecution<?> queryExecution = createJdbcQueryExecution(accessor, processor);
 		MapSqlParameterSource parameterMap = this.bindParameters(accessor);
 
-		return queryExecution.execute(evaluateExpressions(objects, accessor.getBindableParameters(), parameterMap),
-				parameterMap);
+		String sql = this.queryProvider != null ? getProvidedQuery(this.queryProvider, parameterMap)
+				: evaluateExpressions(objects, accessor.getBindableParameters(), parameterMap);
+
+		return queryExecution.execute(sql, parameterMap);
+	}
+
+	private String getProvidedQuery(QueryProvider queryProvider, SqlParameterSource parameterSource) {
+
+		String providedQuery = queryProvider.getQuery(parameterSource);
+
+		if (!StringUtils.hasText(providedQuery)) {
+			throw new IllegalStateException(String.format("QueryProvider %s returned a null or empty query for method %s",
+					queryProvider.getClass().getName(), getQueryMethod()));
+		}
+
+		return providedQuery;
 	}
 
 	private String evaluateExpressions(Object[] objects, Parameters<?, ?> bindableParameters,
 			MapSqlParameterSource parameterMap) {
 
-		if (parsedQuery.hasParameterBindings()) {
+		ValueExpressionQueryRewriter.ParsedQuery parsedQuery = this.parsedQuery;
+
+		if (parsedQuery != null && parsedQuery.hasParameterBindings()) {
 
 			ValueEvaluationContext evaluationContext = delegate.createValueContextProvider(bindableParameters)
 					.getEvaluationContext(objects);
@@ -198,6 +267,8 @@ public class StringBasedJdbcQuery extends AbstractJdbcQuery {
 
 			return parsedQuery.getQueryString();
 		}
+
+		Assert.state(this.query != null, "Query must not be null");
 
 		return this.query;
 	}

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/support/JdbcQueryLookupStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/support/JdbcQueryLookupStrategy.java
@@ -21,9 +21,12 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.beans.BeanInstantiationException;
+import org.springframework.beans.BeanUtils;
 import org.springframework.data.jdbc.core.JdbcAggregateOperations;
 import org.springframework.data.jdbc.repository.query.JdbcQueryMethod;
 import org.springframework.data.jdbc.repository.query.PartTreeJdbcQuery;
+import org.springframework.data.jdbc.repository.query.QueryProvider;
 import org.springframework.data.jdbc.repository.query.RowMapperFactory;
 import org.springframework.data.jdbc.repository.query.StringBasedJdbcQuery;
 import org.springframework.data.projection.ProjectionFactory;
@@ -48,6 +51,7 @@ import org.springframework.util.Assert;
  * @author Diego Krupitza
  * @author Christopher Klein
  * @author Mikhail Polivakha
+ * @author Sanghyuk Jung
  */
 abstract class JdbcQueryLookupStrategy extends RelationalQueryLookupStrategy {
 
@@ -114,6 +118,24 @@ abstract class JdbcQueryLookupStrategy extends RelationalQueryLookupStrategy {
 
 			JdbcQueryMethod queryMethod = getJdbcQueryMethod(method, repositoryMetadata, projectionFactory, namedQueries);
 
+			if (queryMethod.hasQueryProvider()) {
+
+				if (queryMethod.hasAnnotatedQuery() || queryMethod.hasAnnotatedQueryName()) {
+					throw new IllegalArgumentException(String.format(
+							"Invalid query configuration; Query method %s is annotated with both, a query provider and a query or a query name; Configure either one but not both",
+							method));
+				}
+
+				if (namedQueries.hasQuery(queryMethod.getNamedQueryName())) {
+					LOG.warn(String.format(
+							"Query method %s is annotated with a query provider and a named query exists; Using the query provider",
+							method));
+				}
+
+				return new StringBasedJdbcQuery(createQueryProvider(queryMethod, method), queryMethod, operations,
+						rowMapperFactory, delegate);
+			}
+
 			if (namedQueries.hasQuery(queryMethod.getNamedQueryName()) || queryMethod.hasAnnotatedQuery()) {
 
 				if (queryMethod.hasAnnotatedQuery() && queryMethod.hasAnnotatedQueryName()) {
@@ -128,6 +150,20 @@ abstract class JdbcQueryLookupStrategy extends RelationalQueryLookupStrategy {
 
 			throw new IllegalStateException(
 					String.format("Did neither find a NamedQuery nor an annotated query for method %s", method));
+		}
+
+		private static QueryProvider createQueryProvider(JdbcQueryMethod queryMethod, Method method) {
+
+			Class<? extends QueryProvider> queryProviderClass = queryMethod.getQueryProviderClass();
+
+			Assert.state(queryProviderClass != null, "QueryProvider class must not be null");
+
+			try {
+				return BeanUtils.instantiateClass(queryProviderClass);
+			} catch (BeanInstantiationException e) {
+				throw new IllegalArgumentException(String.format("Could not instantiate QueryProvider %s for query method %s",
+						queryProviderClass.getName(), method), e);
+			}
 		}
 	}
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/aot/JdbcRepositoryContributorIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/aot/JdbcRepositoryContributorIntegrationTests.java
@@ -435,4 +435,11 @@ class JdbcRepositoryContributorIntegrationTests {
 		assertThat(fragment.deleteOneByFirstname("Walter")).isNull();
 	}
 
+	@Test // GH-542
+	void shouldNotContributeQueryProviderMethod() {
+
+		assertThatThrownBy(() -> fragment.findWithDynamicQuery("Walter"))
+				.hasRootCauseInstanceOf(NoSuchMethodException.class);
+	}
+
 }

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/aot/UserQueryProvider.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/aot/UserQueryProvider.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jdbc.repository.aot;
+
+import org.springframework.data.jdbc.repository.query.QueryProvider;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+
+/**
+ * {@link QueryProvider} for testing AOT processing of query provider methods.
+ *
+ * @author Sanghyuk Jung
+ */
+public class UserQueryProvider implements QueryProvider {
+
+	@Override
+	public String getQuery(SqlParameterSource parameterSource) {
+		return "SELECT * FROM MY_USER WHERE firstname = :name";
+	}
+}

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/aot/UserRepository.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/aot/UserRepository.java
@@ -165,4 +165,11 @@ public interface UserRepository extends CrudRepository<User, Integer> {
 	@Query("delete from MY_USER where firstname = :firstname")
 	void deleteWithoutResult(String firstname);
 
+	// -------------------------------------------------------------------------
+	// Dynamic Queries
+	// -------------------------------------------------------------------------
+
+	@Query(queryProviderClass = UserQueryProvider.class)
+	List<User> findWithDynamicQuery(String name);
+
 }

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/query/JdbcQueryMethodUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/query/JdbcQueryMethodUnitTests.java
@@ -34,6 +34,7 @@ import org.springframework.data.repository.core.NamedQueries;
 import org.springframework.data.repository.core.RepositoryMetadata;
 import org.springframework.data.repository.core.support.PropertiesBasedNamedQueries;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 
 /**
  * Unit tests for {@link JdbcQueryMethod}.
@@ -43,6 +44,7 @@ import org.springframework.jdbc.core.RowMapper;
  * @author Moises Cisneros
  * @author Mark Paluch
  * @author Diego Krupitza
+ * @author Sanghyuk Jung
  */
 public class JdbcQueryMethodUnitTests {
 
@@ -148,6 +150,28 @@ public class JdbcQueryMethodUnitTests {
 		assertThat(queryMethodWithWriteLock.lookupLockAnnotation()).isEmpty();
 	}
 
+	@Test // GH-542
+	public void returnsSpecifiedQueryProviderClass() throws NoSuchMethodException {
+
+		JdbcQueryMethod queryMethod = createJdbcQueryMethod("queryMethodWithQueryProvider");
+
+		assertThat(queryMethod.getQueryProviderClass()).isEqualTo(CustomQueryProvider.class);
+		assertThat(queryMethod.hasQueryProvider()).isTrue();
+	}
+
+	@Test // GH-542
+	public void detectsAbsenceOfQueryProvider() throws NoSuchMethodException {
+
+		JdbcQueryMethod queryMethod = createJdbcQueryMethod("queryMethod");
+
+		assertThat(queryMethod.hasQueryProvider()).isFalse();
+
+		JdbcQueryMethod queryMethodWithoutAnnotation = createJdbcQueryMethod("methodWithoutAnyQuery");
+
+		assertThat(queryMethodWithoutAnnotation.hasQueryProvider()).isFalse();
+		assertThat(queryMethodWithoutAnnotation.getQueryProviderClass()).isNull();
+	}
+
 	@Lock(LockMode.PESSIMISTIC_WRITE)
 	@Query
 	private void queryMethodWithWriteLock() {}
@@ -169,11 +193,22 @@ public class JdbcQueryMethodUnitTests {
 
 	private void methodWithoutAnyQuery() {}
 
+	@Query(queryProviderClass = CustomQueryProvider.class)
+	private void queryMethodWithQueryProvider() {}
+
 	private class CustomRowMapper implements RowMapper<Object> {
 
 		@Override
 		public Object mapRow(ResultSet rs, int rowNum) {
 			return null;
+		}
+	}
+
+	private static class CustomQueryProvider implements QueryProvider {
+
+		@Override
+		public String getQuery(SqlParameterSource parameterSource) {
+			return QUERY;
 		}
 	}
 }

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/query/QueryAnnotationHsqlIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/query/QueryAnnotationHsqlIntegrationTests.java
@@ -40,6 +40,7 @@ import org.springframework.data.jdbc.testing.IntegrationTest;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 
 /**
  * Tests the execution of queries from {@link Query} annotations on repository methods.
@@ -48,6 +49,7 @@ import org.springframework.data.repository.query.Param;
  * @author Kazuki Shimizu
  * @author Mark Paluch
  * @author Dennis Effing
+ * @author Sanghyuk Jung
  */
 @IntegrationTest
 @EnabledOnDatabase(DatabaseType.HSQL)
@@ -263,6 +265,32 @@ public class QueryAnnotationHsqlIntegrationTests {
 		assertThat(repository.immutableTuple()).isEqualTo(new DummyEntityRepository.ImmutableTuple("one", "two", 3));
 	}
 
+	@Test // GH-542
+	public void executeQueryFromQueryProviderWithoutCondition() {
+
+		repository.save(dummyEntity("a"));
+		repository.save(dummyEntity("b"));
+
+		List<DummyEntity> entities = repository.findWithDynamicNameCondition(null);
+
+		assertThat(entities) //
+				.extracting(e -> e.name) //
+				.containsExactlyInAnyOrder("a", "b");
+	}
+
+	@Test // GH-542
+	public void executeQueryFromQueryProviderWithCondition() {
+
+		repository.save(dummyEntity("a"));
+		repository.save(dummyEntity("b"));
+
+		List<DummyEntity> entities = repository.findWithDynamicNameCondition("a");
+
+		assertThat(entities) //
+				.extracting(e -> e.name) //
+				.containsExactly("a");
+	}
+
 	private DummyEntity dummyEntity(String name) {
 
 		DummyEntity entity = new DummyEntity();
@@ -338,7 +366,21 @@ public class QueryAnnotationHsqlIntegrationTests {
 		@Query("SELECT 'one' one, 'two' two, 3 three FROM (VALUES (0)) as tableName")
 		ImmutableTuple immutableTuple();
 
+		// GH-542
+		@Query(queryProviderClass = DynamicNameQueryProvider.class)
+		List<DummyEntity> findWithDynamicNameCondition(@Param("name") @Nullable String name);
+
 		record ImmutableTuple(String one, String two, int three) {
+		}
+	}
+
+	static class DynamicNameQueryProvider implements QueryProvider {
+
+		@Override
+		public String getQuery(SqlParameterSource parameterSource) {
+
+			String sql = "SELECT * FROM DUMMY_ENTITY";
+			return isNotNull(parameterSource, "name") ? sql + " WHERE name = :name" : sql;
 		}
 	}
 }

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/query/StringBasedJdbcQueryUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/query/StringBasedJdbcQueryUnitTests.java
@@ -85,6 +85,7 @@ import org.springframework.util.ReflectionUtils;
  * @author Christopher Klein
  * @author Marcin Grzejszczak
  * @author Mikhail Polivakha
+ * @author Sanghyuk Jung
  */
 class StringBasedJdbcQueryUnitTests {
 
@@ -423,6 +424,51 @@ class StringBasedJdbcQueryUnitTests {
 		assertThat(parameterSource.getSqlType("value")).isEqualTo(JDBCType.OTHER.getVendorTypeNumber());
 	}
 
+	@Test // GH-542
+	void queryProviderGeneratedSqlGetsExecuted() {
+
+		JdbcQueryMethod queryMethod = createMethod("findAllWithQueryProvider", String.class);
+		StringBasedJdbcQuery query = createQueryWithQueryProvider(queryMethod, new DynamicQueryProvider());
+
+		query.execute(new Object[] { "John" });
+
+		ArgumentCaptor<SqlParameterSource> paramSource = ArgumentCaptor.forClass(SqlParameterSource.class);
+		verify(operations).queryForObject(eq("SELECT * FROM dummy_entity WHERE name = :name"), paramSource.capture(),
+				any(RowMapper.class));
+		assertThat(paramSource.getValue().getValue("name")).isEqualTo("John");
+	}
+
+	@Test // GH-542
+	void queryProviderGeneratesSqlBasedOnBoundParameterValues() {
+
+		JdbcQueryMethod queryMethod = createMethod("findAllWithQueryProvider", String.class);
+		StringBasedJdbcQuery query = createQueryWithQueryProvider(queryMethod, new DynamicQueryProvider());
+
+		query.execute(new Object[] { null });
+
+		verify(operations).queryForObject(eq("SELECT * FROM dummy_entity"), any(SqlParameterSource.class),
+				any(RowMapper.class));
+	}
+
+	@Test // GH-542
+	void queryProviderReturningEmptyQueryThrowsException() {
+
+		JdbcQueryMethod queryMethod = createMethod("findAllWithQueryProvider", String.class);
+		StringBasedJdbcQuery query = createQueryWithQueryProvider(queryMethod, parameterSource -> "");
+
+		assertThatIllegalStateException().isThrownBy(() -> query.execute(new Object[] { "John" }))
+				.withMessageContaining("returned a null or empty query");
+	}
+
+	@Test // GH-542
+	void queryProviderQueryUsesCustomRowMapperWhenSpecified() {
+
+		JdbcQueryMethod queryMethod = createMethod("findAllWithQueryProviderAndCustomRowMapper", String.class);
+		StringBasedJdbcQuery query = createQueryWithQueryProvider(queryMethod, new DynamicQueryProvider());
+
+		assertThat(query.determineRowMapper(queryMethod.getResultProcessor(), false)).isInstanceOf(CustomRowMapper.class);
+	}
+
 	QueryFixture forMethod(String name, Class... paramTypes) {
 		return new QueryFixture(createMethod(name, paramTypes));
 	}
@@ -490,6 +536,11 @@ class StringBasedJdbcQueryUnitTests {
 	private StringBasedJdbcQuery createQuery(JdbcQueryMethod queryMethod, String preparedReference, Object value) {
 		return new StringBasedJdbcQuery(queryMethod, operations, new StubRowMapperFactory(preparedReference, value),
 				converter, delegate);
+	}
+
+	private StringBasedJdbcQuery createQueryWithQueryProvider(JdbcQueryMethod queryMethod, QueryProvider queryProvider) {
+		return new StringBasedJdbcQuery(queryProvider, queryMethod, operations, result -> defaultRowMapper, converter,
+				delegate);
 	}
 
 	interface MyRepository extends Repository<Object, Long> {
@@ -572,6 +623,22 @@ class StringBasedJdbcQueryUnitTests {
 
 		@Query(value = "some sql statement")
 		List<DummyEntity> findByCustomValue(@Param("value") Direction value);
+
+		@Query(queryProviderClass = DynamicQueryProvider.class)
+		List<Object> findAllWithQueryProvider(@Param("name") String name);
+
+		@Query(queryProviderClass = DynamicQueryProvider.class, rowMapperClass = CustomRowMapper.class)
+		List<Object> findAllWithQueryProviderAndCustomRowMapper(@Param("name") String name);
+	}
+
+	static class DynamicQueryProvider implements QueryProvider {
+
+		@Override
+		public String getQuery(SqlParameterSource parameterSource) {
+
+			String sql = "SELECT * FROM dummy_entity";
+			return isNotNull(parameterSource, "name") ? sql + " WHERE name = :name" : sql;
+		}
 	}
 
 	private static class CustomRowMapper implements RowMapper<Object> {

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/support/JdbcQueryLookupStrategyUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/support/JdbcQueryLookupStrategyUnitTests.java
@@ -35,6 +35,7 @@ import org.springframework.data.jdbc.core.convert.QueryMappingConfiguration;
 import org.springframework.data.jdbc.core.dialect.JdbcH2Dialect;
 import org.springframework.data.jdbc.repository.config.DefaultQueryMappingConfiguration;
 import org.springframework.data.jdbc.repository.query.Query;
+import org.springframework.data.jdbc.repository.query.QueryProvider;
 import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.repository.core.NamedQueries;
@@ -59,6 +60,7 @@ import org.springframework.util.ReflectionUtils;
  * @author Hebert Coelho
  * @author Diego Krupitza
  * @author Christopher Klein
+ * @author Sanghyuk Jung
  */
 class JdbcQueryLookupStrategyUnitTests {
 
@@ -132,6 +134,54 @@ class JdbcQueryLookupStrategyUnitTests {
 				.hasMessageContaining("findByName");
 	}
 
+	@Test // GH-542
+	void resolvesQueryProviderQuery() {
+
+		RowMapper<? extends NumberFormat> numberFormatMapper = mock(RowMapper.class);
+		QueryMappingConfiguration mappingConfiguration = new DefaultQueryMappingConfiguration()
+				.registerRowMapper(NumberFormat.class, numberFormatMapper);
+
+		RepositoryQuery repositoryQuery = getRepositoryQuery(QueryLookupStrategy.Key.CREATE_IF_NOT_FOUND,
+				"findByQueryProvider", mappingConfiguration);
+
+		repositoryQuery.execute(new Object[] {});
+
+		verify(jdbcOperations).queryForObject(eq("SQL from provider"), any(SqlParameterSource.class), any(RowMapper.class));
+	}
+
+	@Test // GH-542
+	void failsOnQueryProviderCombinedWithDeclaredQuery() {
+
+		QueryMappingConfiguration mappingConfiguration = new DefaultQueryMappingConfiguration();
+
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> getRepositoryQuery(QueryLookupStrategy.Key.CREATE_IF_NOT_FOUND, "withQueryProviderAndValue",
+						mappingConfiguration))
+				.withMessageContaining("query provider");
+	}
+
+	@Test // GH-542
+	void failsOnQueryProviderCombinedWithQueryName() {
+
+		QueryMappingConfiguration mappingConfiguration = new DefaultQueryMappingConfiguration();
+
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> getRepositoryQuery(QueryLookupStrategy.Key.CREATE_IF_NOT_FOUND, "withQueryProviderAndName",
+						mappingConfiguration))
+				.withMessageContaining("query provider");
+	}
+
+	@Test // GH-542
+	void failsOnNonInstantiableQueryProvider() {
+
+		QueryMappingConfiguration mappingConfiguration = new DefaultQueryMappingConfiguration();
+
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> getRepositoryQuery(QueryLookupStrategy.Key.USE_DECLARED_QUERY,
+						"withNonInstantiableQueryProvider", mappingConfiguration))
+				.withMessageContaining("Could not instantiate QueryProvider");
+	}
+
 	@ParameterizedTest
 	@MethodSource("correctLookUpStrategyForKeySource")
 	void correctLookUpStrategyForKey(QueryLookupStrategy.Key key, Class expectedClass) {
@@ -177,9 +227,31 @@ class JdbcQueryLookupStrategyUnitTests {
 		void annotatedQueryWithQueryAndQueryName();
 
 		NumberFormat findByName();
+
+		@Query(queryProviderClass = StaticQueryProvider.class)
+		NumberFormat findByQueryProvider();
+
+		@Query(value = "some SQL", queryProviderClass = StaticQueryProvider.class)
+		NumberFormat withQueryProviderAndValue();
+
+		@Query(name = "query-name", queryProviderClass = StaticQueryProvider.class)
+		NumberFormat withQueryProviderAndName();
+
+		@Query(queryProviderClass = NonInstantiableQueryProvider.class)
+		NumberFormat withNonInstantiableQueryProvider();
 	}
 
 	record NumberFormat(String numberFormatString) {
 
 	}
+
+	static class StaticQueryProvider implements QueryProvider {
+
+		@Override
+		public String getQuery(SqlParameterSource parameterSource) {
+			return "SQL from provider";
+		}
+	}
+
+	abstract static class NonInstantiableQueryProvider implements QueryProvider {}
 }

--- a/src/main/antora/modules/ROOT/pages/jdbc/query-methods.adoc
+++ b/src/main/antora/modules/ROOT/pages/jdbc/query-methods.adoc
@@ -165,6 +165,45 @@ The location of that file may be changed by setting a value to `@EnableJdbcRepos
 
 Named queries are handled in the same way as queries provided by annotation.
 
+[[jdbc.query-methods.at-query.query-provider]]
+== Dynamic Queries with `QueryProvider`
+
+Instead of a static SQL statement, the `@Query` annotation can reference a `QueryProvider` implementation via the `queryProviderClass` attribute.
+A `QueryProvider` generates the SQL statement to execute at runtime, based on the actual parameter values.
+This allows composing the SQL statement per invocation, for example by appending a condition only when a parameter is not `null`:
+
+.Declare a query method using a QueryProvider
+[source,java]
+----
+interface UserRepository extends CrudRepository<User, Long> {
+
+    @Query(queryProviderClass = UserQueryProvider.class)
+    List<User> findByCityAndOptionalName(@Param("city") String city, @Param("name") @Nullable String name);
+}
+
+class UserQueryProvider implements QueryProvider {
+
+    @Override
+    public String getQuery(SqlParameterSource parameterSource) {
+
+        String sql = "SELECT * FROM user WHERE city = :city";
+        return isNotNull(parameterSource, "name") ? sql + " AND name = :name" : sql;
+    }
+}
+----
+
+The provider receives the fully bound `SqlParameterSource` for inspection while parameter binding, query execution, and result mapping remain handled by Spring Data JDBC.
+The returned SQL statement may contain named parameters matching the bound parameter names and gets executed as is.
+A custom `RowMapper` or `ResultSetExtractor` may be configured as for any other `@Query` method.
+
+The following restrictions apply:
+
+* `queryProviderClass` is mutually exclusive with the `value` and `name` attributes of `@Query`.
+* The configured class must expose a default constructor and must be thread-safe, as a single instance is shared across query method executions.
+* SpEL expressions (`:#{…}`, `#{tableName}`) are not processed within the SQL statement returned by a provider.
+* As with other string-based queries, pagination, `Sort`, and `Limit` parameters are not supported.
+* Query methods using a `QueryProvider` are not subject to ahead-of-time (AOT) repository generation; they are resolved at runtime.
+
 [[jdbc.query-methods.customizing-query-methods]]
 === Customizing Query Methods
 


### PR DESCRIPTION
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

---

Introduce a `QueryProvider` SPI that generates the SQL statement for a repository query method at runtime, based on the bound parameter values, following the design discussed in #542. A provider implementation is configured via the new `queryProviderClass` attribute of `@Query`, while parameter binding, query execution, and result mapping remain handled by Spring Data JDBC:

```java
interface ProductRepository extends CrudRepository<Product, String> {

    @Query(queryProviderClass = ProductQueryProvider.class)
    List<Product> findByName(@Param("name") @Nullable String name);
}

class ProductQueryProvider implements QueryProvider {

    @Override
    public String getQuery(SqlParameterSource source) {

        String sql = "SELECT * FROM product";
        return isNotNull(source, "name") ? sql + " WHERE name = :name" : sql;
    }
}
```

Changes:

* New `QueryProvider` functional interface (`getQuery(SqlParameterSource)` plus `isNotNull`/`isNotEmpty` default helpers) in `org.springframework.data.jdbc.repository.query`.
* New `@Query(queryProviderClass = …)` attribute, mutually exclusive with `value` and `name`. The configured class gets instantiated through its default constructor, following the `rowMapperClass` conventions.
* `StringBasedJdbcQuery` obtains the SQL statement from the provider on every invocation after parameter binding. Custom `RowMapper`/`ResultSetExtractor` configuration applies as for any other `@Query` method. Value expressions and `#{#tableName}` preprocessing are not applied to provider-generated SQL.
* `DeclaredQueryLookupStrategy` resolves provider methods first and reports invalid combinations (`value`/`name` together with a provider, non-instantiable provider classes) with `IllegalArgumentException` so that `CREATE_IF_NOT_FOUND` does not silently fall back to query derivation.
* Query methods using a `QueryProvider` are excluded from AOT repository generation and resolve at runtime.
* Reference documentation section for dynamic queries.

Closes #542
