### PR TITLE
Qualify child aggregate columns with the table they are selected from

### DIFF
--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/QueryMapper.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/QueryMapper.java
@@ -36,6 +36,7 @@ import org.springframework.data.mapping.MappingException;
 import org.springframework.data.mapping.PersistentPropertyAccessor;
 import org.springframework.data.mapping.PersistentPropertyPath;
 import org.springframework.data.mapping.context.MappingContext;
+import org.springframework.data.relational.core.mapping.AggregatePath;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
 import org.springframework.data.relational.core.query.CriteriaDefinition;
@@ -57,6 +58,7 @@ import org.springframework.util.ClassUtils;
  * @author Yan Qiang
  * @author Mikhail Fedorov
  * @author Christoph Strobl
+ * @author Donghwan Kim
  * @since 3.0
  */
 public class QueryMapper {
@@ -127,7 +129,7 @@ public class QueryMapper {
 			return fields;
 		}
 
-		return List.of(OrderByField.from(table.column(field.getMappedColumnName())));
+		return List.of(OrderByField.from(getTable(table, field).column(field.getMappedColumnName())));
 	}
 
 	/**
@@ -351,7 +353,7 @@ public class QueryMapper {
 		}
 
 		TypeInformation<?> actualType = propertyField.getTypeHint().getRequiredActualType();
-		Column column = table.column(propertyField.getMappedColumnName());
+		Column column = getTable(table, propertyField).column(propertyField.getMappedColumnName());
 		Object mappedValue;
 		SQLType sqlType;
 
@@ -467,6 +469,35 @@ public class QueryMapper {
 				converter.getColumnType(property), //
 				converter.getTargetSqlType(property) //
 		);
+	}
+
+	/**
+	 * Returns the {@link Table} a column of the given {@link Field} belongs to. For a property of a child aggregate that
+	 * is the joined table the child is selected from, for everything else the table of the aggregate root.
+	 */
+	private Table getTable(Table rootTable, Field field) {
+
+		if (!(field instanceof MetadataBackedField metadataBackedField)) {
+			return rootTable;
+		}
+
+		PersistentPropertyPath<RelationalPersistentProperty> path = metadataBackedField.getPath();
+
+		if (path == null) {
+			return rootTable;
+		}
+
+		AggregatePath aggregatePath = converter.getMappingContext().getAggregatePath(path);
+
+		// the column of an entity-valued property lives in the owning table, not in the table of the entity itself
+		if (aggregatePath.isEntity()) {
+			return rootTable;
+		}
+
+		AggregatePath.TableInfo tableInfo = aggregatePath.getTableInfo();
+		SqlIdentifier tableAlias = tableInfo.tableAlias();
+
+		return tableAlias == null ? rootTable : Table.create(tableInfo.qualifiedTableName()).as(tableAlias);
 	}
 
 	private Condition mapEmbeddedObjectCondition(CriteriaDefinition criteria, MapSqlParameterSource parameterSource,

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/AbstractJdbcAggregateTemplateIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/AbstractJdbcAggregateTemplateIntegrationTests.java
@@ -88,6 +88,7 @@ import org.springframework.test.context.ContextConfiguration;
  * @author Vincent Galloy
  * @author Sergey Korotaev
  * @author Sanghun Lee
+ * @author Donghwan Kim
  */
 @IntegrationTest
 abstract class AbstractJdbcAggregateTemplateIntegrationTests {
@@ -403,6 +404,24 @@ abstract class AbstractJdbcAggregateTemplateIntegrationTests {
 		assertThat(reloadedById) //
 				.extracting(e -> e.id, e -> e.name, e -> e.content.size()) //
 				.containsExactly(tuple(two.id, two.name, 2));
+	}
+
+	@Test // GH-2112
+	void findAllByQueryWithCriteriaOnChildAggregate() {
+
+		template.save(createLegoSet("Lava"));
+
+		LegoSet star = createLegoSet("Star");
+		star.manual.content = "Assembly instructions for the Star";
+		template.save(star);
+
+		Query query = Query.query(Criteria.where("manual.content").is(star.manual.content));
+
+		Iterable<LegoSet> reloadedByManualContent = template.findAll(query, LegoSet.class);
+
+		assertThat(reloadedByManualContent) //
+				.extracting(l -> l.name) //
+				.containsExactly("Star");
 	}
 
 	@Test // GH-1803

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlGeneratorUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlGeneratorUnitTests.java
@@ -74,6 +74,7 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
  * @author Hari Ohm Prasath
  * @author Viktor Ardelean
  * @author Jaeyeon Kim
+ * @author Donghwan Kim
  */
 @SuppressWarnings("Convert2MethodRef")
 class SqlGeneratorUnitTests {
@@ -463,6 +464,32 @@ class SqlGeneratorUnitTests {
 				"ref.x_content AS ref_x_content", //
 				"FROM dummy_entity", //
 				"LEFT OUTER JOIN referenced_entity ref ON ref.dummy_entity = dummy_entity.id1");
+	}
+
+	@Test // GH-2112
+	void selectByQueryWithCriteriaOnChildAggregate() {
+
+		Query query = Query.query(Criteria.where("ref.content").is("some content"));
+
+		String sql = sqlGenerator.selectByQuery(query, new MapSqlParameterSource());
+
+		assertThat(sql).contains( //
+				"LEFT OUTER JOIN referenced_entity ref ON ref.dummy_entity = dummy_entity.id1", //
+				"WHERE ref.x_content = :x_content" //
+		);
+	}
+
+	@Test // GH-2112
+	void selectByQuerySortedByChildAggregate() {
+
+		Query query = Query.query(Criteria.where("id").is(23L)).sort(Sort.by("ref.content"));
+
+		String sql = sqlGenerator.selectByQuery(query, new MapSqlParameterSource());
+
+		assertThat(sql).contains( //
+				"LEFT OUTER JOIN referenced_entity ref ON ref.dummy_entity = dummy_entity.id1", //
+				"ORDER BY ref.x_content ASC" //
+		);
 	}
 
 	@Test // GH-1919


### PR DESCRIPTION
Fixes #2112.

A `Criteria` on a property of a child aggregate rendered the column against the aggregate root's table, so `Criteria.where("manual.content")` on a `LegoSet` produced

```sql
FROM "LEGO_SET" LEFT OUTER JOIN "MANUAL" "manual" ON "manual"."LEGO_SET" = "LEGO_SET"."id1"
WHERE "LEGO_SET"."CONTENT" = ?
```

The join and the projection already use the child's aliased table; only the condition doesn't, so the statement asks for a column the root table does not have and fails with a `BadSqlGrammarException` (or silently matches nothing where the root happens to have a same-named column, as in the issue).

`QueryMapper.mapCondition` builds the column with `table.column(...)`, where `table` is always the root table. The mapped column name already comes from the leaf property of the path, so the name was right and the qualification was wrong. This resolves the table from the property path instead, the same way `SqlContext.getTable(AggregatePath)` does for the projection: the table owner of the path, aliased, and the root table when the path has no table alias (a root property or an embedded one).

`Sort` had the same problem — `Query.sort(Sort.by("manual.content"))` rendered `ORDER BY "LEGO_SET"."CONTENT"` — so `createSimpleOrderByFields` goes through the same resolution.

One case needs to stay on the root table: an entity-valued property whose value is written to a column of the owning table by a custom converter. There the path's own table owner is the child's table, but the column belongs to the parent, so paths whose leaf is an entity keep the root table. That is what `PartTreeJdbcQueryUnitTests.considersConvertersForQueryArguments` (GH-2059) covers, and it stays green.

Tests: two unit tests in `SqlGeneratorUnitTests` for the rendered criteria and sort, and an integration test in `AbstractJdbcAggregateTemplateIntegrationTests` that queries `LegoSet` by `manual.content` — it fails with `BadSqlGrammarException` without the change. `mvn verify` on `spring-data-jdbc` is green (565 unit, 630 integration). I could not run `-Pall-dbs` here, so the integration tests ran on HSQLDB/H2 only; the change is dialect independent.

This was prepared with AI assistance (Claude Code) and reviewed by me before submitting.
