### PR TITLE
Emit Sort.Order separator before non-first orders in AOT generation

### DIFF
--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/aot/JdbcCodeBlocks.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/aot/JdbcCodeBlocks.java
@@ -69,6 +69,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Atirna
  * @since 4.0
  */
 class JdbcCodeBlocks {
@@ -264,15 +265,14 @@ class JdbcCodeBlocks {
 			boolean first = true;
 			for (Sort.Order order : sort) {
 
+				if (!first) {
+					sortBuilder.add(", ");
+				}
+				first = false;
+
 				sortBuilder.add("$T.$L($S)", Sort.Order.class, order.isAscending() ? "asc" : "desc", order.getProperty());
 				if (order.isIgnoreCase()) {
 					sortBuilder.add(".ignoreCase()");
-				}
-
-				if (first) {
-					first = false;
-				} else {
-					sortBuilder.add(", ");
 				}
 			}
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/aot/JdbcRepositoryContributorIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/aot/JdbcRepositoryContributorIntegrationTests.java
@@ -54,6 +54,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
  * Integration tests for AOT processing via {@link JdbcRepositoryContributor}.
  *
  * @author Mark Paluch
+ * @author Atirna
  */
 @SpringJUnitConfig(classes = JdbcRepositoryContributorIntegrationTests.JdbcRepositoryContributorConfiguration.class)
 @IntegrationTest
@@ -268,6 +269,19 @@ class JdbcRepositoryContributorIntegrationTests {
 
 		assertThat(users).hasSize(5).extracting(User::getFirstname).containsSequence("Flynn", "Skyler", "Gustavo", "Walter",
 				"Mike");
+	}
+
+	@Test // GH-2377
+	void listWithMultipleStaticOrderByProperties() {
+
+		operations.insert(new User("Flynn", 26));
+
+		List<User> users = fragment.findAllByOrderByFirstnameAscAgeAsc();
+
+		assertThat(users).extracting(User::getFirstname).containsExactly("Flynn", "Flynn", "Gustavo", "Hector", "Mike",
+				"Skyler", "Walter");
+		assertThat(users.get(0).getAge()).isEqualTo(16);
+		assertThat(users.get(1).getAge()).isEqualTo(26);
 	}
 
 	@Test // GH-2121

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/aot/UserRepository.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/aot/UserRepository.java
@@ -68,6 +68,8 @@ public interface UserRepository extends CrudRepository<User, Integer> {
 
 	List<User> findTop5ByOrderByAge();
 
+	List<User> findAllByOrderByFirstnameAscAgeAsc();
+
 	Slice<User> findSliceByAgeGreaterThan(Pageable pageable, int age);
 
 	Page<User> findPageByAgeGreaterThan(Pageable pageable, int age);


### PR DESCRIPTION
Derived query methods with two or more static `OrderBy` properties produce Java from the AOT generator that does not compile, so `compileAotJava` fails and the app cannot build in AOT / GraalVM native mode.

## Why

`JdbcCodeBlocks.buildSort` appended the `, ` separator *after* each non-first order instead of *before*, so `findAllByOrderByFirstNameAscLastNameDesc()` generated:

```java
Sort.by(Sort.Order.asc("firstName")Sort.Order.asc("lastName"), )
```

which javac rejects with `')' or ',' expected`. With one static OrderBy property the loop happened to work because the trailing separator landed after the last (only) order, masking the bug. The separator now goes before each non-first order:

```java
Sort.by(Sort.Order.asc("firstName"), Sort.Order.asc("lastName"))
```

Single-order emission is unchanged (`findTop5ByOrderByAge` and its test cover that).

## Verification

- before, on current `main`: `./mvnw -pl spring-data-jdbc verify -Dit.test=JdbcRepositoryContributorIntegrationTests -Dspring.profiles.active=h2`: context load fails with `CompilationException: Unable to compile source` on the malformed `Sort.by(...)`
- after: same command, `Tests run: 38, Failures: 0, Errors: 0`
- the new `listWithMultipleStaticOrderByProperties` inserts a duplicate firstname so the second order key decides the row order, and asserts both keys' effect on the result

Fixes #2377
