### PR TITLE
Create foreign keys for references between aggregates

### DIFF
--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/schema/Tables.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/schema/Tables.java
@@ -43,6 +43,7 @@ import org.springframework.util.Assert;
  *
  * @author Kurt Niemi
  * @author Evgenii Koba
+ * @author Sanghyeok Hyun
  * @since 3.2
  */
 record Tables(List<Table> tables) {
@@ -51,13 +52,14 @@ record Tables(List<Table> tables) {
 		return from(context.getPersistentEntities().stream(), new DefaultSqlTypeMapping(), null, context);
 	}
 
-	// TODO: Add support (i.e. create tickets) to support entities, embedded properties, and aggregate references.
+	// TODO: Add support (i.e. create tickets) to support entities and embedded properties.
 
 	public static Tables from(Stream<? extends RelationalPersistentEntity<?>> persistentEntities,
 			SqlTypeMapping sqlTypeMapping, @Nullable String defaultSchema,
 			MappingContext<? extends RelationalPersistentEntity<?>, ? extends RelationalPersistentProperty> context) {
 
 		List<ForeignKeyMetadata> foreignKeyMetadataList = new ArrayList<>();
+		List<AggregateReferenceMetadata> aggregateReferenceMetadataList = new ArrayList<>();
 		List<Table> tables = persistentEntities
 				.filter(it -> it.isAnnotationPresent(org.springframework.data.relational.core.mapping.Table.class)) //
 				.map(entity -> {
@@ -81,11 +83,17 @@ record Tables(List<Table> tables) {
 						Column column = new Column(property.getColumnName().getReference(), columnType,
 								sqlTypeMapping.isNullable(property), identifierColumns.contains(property));
 						table.columns().add(column);
+
+						if (property.isAssociation() && property.getAssociationTargetTypeInformation() != null) {
+							aggregateReferenceMetadataList.add(new AggregateReferenceMetadata(table,
+									property.getColumnName().getReference(), property.getAssociationTargetTypeInformation().getType()));
+						}
 					}
 					return table;
 				}).collect(Collectors.toList());
 
 		applyForeignKeyMetadata(tables, foreignKeyMetadataList);
+		applyAggregateReferenceMetadata(tables, aggregateReferenceMetadataList, context);
 
 		return new Tables(tables);
 	}
@@ -136,6 +144,40 @@ record Tables(List<Table> tables) {
 						parentIdColumnNames, foreignKeyMetadata.parentTableName(), parentIdColumnNames));
 			}
 
+		});
+	}
+
+	/**
+	 * Apply aggregate reference information to create foreign keys between aggregates. References to aggregates outside
+	 * of the schema generation scope are skipped.
+	 */
+	private static void applyAggregateReferenceMetadata(List<Table> tables,
+			List<AggregateReferenceMetadata> aggregateReferenceMetadataList,
+			MappingContext<? extends RelationalPersistentEntity<?>, ? extends RelationalPersistentProperty> context) {
+
+		aggregateReferenceMetadataList.forEach(metadata -> {
+
+			if (!context.hasPersistentEntityFor(metadata.targetType())) {
+				return;
+			}
+
+			RelationalPersistentEntity<?> targetEntity = context.getRequiredPersistentEntity(metadata.targetType());
+			Table targetTable = findTableByName(tables, targetEntity.getTableName().getReference());
+
+			if (targetTable == null) {
+				return;
+			}
+
+			List<Column> targetIdColumns = targetTable.getIdColumns();
+
+			if (targetIdColumns.size() != 1) {
+				return;
+			}
+
+			Table table = metadata.table();
+			String foreignKeyName = getForeignKeyName(table.name(), List.of(metadata.columnName()));
+			addIfAbsent(table.foreignKeys(), new ForeignKey(foreignKeyName, table.name(), List.of(metadata.columnName()),
+					targetTable.name(), List.of(targetIdColumns.get(0).name())));
 		});
 	}
 
@@ -234,6 +276,10 @@ record Tables(List<Table> tables) {
 
 	private record ForeignKeyMetadata(String tableName, String referencingColumnName, @Nullable String keyColumnName,
 			@Nullable String keyColumnType, String parentTableName) {
+
+	}
+
+	private record AggregateReferenceMetadata(Table table, String columnName, Class<?> targetType) {
 
 	}
 }

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/mapping/schema/LiquibaseChangeSetWriterUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/mapping/schema/LiquibaseChangeSetWriterUnitTests.java
@@ -32,6 +32,8 @@ import java.util.Set;
 import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.jdbc.core.mapping.AggregateReference;
+import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
 import org.springframework.data.jdbc.core.mapping.schema.LiquibaseChangeSetWriter.ChangeSetMetadata;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.MappedCollection;
@@ -42,6 +44,7 @@ import org.springframework.data.relational.core.mapping.RelationalMappingContext
  *
  * @author Mark Paluch
  * @author Evgenii Koba
+ * @author Sanghyeok Hyun
  */
 class LiquibaseChangeSetWriterUnitTests {
 
@@ -176,6 +179,56 @@ class LiquibaseChangeSetWriterUnitTests {
 	}
 
 
+	@Test // GH-1600
+	void createForeignKeyForAggregateReference() {
+
+		RelationalMappingContext context = new JdbcMappingContext();
+		context.getRequiredPersistentEntity(Applicant.class);
+		context.getRequiredPersistentEntity(Country.class);
+
+		LiquibaseChangeSetWriter writer = new LiquibaseChangeSetWriter(context);
+
+		ChangeSet changeSet = writer.createChangeSet(ChangeSetMetadata.create(), new DatabaseChangeLog());
+
+		assertCreateTable(changeSet, "applicant", Tuple.tuple("id", "BIGINT", true),
+				Tuple.tuple("country", "BIGINT", null));
+
+		assertAddForeignKey(changeSet, "applicant", "country", "country", "id");
+	}
+
+	@Test // GH-1600
+	void createForeignKeysForMultipleAggregateReferencesToSameAggregate() {
+
+		RelationalMappingContext context = new JdbcMappingContext();
+		context.getRequiredPersistentEntity(Trip.class);
+		context.getRequiredPersistentEntity(Country.class);
+
+		LiquibaseChangeSetWriter writer = new LiquibaseChangeSetWriter(context);
+
+		ChangeSet changeSet = writer.createChangeSet(ChangeSetMetadata.create(), new DatabaseChangeLog());
+
+		assertAddForeignKey(changeSet, "trip", "origin", "country", "id");
+
+		assertAddForeignKey(changeSet, "trip", "destination", "country", "id");
+	}
+
+	@Test // GH-1600
+	void skipForeignKeyForAggregateReferenceOutsideSchemaGenerationScope() {
+
+		RelationalMappingContext context = new JdbcMappingContext();
+		context.getRequiredPersistentEntity(Applicant.class);
+
+		LiquibaseChangeSetWriter writer = new LiquibaseChangeSetWriter(context);
+		writer.setSchemaFilter(it -> !it.getType().equals(Country.class));
+
+		ChangeSet changeSet = writer.createChangeSet(ChangeSetMetadata.create(), new DatabaseChangeLog());
+
+		assertCreateTable(changeSet, "applicant", Tuple.tuple("id", "BIGINT", true),
+				Tuple.tuple("country", "BIGINT", null));
+
+		assertThat(changeSet.getChanges()).noneMatch(change -> change instanceof AddForeignKeyConstraintChange);
+	}
+
 	void assertCreateTable(ChangeSet changeSet, String tableName, Tuple... columnTuples) {
 		Optional<Change> createTableOptional = changeSet.getChanges().stream().filter(change -> change instanceof CreateTableChange createTableChange && createTableChange.getTableName().equals(tableName)).findFirst();
 		assertThat(createTableOptional.isPresent()).isTrue();
@@ -264,6 +317,24 @@ class LiquibaseChangeSetWriterUnitTests {
 	static class OneToOneLevel2 {
 		NoIdTable table1;
 		@Column("additional_one_to_one_level2") NoIdTable table2;
+	}
+
+	@org.springframework.data.relational.core.mapping.Table
+	static class Applicant {
+		@Id long id;
+		AggregateReference<Country, Long> country;
+	}
+
+	@org.springframework.data.relational.core.mapping.Table
+	static class Trip {
+		@Id long id;
+		AggregateReference<Country, Long> origin;
+		AggregateReference<Country, Long> destination;
+	}
+
+	@org.springframework.data.relational.core.mapping.Table
+	static class Country {
+		@Id long id;
 	}
 
 }


### PR DESCRIPTION
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

Closes #1600

Following the approach of #1599 (original pull request #1629), schema generation now creates foreign key constraints for references between aggregates, represented by `AggregateReference` properties.

For columns mapped from `AggregateReference` properties, the referenced aggregate root's table and identifier column are resolved via the mapping context, and a foreign key is added to the referencing table. If the referenced aggregate is not part of the schema generation scope (e.g. excluded by the schema filter), the foreign key is skipped rather than failing.

Foreign key names are derived from the referencing table and column (e.g. `trip_origin_fk`) so that multiple references to the same aggregate do not collide.

Tested with:

```
./mvnw -pl spring-data-jdbc test -Dtest="org.springframework.data.jdbc.core.mapping.schema.*"
```
