### PR TITLE
Fix AOT JDBC repository ClassCastException for Set return types

### DIFF
--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/aot/AotRepositoryFragmentSupport.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/aot/AotRepositoryFragmentSupport.java
@@ -233,6 +233,11 @@ public class AotRepositoryFragmentSupport {
 	}
 
 	protected @Nullable Object convertMany(@Nullable Object result, Class<?> projection) {
+		return convertMany(result, projection, null);
+	}
+
+	protected @Nullable Object convertMany(@Nullable Object result, Class<?> projection,
+			@Nullable Class<?> collectionType) {
 
 		if (result == null) {
 			return null;
@@ -252,8 +257,8 @@ public class AotRepositoryFragmentSupport {
 
 		if (result instanceof Collection<?> collection) {
 
-			Collection<@Nullable Object> target = CollectionFactory.createCollection(collection.getClass(),
-					collection.size());
+			Class<?> targetType = collectionType != null ? collectionType : collection.getClass();
+			Collection<@Nullable Object> target = CollectionFactory.createCollection(targetType, collection.size());
 			for (Object o : collection) {
 				target.add(convertOne(o, projection));
 			}

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/aot/JdbcCodeBlocks.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/aot/JdbcCodeBlocks.java
@@ -692,7 +692,8 @@ class JdbcCodeBlocks {
 
 			builder.addStatement(LordOfTheStrings.returning(returnType) //
 					.when(Collection.class.isAssignableFrom(context.getMethodReturn().toClass()),
-							"($T) convertMany($L, $T.class)", context.getMethodReturn().getTypeName(), result, queryResultType) //
+							"($T) convertMany($L, $T.class, $T.class)", context.getMethodReturn().getTypeName(), result,
+							queryResultType, context.getMethodReturn().toClass()) //
 					.when(context.getRepositoryInformation().getDomainType(),
 							"($1T) ($2L.isEmpty() ? null : $2L.iterator().next())", actualReturnType, result) //
 					.whenBoolean("!$L.isEmpty()", result) //
@@ -831,8 +832,9 @@ class JdbcCodeBlocks {
 							context.localVariable("converted"), TypeDescriptor.class);
 				} else {
 
-					builder.addStatement("return ($T) convertMany($L, %s)".formatted(dynamicProjection ? "$L" : "$T.class"),
-							methodReturn.getTypeName(), result, queryResultTypeRef);
+					builder.addStatement(
+							"return ($1T) convertMany($2L, %s, $3T.class)".formatted(dynamicProjection ? "$4L" : "$4T.class"),
+							methodReturn.getTypeName(), result, methodReturn.toClass(), queryResultTypeRef);
 				}
 			} else if (queryMethod.isStreamQuery()) {
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/aot/JdbcRepositoryContributorIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/aot/JdbcRepositoryContributorIntegrationTests.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.*;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -187,6 +188,14 @@ class JdbcRepositoryContributorIntegrationTests {
 	void shouldFindBetween() {
 
 		List<User> users = fragment.findAllByAgeBetween(40, 51);
+
+		assertThat(users).hasSize(2);
+	}
+
+	@Test // GH-2382
+	void shouldFindBetweenAsSet() {
+
+		Set<User> users = fragment.findUsersByAgeBetween(40, 51);
 
 		assertThat(users).hasSize(2);
 	}

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/aot/UserRepository.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/aot/UserRepository.java
@@ -18,6 +18,7 @@ package org.springframework.data.jdbc.repository.aot;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.springframework.data.domain.Page;
@@ -53,6 +54,8 @@ public interface UserRepository extends CrudRepository<User, Integer> {
 	List<User> findByFriend(AggregateReference<User, Long> friend);
 
 	List<User> findAllByAgeBetween(int start, int end);
+
+	Set<User> findUsersByAgeBetween(int start, int end);
 
 	Streamable<User> findStreamableByAgeBetween(int start, int end);
 


### PR DESCRIPTION
Fixes #2382

## Summary

- Extend `AotRepositoryFragmentSupport.convertMany` with an optional declared collection type so query results stored in an `ArrayList` can be converted into the method's collection return type (e.g. `LinkedHashSet` for `Set`).
- Pass the erasure of the declared return type from AOT code generation for collection queries and delete-by-query methods that return collections.

## Test plan

- [x] `mvn -pl spring-data-jdbc -am test -Dtest=org.springframework.data.jdbc.repository.aot.JdbcRepositoryContributorIntegrationTests -Dsurefire.failIfNoSpecifiedTests=false` (Java 21, Maven 3.9+)
- [x] New integration test `shouldFindBetweenAsSet` exercises AOT-generated `Set<User>` derived query

---

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).