### PR TITLE
Fix AOT-generated GreaterThanEqual query to call greaterThanOrEquals

### DIFF
--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/aot/JdbcCodeBlocks.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/aot/JdbcCodeBlocks.java
@@ -360,7 +360,7 @@ class JdbcCodeBlocks {
 				case LT -> builder.add(".lessThan($L)", renderPlaceholder(value));
 				case LTE -> builder.add(".lessThanOrEquals($L)", renderPlaceholder(value));
 				case GT -> builder.add(".greaterThan($L)", renderPlaceholder(value));
-				case GTE -> builder.add(".greaterThanEquals($L)", renderPlaceholder(value));
+				case GTE -> builder.add(".greaterThanOrEquals($L)", renderPlaceholder(value));
 				case IS_NULL -> builder.add(".isNull()");
 				case IS_NOT_NULL -> builder.add(".isNotNull()");
 				case LIKE -> applyLike(builder, "like", value);

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/aot/JdbcRepositoryContributorIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/aot/JdbcRepositoryContributorIntegrationTests.java
@@ -261,6 +261,22 @@ class JdbcRepositoryContributorIntegrationTests {
 		assertThat(fragment.existsByAgeLessThan(5)).isFalse();
 	}
 
+	@Test // GH-2365
+	void findAllByAgeLessThanEqual() {
+
+		List<User> users = fragment.findAllByAgeLessThanEqual(51);
+
+		assertThat(users).extracting(User::getFirstname).containsExactlyInAnyOrder("Skyler", "Flynn", "Gustavo");
+	}
+
+	@Test // GH-2365
+	void findAllByAgeGreaterThanEqual() {
+
+		List<User> users = fragment.findAllByAgeGreaterThanEqual(51);
+
+		assertThat(users).extracting(User::getFirstname).containsExactlyInAnyOrder("Walter", "Mike", "Gustavo", "Hector");
+	}
+
 	@Test // GH-2121
 	void listWithLimit() {
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/aot/UserRepository.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/aot/UserRepository.java
@@ -66,6 +66,10 @@ public interface UserRepository extends CrudRepository<User, Integer> {
 
 	boolean existsByAgeLessThan(int age);
 
+	List<User> findAllByAgeLessThanEqual(int age);
+
+	List<User> findAllByAgeGreaterThanEqual(int age);
+
 	List<User> findTop5ByOrderByAge();
 
 	Slice<User> findSliceByAgeGreaterThan(Pageable pageable, int age);


### PR DESCRIPTION
## What

`JdbcCodeBlocks#appendCriteria` generated `Criteria.greaterThanEquals(...)` for the `GTE` comparator, but `Criteria` only declares `greaterThanOrEquals(Object)`. Any repository method using the `GreaterThanEqual` derived-query keyword therefore failed to compile once Spring AOT processing was enabled (`compileAotJava`, `bootBuildImage`, `jib`, etc.), while the sibling `LessThanEqual` keyword worked correctly and generated `.lessThanOrEquals(...)`.

Fixes #2365.

## Why

```java
case LTE -> builder.add(".lessThanOrEquals($L)", renderPlaceholder(value));
case GT  -> builder.add(".greaterThan($L)", renderPlaceholder(value));
case GTE -> builder.add(".greaterThanEquals($L)", renderPlaceholder(value)); // missing "Or"
```

`Criteria` only exposes `greaterThanOrEquals(Object)` (no `greaterThanEquals`), so the generated source referenced a method that doesn't exist:

```java
public List<PaymentEntity> findAllByValueDateGreaterThanEqual(LocalDate from) {
    Criteria criteria = Criteria.where("valueDate").greaterThanEquals(from); // cannot find symbol
    ...
}
```

The non-AOT runtime path (`CriteriaFactory`) already maps `GREATER_THAN_EQUAL` to `greaterThanOrEquals` correctly, so only the AOT source-generation path in `JdbcCodeBlocks` had the typo.

## Change

One-word fix: `.greaterThanEquals($L)` → `.greaterThanOrEquals($L)`.

## Tests

Added `findAllByAgeGreaterThanEqual` and `findAllByAgeLessThanEqual` to `JdbcRepositoryContributorIntegrationTests` (and the corresponding derived-query methods to the test `UserRepository`), asserting the correct result set at the boundary value.

- Without the fix, `findAllByAgeGreaterThanEqual` fails to load its `ApplicationContext` because the AOT-compiled fragment doesn't compile (verified locally by reverting the one-line fix).
- With the fix, `./mvnw -pl spring-data-jdbc test -Dtest=JdbcRepositoryContributorIntegrationTests` passes: 39/39, 0 failures, 0 errors.
