### PR TITLE
Fix AOT generated GreaterThanEqual derived query

### DIFF
--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/aot/JdbcCodeBlocks.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/aot/JdbcCodeBlocks.java
@@ -69,6 +69,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Aditya Nikam
  * @since 4.0
  */
 class JdbcCodeBlocks {
@@ -360,7 +361,7 @@ class JdbcCodeBlocks {
 				case LT -> builder.add(".lessThan($L)", renderPlaceholder(value));
 				case LTE -> builder.add(".lessThanOrEquals($L)", renderPlaceholder(value));
 				case GT -> builder.add(".greaterThan($L)", renderPlaceholder(value));
-				case GTE -> builder.add(".greaterThanEquals($L)", renderPlaceholder(value));
+				case GTE -> builder.add(".greaterThanOrEquals($L)", renderPlaceholder(value));
 				case IS_NULL -> builder.add(".isNull()");
 				case IS_NOT_NULL -> builder.add(".isNotNull()");
 				case LIKE -> applyLike(builder, "like", value);

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/aot/JdbcRepositoryContributorIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/aot/JdbcRepositoryContributorIntegrationTests.java
@@ -54,6 +54,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
  * Integration tests for AOT processing via {@link JdbcRepositoryContributor}.
  *
  * @author Mark Paluch
+ * @author Aditya Nikam
  */
 @SpringJUnitConfig(classes = JdbcRepositoryContributorIntegrationTests.JdbcRepositoryContributorConfiguration.class)
 @IntegrationTest
@@ -200,6 +201,14 @@ class JdbcRepositoryContributorIntegrationTests {
 	@Test // GH-2121
 	void streamByAgeGreaterThan() {
 		assertThat(fragment.streamByAgeGreaterThan(20)).hasSize(5);
+	}
+	
+	@Test // GH-2365
+	void shouldFindByAgeGreaterThanEqual() {
+
+		List<User> users = fragment.findAllByAgeGreaterThanEqual(51);
+
+		assertThat(users).hasSize(4);
 	}
 
 	@Test // GH-2121

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/aot/UserRepository.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/aot/UserRepository.java
@@ -60,6 +60,8 @@ public interface UserRepository extends CrudRepository<User, Integer> {
 
 	Stream<User> streamByAgeGreaterThan(int age);
 
+	List<User> findAllByAgeGreaterThanEqual(int age);
+
 	long countByAgeLessThan(int age);
 
 	short countShortByAgeLessThan(int age);


### PR DESCRIPTION
Closes #2365

JdbcCodeBlocks emitted Criteria.greaterThanEquals(...) for the GTE comparator, a method that does not exist on Criteria. The correct method is greaterThanOrEquals(...), used directly above it for the LTE comparator.

Since AOT processing generates a repository's whole fragment as a single Java class, this one bad call broke compilation of the entire generated class, not just the affected query method. I confirmed this by temporarily reverting the fix locally: all 38 tests in JdbcRepositoryContributorIntegrationTests failed, not only a test targeting GreaterThanEqual specifically.

Added findAllByAgeGreaterThanEqual to the UserRepository test fixture and a matching integration test that exercises the generated fragment against a real H2 database, run with mvn test.

- [x] You have read the Spring Data contribution guidelines.
- [x] You use the code formatters provided here and have them applied to your changes. No formatting related changes are included.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched.