### PR TITLE
Fix @InsertOnlyProperty handling for embedded properties

### DIFF
--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlGenerator.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlGenerator.java
@@ -63,6 +63,7 @@ import org.springframework.util.Assert;
  * @author Kurt Niemi
  * @author Christoph Strobl
  * @author Jaeyeon Kim
+ * @author Seungmin Baek
  */
 public class SqlGenerator {
 
@@ -1455,7 +1456,7 @@ public class SqlGenerator {
 			this.mappingContext = mappingContext;
 			this.converter = converter;
 
-			populateColumnNameCache(entity, "");
+			populateColumnNameCache(entity, "", false);
 
 			Set<SqlIdentifier> insertable = new LinkedHashSet<>(nonIdColumnNames);
 			insertable.removeAll(readOnlyColumnNames);
@@ -1471,7 +1472,7 @@ public class SqlGenerator {
 			this.updatableColumns = Collections.unmodifiableSet(updatable);
 		}
 
-		private void populateColumnNameCache(RelationalPersistentEntity<?> entity, String prefix) {
+		private void populateColumnNameCache(RelationalPersistentEntity<?> entity, String prefix, boolean insertOnly) {
 
 			entity.doWithAll(property -> {
 
@@ -1480,7 +1481,7 @@ public class SqlGenerator {
 					Association association = Association.from(property, converter);
 					if (association.isComplexIdentifier()) {
 						populateColumnNameCache(association.getRequiredTargetIdentifierEntity(),
-								prefix + property.getEmbeddedPrefix());
+								prefix + property.getEmbeddedPrefix(), insertOnly);
 						return;
 					}
 				}
@@ -1488,14 +1489,14 @@ public class SqlGenerator {
 				if (!property.isEntity()) {
 
 					// the referencing column of referenced entity is expected to be on the other side of the relation
-					initSimpleColumnName(property, prefix);
+					initSimpleColumnName(property, prefix, insertOnly);
 				} else if (property.isEmbedded()) {
-					initEmbeddedColumnNames(property, prefix);
+					initEmbeddedColumnNames(property, prefix, insertOnly || property.isInsertOnly());
 				}
 			});
 		}
 
-		private void initSimpleColumnName(RelationalPersistentProperty property, String prefix) {
+		private void initSimpleColumnName(RelationalPersistentProperty property, String prefix, boolean insertOnly) {
 
 			SqlIdentifier columnName = property.getColumnName().transform(prefix::concat);
 
@@ -1510,19 +1511,19 @@ public class SqlGenerator {
 			if (!property.isWritable()) {
 				readOnlyColumnNames.add(columnName);
 			}
-			if (property.isInsertOnly()) {
+			if (insertOnly || property.isInsertOnly()) {
 				insertOnlyColumnNames.add(columnName);
 			}
 		}
 
-		private void initEmbeddedColumnNames(RelationalPersistentProperty property, String prefix) {
+		private void initEmbeddedColumnNames(RelationalPersistentProperty property, String prefix, boolean insertOnly) {
 
 			String embeddedPrefix = property.getEmbeddedPrefix();
 
 			RelationalPersistentEntity<?> embeddedEntity = mappingContext
 					.getRequiredPersistentEntity(converter.getColumnType(property));
 
-			populateColumnNameCache(embeddedEntity, prefix + embeddedPrefix);
+			populateColumnNameCache(embeddedEntity, prefix + embeddedPrefix, insertOnly);
 		}
 
 		/**

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlGeneratorUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlGeneratorUnitTests.java
@@ -44,6 +44,8 @@ import org.springframework.data.relational.core.dialect.Dialect;
 import org.springframework.data.relational.core.mapping.AggregatePath;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.DefaultNamingStrategy;
+import org.springframework.data.relational.core.mapping.Embedded;
+import org.springframework.data.relational.core.mapping.InsertOnlyProperty;
 import org.springframework.data.relational.core.mapping.MappedCollection;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
@@ -74,6 +76,7 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
  * @author Hari Ohm Prasath
  * @author Viktor Ardelean
  * @author Jaeyeon Kim
+ * @author Seungmin Baek
  */
 @SuppressWarnings("Convert2MethodRef")
 class SqlGeneratorUnitTests {
@@ -684,6 +687,27 @@ class SqlGeneratorUnitTests {
 
 		assertThat(findAll).containsSubsequence("SELECT",
 				"\"child\".\"PARENT_OF_NO_ID_CHILD\" AS \"CHILD_PARENT_OF_NO_ID_CHILD\"", "FROM");
+	}
+
+	@Test // GH-2366
+	void updateExcludesInsertOnlyEmbeddedProperties() {
+
+		SqlGenerator sqlGenerator = createSqlGenerator(WithInsertOnlyEmbedded.class, AnsiDialect.INSTANCE);
+
+		String update = sqlGenerator.getUpdate();
+
+		assertThat(update).contains("X_NAME").doesNotContain("CREATED_BY").doesNotContain("CREATED_AT");
+	}
+
+	@Test // GH-2366
+	void updateExcludesInsertOnlyPropertiesInsideEmbedded() {
+
+		SqlGenerator sqlGenerator = createSqlGenerator(WithEmbeddedInsertOnlyField.class, AnsiDialect.INSTANCE);
+
+		String update = sqlGenerator.getUpdate();
+
+		assertThat(update).doesNotContain("CREATED_BY");
+		assertThat(update).contains("AUDIT_X_UPDATED_BY");
 	}
 
 	@Test // DATAJDBC-262
@@ -1335,4 +1359,18 @@ class SqlGeneratorUnitTests {
 
 	record Child(@Column("NICK_NAME") String nickName, String name) {
 	}
+	record WithInsertOnlyEmbedded(@Id Long id, String name,
+			@InsertOnlyProperty @Embedded(onEmpty = Embedded.OnEmpty.USE_NULL, prefix = "audit_") Audit audit) {
+	}
+
+	record Audit(String createdBy, String createdAt) {
+	}
+
+	record WithEmbeddedInsertOnlyField(@Id Long id, String name,
+			@Embedded(onEmpty = Embedded.OnEmpty.USE_NULL, prefix = "audit_") AuditFields audit) {
+	}
+
+	record AuditFields(@InsertOnlyProperty String createdBy, String updatedBy) {
+	}
+
 }

--- a/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/core/R2dbcEntityTemplate.java
+++ b/spring-data-r2dbc/src/main/java/org/springframework/data/r2dbc/core/R2dbcEntityTemplate.java
@@ -66,6 +66,7 @@ import org.springframework.data.relational.core.mapping.OptimisticLockingUtils;
 import org.springframework.data.relational.core.mapping.PersistentPropertyTranslator;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
+import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.query.Criteria;
 import org.springframework.data.relational.core.query.CriteriaDefinition;
 import org.springframework.data.relational.core.query.Query;
@@ -102,6 +103,7 @@ import org.springframework.util.Assert;
  * @author Jens Schauder
  * @author Christoph Strobl
  * @author Woo Jin-Lee
+ * @author Seungmin Baek
  * @since 1.1
  */
 public class R2dbcEntityTemplate implements R2dbcEntityOperations, BeanFactoryAware, ApplicationContextAware {
@@ -649,11 +651,7 @@ public class R2dbcEntityTemplate implements R2dbcEntityOperations, BeanFactoryAw
 							idValues.put(sqlIdentifier, outboundRow.remove(sqlIdentifier));
 						});
 
-						persistentEntity.forEach(p -> {
-							if (p.isInsertOnly()) {
-								outboundRow.remove(p.getColumnName());
-							}
-						});
+						getInsertOnlyColumns(persistentEntity).forEach(outboundRow::remove);
 
 						Criteria criteria = null;
 						for (Map.Entry<SqlIdentifier, Object> idAndValue : idValues.entrySet()) {
@@ -743,12 +741,7 @@ public class R2dbcEntityTemplate implements R2dbcEntityOperations, BeanFactoryAw
 		}
 
 		List<SqlIdentifier> updateColumns = new ArrayList<>();
-		Set<SqlIdentifier> insertOnlyColumns = new LinkedHashSet<>();
-		persistentEntity.forEach(p -> {
-			if (p.isInsertOnly()) {
-				insertOnlyColumns.add(p.getColumnName());
-			}
-		});
+		Set<SqlIdentifier> insertOnlyColumns = getInsertOnlyColumns(persistentEntity);
 
 		for (SqlIdentifier column : outboundRow.keySet()) {
 			if (!identifierColumns.contains(column) && !insertOnlyColumns.contains(column)) {
@@ -888,6 +881,35 @@ public class R2dbcEntityTemplate implements R2dbcEntityOperations, BeanFactoryAw
 		RelationalPersistentEntity<?> entity = this.mappingContext.getPersistentEntity(entityClass);
 
 		return entity != null ? entity.getQualifiedTableName() : SqlIdentifier.EMPTY;
+	}
+
+	/**
+	 * Collect the column names of all {@link RelationalPersistentProperty#isInsertOnly() insert-only} properties,
+	 * expanding {@link RelationalPersistentProperty#isEmbedded() embedded} properties into their (prefixed) column
+	 * names. Properties within an insert-only embedded property are insert-only themselves.
+	 */
+	private Set<SqlIdentifier> getInsertOnlyColumns(RelationalPersistentEntity<?> persistentEntity) {
+
+		Set<SqlIdentifier> insertOnlyColumns = new LinkedHashSet<>();
+		collectInsertOnlyColumns(persistentEntity, false, insertOnlyColumns);
+		return insertOnlyColumns;
+	}
+
+	private void collectInsertOnlyColumns(RelationalPersistentEntity<?> persistentEntity, boolean insertOnlyParent,
+			Set<SqlIdentifier> insertOnlyColumns) {
+
+		for (RelationalPersistentProperty property : persistentEntity) {
+
+			boolean insertOnly = insertOnlyParent || property.isInsertOnly();
+
+			if (property.isEmbedded()) {
+				RelationalPersistentEntity<?> embeddedEntity = ((RelationalMappingContext) this.mappingContext)
+						.getRequiredPersistentEntity(property);
+				collectInsertOnlyColumns(embeddedEntity, insertOnly, insertOnlyColumns);
+			} else if (insertOnly) {
+				insertOnlyColumns.add(property.getColumnName());
+			}
+		}
 	}
 
 	private RelationalPersistentEntity<?> getRequiredEntity(Class<?> entityClass) {

--- a/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/core/R2dbcEntityTemplateUnitTests.java
+++ b/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/core/R2dbcEntityTemplateUnitTests.java
@@ -61,6 +61,7 @@ import org.springframework.data.r2dbc.mapping.event.BeforeSaveCallback;
 import org.springframework.data.r2dbc.mapping.event.ReactiveAuditingEntityCallback;
 import org.springframework.data.r2dbc.testing.StatementRecorder;
 import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Embedded;
 import org.springframework.data.relational.core.mapping.InsertOnlyProperty;
 import org.springframework.data.relational.core.query.Criteria;
 import org.springframework.data.relational.core.query.Query;
@@ -78,6 +79,7 @@ import org.springframework.util.CollectionUtils;
  * @author Jose Luis Leon
  * @author Robert Heim
  * @author Jens Schauder
+ * @author Seungmin Baek
  */
 public class R2dbcEntityTemplateUnitTests {
 
@@ -595,6 +597,44 @@ public class R2dbcEntityTemplateUnitTests {
 				Parameter.from(23L));
 	}
 
+	@Test // GH-2366
+	void updateExcludesInsertOnlyEmbeddedProperties() {
+
+		MockRowMetadata metadata = MockRowMetadata.builder().build();
+		MockResult result = MockResult.builder().rowMetadata(metadata).rowsUpdated(1).build();
+
+		recorder.addStubbing(s -> s.startsWith("UPDATE"), result);
+
+		entityTemplate.update(new WithInsertOnlyEmbedded(23L, "Alfred", new Audit("creator", "then"))) //
+				.as(StepVerifier::create) //
+				.expectNextCount(1) //
+				.verifyComplete();
+
+		StatementRecorder.RecordedStatement statement = recorder.getCreatedStatement(s -> s.startsWith("UPDATE"));
+
+		assertThat(statement.getSql()).isEqualTo(
+				"UPDATE \"with_insert_only_embedded\" SET \"name\" = $1 WHERE \"with_insert_only_embedded\".\"id\" = $2");
+	}
+
+	@Test // GH-2366
+	void updateExcludesInsertOnlyPropertiesInsideEmbedded() {
+
+		MockRowMetadata metadata = MockRowMetadata.builder().build();
+		MockResult result = MockResult.builder().rowMetadata(metadata).rowsUpdated(1).build();
+
+		recorder.addStubbing(s -> s.startsWith("UPDATE"), result);
+
+		entityTemplate.update(new WithEmbeddedInsertOnlyField(23L, "Alfred", new AuditFields("creator", "editor"))) //
+				.as(StepVerifier::create) //
+				.expectNextCount(1) //
+				.verifyComplete();
+
+		StatementRecorder.RecordedStatement statement = recorder.getCreatedStatement(s -> s.startsWith("UPDATE"));
+
+		assertThat(statement.getSql()).isEqualTo(
+				"UPDATE \"with_embedded_insert_only_field\" SET \"name\" = $1, \"audit_updated_by\" = $2 WHERE \"with_embedded_insert_only_field\".\"id\" = $3");
+	}
+
 	@Test // GH-1696
 	void shouldConsiderParameterConverter() {
 
@@ -834,6 +874,20 @@ public class R2dbcEntityTemplateUnitTests {
 			return this.lastModifiedDate == lastModifiedDate ? this
 					: new WithAuditingAndOptimisticLocking(id, version, name, createdDate, lastModifiedDate);
 		}
+	}
+
+	record WithInsertOnlyEmbedded(@Id Long id, String name,
+			@InsertOnlyProperty @Embedded(onEmpty = Embedded.OnEmpty.USE_NULL, prefix = "audit_") Audit audit) {
+	}
+
+	record Audit(String createdBy, String createdAt) {
+	}
+
+	record WithEmbeddedInsertOnlyField(@Id Long id, String name,
+			@Embedded(onEmpty = Embedded.OnEmpty.USE_NULL, prefix = "audit_") AuditFields audit) {
+	}
+
+	record AuditFields(@InsertOnlyProperty String createdBy, String updatedBy) {
 	}
 
 	record WithInsertOnly(@Id Long id,

--- a/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/core/ReactiveUpsertOperationUnitTests.java
+++ b/spring-data-r2dbc/src/test/java/org/springframework/data/r2dbc/core/ReactiveUpsertOperationUnitTests.java
@@ -29,6 +29,7 @@ import org.springframework.data.r2dbc.mapping.R2dbcMappingContext;
 import org.springframework.data.r2dbc.testing.StatementRecorder;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Embedded;
+import org.springframework.data.relational.core.mapping.InsertOnlyProperty;
 import org.springframework.data.relational.core.mapping.Table;
 import org.springframework.r2dbc.core.DatabaseClient;
 import org.springframework.r2dbc.core.Parameter;
@@ -38,6 +39,7 @@ import org.springframework.r2dbc.core.Parameter;
  *
  * @author Christoph Strobl
  * @author Woo Jin-Lee
+ * @author Seungmin Baek
  */
 public class ReactiveUpsertOperationUnitTests {
 
@@ -180,6 +182,25 @@ public class ReactiveUpsertOperationUnitTests {
 				"INSERT INTO entity (col1, col2, name) VALUES ($1, $2, $3) ON CONFLICT (col1, col2) DO UPDATE SET name = EXCLUDED.name");
 	}
 
+	@Test // GH-2366
+	void upsertDoesNotUpdateInsertOnlyEmbeddedProperties() {
+
+		MockRowMetadata metadata = MockRowMetadata.builder().build();
+		MockResult result = MockResult.builder().rowMetadata(metadata).rowsUpdated(1).build();
+
+		recorder.addStubbing(s -> s.startsWith("INSERT"), result);
+
+		entityTemplate.upsert(new WithInsertOnlyEmbedded(23L, "Walter", new Audit("creator", "then"))) //
+				.as(StepVerifier::create) //
+				.expectNextCount(1) //
+				.verifyComplete();
+
+		StatementRecorder.RecordedStatement statement = recorder.getCreatedStatement(s -> s.startsWith("INSERT"));
+
+		String updateClause = statement.getSql().substring(statement.getSql().indexOf("DO UPDATE SET"));
+		assertThat(updateClause).contains("name").doesNotContain("audit_created_by").doesNotContain("audit_created_at");
+	}
+
 	static class Person {
 
 		@Id Long id;
@@ -211,6 +232,13 @@ public class ReactiveUpsertOperationUnitTests {
 	}
 
 	record EntityId(String col1, String col2) {
+	}
+
+	record WithInsertOnlyEmbedded(@Id Long id, String name,
+			@InsertOnlyProperty @Embedded(onEmpty = Embedded.OnEmpty.USE_NULL, prefix = "audit_") Audit audit) {
+	}
+
+	record Audit(String createdBy, String createdAt) {
 	}
 
 }


### PR DESCRIPTION
Closes #2366

`@InsertOnlyProperty` was silently ignored when combined with `@Embedded`, so insert-only columns (the typical case being creation-audit fields grouped in an embeddable) were overwritten on every update.

**What was broken**

- `R2dbcEntityTemplate` collected insert-only columns by iterating the *top-level* entity properties. An annotated embedded **container** contributed its container name (not a real column of the outbound row, which holds the expanded, prefixed leaf columns), and an annotated property **inside** an embeddable was never visited. Both the update path and the upsert path's `insertOnlyColumns` collection (added in #2313 / fc94989) were affected.
- On the JDBC side, `SqlGenerator` handled leaf-annotated properties correctly (its column-cache recursion reads each leaf's `isInsertOnly()`), but an annotated **container** was not propagated to the columns it contributes. Verified with a test before the fix:

  ```
  UPDATE "WITH_INSERT_ONLY_EMBEDDED" SET "NAME" = :name, "AUDIT_CREATED_BY" = :audit_created_by, "AUDIT_CREATED_AT" = :audit_created_at WHERE ...
  ```

  So the leaf-annotated gap was R2DBC-specific, while the container-annotated gap affected both modules (also noted on the issue).

**Fix**

- `R2dbcEntityTemplate`: a private helper collects insert-only column names by expanding embedded properties through `RelationalMappingContext#getRequiredPersistentEntity(RelationalPersistentProperty)` — the same recursion `DefaultReactiveDataAccessStrategy#getAllColumns` already uses (the cast to `RelationalMappingContext` mirrors that class as well). Properties inside an insert-only container are treated as insert-only. Used by both the update and the upsert path.
- `SqlGenerator` (JDBC): the embedded recursion in the column-name cache now propagates the container's insert-only flag, so leaf columns of an insert-only embedded land in `insertOnlyColumnNames` and are excluded from the updatable columns.

**Tests**

Five new tests, all failing before the fix and passing after:

- `R2dbcEntityTemplateUnitTests`: update excludes insert-only embedded container columns / insert-only properties inside an embeddable (exact-SQL assertions in the style of `updateExcludesInsertOnlyColumns`)
- `ReactiveUpsertOperationUnitTests`: the `DO UPDATE SET` clause no longer touches insert-only embedded columns
- `SqlGeneratorUnitTests`: JDBC update SQL excludes container-contributed insert-only columns; leaf-annotated exclusion kept as a regression guard

Full `spring-data-jdbc` and `spring-data-r2dbc` test suites pass.

---

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don't submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
